### PR TITLE
added configurable order numbers

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/OrderDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/OrderDataGrid.php
@@ -28,7 +28,7 @@ class OrderDataGrid extends DataGrid
                     $leftJoin->on('order_address_billing.order_id', '=', 'orders.id')
                         ->where('order_address_billing.address_type', 'billing');
                 })
-                ->addSelect('orders.id', 'orders.base_sub_total', 'orders.base_grand_total', 'orders.created_at', 'channel_name', 'status')
+                ->addSelect('orders.id','orders.increment_id', 'orders.base_sub_total', 'orders.base_grand_total', 'orders.created_at', 'channel_name', 'status')
                 ->addSelect(DB::raw('CONCAT(order_address_billing.first_name, " ", order_address_billing.last_name) as billed_to'))
                 ->addSelect(DB::raw('CONCAT(order_address_shipping.first_name, " ", order_address_shipping.last_name) as shipped_to'));
 
@@ -50,7 +50,14 @@ class OrderDataGrid extends DataGrid
             'sortable' => true,
             'filterable' => true
         ]);
-
+        $this->addColumn([
+            'index' => 'increment_id',
+            'label' => trans('admin::app.datagrid.order_number'),
+            'type' => 'string',
+            'searchable' => true,
+            'sortable' => true,
+            'filterable' => true
+        ]);
         $this->addColumn([
             'index' => 'base_sub_total',
             'label' => trans('admin::app.datagrid.sub-total'),

--- a/packages/Webkul/Admin/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en/app.php
@@ -165,7 +165,8 @@ return [
         'ends-till' => 'Ends Till',
         'per-cust' => 'Per Customer',
         'usage-throttle' => 'Usage Times',
-        'for-guest' => 'For Guest'
+        'for-guest' => 'For Guest',
+        'order_number' => 'Order Number'
     ],
 
     'account' => [
@@ -1096,7 +1097,13 @@ return [
             'logo-image' => 'Logo Image',
             'credit-max' => 'Customer Credit Max',
             'credit-max-value' => 'Credit Max Value',
-            'use-credit-max' => 'Use Credit Max'
+            'use-credit-max' => 'Use Credit Max',
+            'invoice-settings' => 'Invoice Settings',
+            'invoiceNumber' => 'Invoice Number Settings',
+            'invoice number prefix' => 'Invoice Number Prefix',
+            'invoice number length' => 'Invoice Number Length',
+            'invoice number suffix' => 'Invoice Number Suffix',
+
         ]
     ]
 ];

--- a/packages/Webkul/Admin/src/Resources/views/sales/orders/view.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/sales/orders/view.blade.php
@@ -14,7 +14,7 @@
                 <h1>
                     <i class="icon angle-left-icon back-link" onclick="history.length > 1 ? history.go(-1) : window.location = '{{ url('/admin/dashboard') }}';"></i>
 
-                    {{ __('admin::app.sales.orders.view-title', ['order_id' => $order->id]) }}
+                    {{ __('admin::app.sales.orders.view-title', ['order_id' => $order->increment_id]) }}
                 </h1>
             </div>
 

--- a/packages/Webkul/Sales/src/Config/system.php
+++ b/packages/Webkul/Sales/src/Config/system.php
@@ -1,0 +1,39 @@
+<?php
+
+return [
+    [
+        'key' => 'sales.invoiceSettings',
+        'name' => 'admin::app.admin.system.invoice-settings',
+        'sort' => 3,
+    ],[
+        'key' => 'sales.invoiceSettings.invoice_number',
+        'name' => 'admin::app.admin.system.invoiceNumber',
+        'sort' => 0,
+        'fields' => [
+            [
+                'name' => 'invoice_number_prefix',
+                'title' => 'admin::app.admin.system.invoice number prefix',
+                'type' => 'text',
+                'validation' => false,
+                'channel_based' => true,
+                'locale_based' => true
+            ],
+            [
+                'name' => 'invoice_number_length',
+                'title' => 'admin::app.admin.system.invoice number length',
+                'type' => 'text',
+                'validation' => false,
+                'channel_based' => true,
+                'locale_based' => true
+            ],
+            [
+                'name' => 'invoice_number_suffix',
+                'title' => 'admin::app.admin.system.invoice number suffix',
+                'type' => 'text',
+                'validation' => false,
+                'channel_based' => true,
+                'locale_based' => true
+            ],
+        ]
+    ]
+];

--- a/packages/Webkul/Sales/src/Providers/SalesServiceProvider.php
+++ b/packages/Webkul/Sales/src/Providers/SalesServiceProvider.php
@@ -20,5 +20,8 @@ class SalesServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->mergeConfigFrom(
+            dirname(__DIR__) . '/Config/system.php', 'core'
+        );
     }
 }

