### PR TITLE
Fix firing the wrong event after storing user

### DIFF
--- a/packages/Webkul/User/src/Http/Controllers/UserController.php
+++ b/packages/Webkul/User/src/Http/Controllers/UserController.php
@@ -96,7 +96,7 @@ class UserController extends Controller
 
         $admin = $this->admin->create($data);
 
-        Event::fire('user.admin.delete.after', $admin);
+        Event::fire('user.admin.create.after', $admin);
 
         session()->flash('success', trans('admin::app.response.create-success', ['name' => 'User']));
 


### PR DESCRIPTION
This PR fixes firing the wrong event after storing a new user.