### PR TITLE
Add intl extension to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     "require": {
         "php": "^7.1.3",
         "ext-curl": "*",
+        "ext-intl": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "ext-pdo": "*",


### PR DESCRIPTION
The intl extension is used and should be included in the composer.json file.