--- a/packages/Webkul/Sales/src/Repositories/OrderRepository.php
+++ b/packages/Webkul/Sales/src/Repositories/OrderRepository.php
@@ -149,9 +149,12 @@ class OrderRepository extends Repository
     public function generateIncrementId()
     {
         $config = new CoreConfig();
-        $invoiceNumberPrefix = $config->where('code','=',"sales.invoiceSettings.invoice_number.invoice_number_prefix")->first()->value;
-        $invoiceNumberLength = $config->where('code','=',"sales.invoiceSettings.invoice_number.invoice_number_length")->first()->value;
-        $invoiceNumberSuffix = $config->where('code','=',"sales.invoiceSettings.invoice_number.invoice_number_suffix")->first()->value;
+        $invoiceNumberPrefix = $config->where('code','=',"sales.invoiceSettings.invoice_number.invoice_number_prefix")->first()
+            ? $config->where('code','=',"sales.invoiceSettings.invoice_number.invoice_number_prefix")->first()->value : false;
+        $invoiceNumberLength = $config->where('code','=',"sales.invoiceSettings.invoice_number.invoice_number_length")->first()
+            ? $config->where('code','=',"sales.invoiceSettings.invoice_number.invoice_number_length")->first()->value : false;
+        $invoiceNumberSuffix = $config->where('code','=',"sales.invoiceSettings.invoice_number.invoice_number_suffix")->first()
+            ? $config->where('code','=',"sales.invoiceSettings.invoice_number.invoice_number_suffix")->value: false;
 
         $lastOrder = $this->model->orderBy('id', 'desc')->limit(1)->first();
         $lastId = $lastOrder ? $lastOrder->id : 0;

--- a/packages/Webkul/Sales/src/Repositories/OrderRepository.php
+++ b/packages/Webkul/Sales/src/Repositories/OrderRepository.php
@@ -154,7 +154,7 @@ class OrderRepository extends Repository
         $invoiceNumberLength = $config->where('code','=',"sales.invoiceSettings.invoice_number.invoice_number_length")->first()
             ? $config->where('code','=',"sales.invoiceSettings.invoice_number.invoice_number_length")->first()->value : false;
         $invoiceNumberSuffix = $config->where('code','=',"sales.invoiceSettings.invoice_number.invoice_number_suffix")->first()
-            ? $config->where('code','=',"sales.invoiceSettings.invoice_number.invoice_number_suffix")->value: false;
+            ? $config->where('code','=',"sales.invoiceSettings.invoice_number.invoice_number_suffix")->first()->value: false;
 
         $lastOrder = $this->model->orderBy('id', 'desc')->limit(1)->first();
         $lastId = $lastOrder ? $lastOrder->id : 0;

--- a/packages/Webkul/Sales/src/Repositories/OrderRepository.php
+++ b/packages/Webkul/Sales/src/Repositories/OrderRepository.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Webkul\Core\Eloquent\Repository;
 use Webkul\Sales\Contracts\Order;
 use Webkul\Sales\Repositories\OrderItemRepository;
+use Webkul\Core\Models\CoreConfig;
 
 /**
  * Order Reposotory
@@ -143,14 +144,27 @@ class OrderRepository extends Repository
 
     /**
      * @inheritDoc
+     * @return int|string
      */
     public function generateIncrementId()
     {
-        $lastOrder = $this->model->orderBy('id', 'desc')->limit(1)->first();
+        $config = new CoreConfig();
+        $invoiceNumberPrefix = $config->where('code','=',"sales.invoiceSettings.invoice_number.invoice_number_prefix")->first()->value;
+        $invoiceNumberLength = $config->where('code','=',"sales.invoiceSettings.invoice_number.invoice_number_length")->first()->value;
+        $invoiceNumberSuffix = $config->where('code','=',"sales.invoiceSettings.invoice_number.invoice_number_suffix")->first()->value;
 
+        $lastOrder = $this->model->orderBy('id', 'desc')->limit(1)->first();
         $lastId = $lastOrder ? $lastOrder->id : 0;
 
-        return $lastId + 1;
+        if($invoiceNumberLength && ( $invoiceNumberPrefix || $invoiceNumberSuffix) ){
+
+            $invoiceNumber = $invoiceNumberPrefix . sprintf("%0{$invoiceNumberLength}d", $lastId + 1) . $invoiceNumberSuffix;
+        }
+        else{
+            $invoiceNumber = $lastId + 1;
+        }
+
+        return $invoiceNumber;
     }
 
     /**

--- a/packages/Webkul/Shop/src/DataGrids/OrderDataGrid.php
+++ b/packages/Webkul/Shop/src/DataGrids/OrderDataGrid.php
@@ -20,7 +20,7 @@ class OrderDataGrid extends DataGrid
     public function prepareQueryBuilder()
     {
         $queryBuilder = DB::table('orders as order')
-                ->addSelect('order.id', 'order.status', 'order.created_at', 'order.grand_total', 'order.order_currency_code')
+                ->addSelect('order.id','order.increment_id', 'order.status', 'order.created_at', 'order.grand_total', 'order.order_currency_code')
                 ->where('customer_id', auth()->guard('customer')->user()->id);
 
         $this->setQueryBuilder($queryBuilder);
@@ -29,9 +29,9 @@ class OrderDataGrid extends DataGrid
     public function addColumns()
     {
         $this->addColumn([
-            'index' => 'id',
+            'index' => 'increment_id',
             'label' => trans('shop::app.customer.account.order.index.order_id'),
-            'type' => 'number',
+            'type' => 'text',
             'searchable' => false,
             'sortable' => true,
             'filterable' => true

--- a/packages/Webkul/Shop/src/Resources/views/checkout/success.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/checkout/success.blade.php
@@ -9,7 +9,7 @@
     <div class="order-success-content" style="min-height: 300px;">
         <h1>{{ __('shop::app.checkout.success.thanks') }}</h1>
 
-        <p>{{ __('shop::app.checkout.success.order-id-info', ['order_id' => $order->id]) }}</p>
+        <p>{{ __('shop::app.checkout.success.order-id-info', ['order_id' => $order->increment_id]) }}</p>
 
         <p>{{ __('shop::app.checkout.success.info') }}</p>
 


### PR DESCRIPTION
Bagisto currently exposes actual orders table ID column to the client and there is no option to configure a custom order number for a specific store.
This is a neccessary feature since many inventory/backend systems require order numbers in a certain format. This is feature is available in WooCommerce and Magento to name a few.

Current change adds an option to configure a custom order number in the backend that consists of 

- a prefix,

- order number that contains the order id and has user-set length

- a suffix. 

If none of the options are set, then the number is set as previously.  

The order number is then visible in admin order index, order single-template view and for customer in success page and order history.