### PR TITLE
Change 'self' references inside models to 'static'. This fixes issues…

### DIFF
--- a/packages/Webkul/Checkout/src/Models/CartItem.php
+++ b/packages/Webkul/Checkout/src/Models/CartItem.php
@@ -53,6 +53,6 @@ class CartItem extends Model implements CartItemContract
      */
     public function child()
     {
-        return $this->belongsTo(self::class, 'id', 'parent_id');
+        return $this->belongsTo(static::class, 'id', 'parent_id');
     }
 }

--- a/packages/Webkul/Product/src/Models/Product.php
+++ b/packages/Webkul/Product/src/Models/Product.php
@@ -38,7 +38,7 @@ class Product extends Model implements ProductContract
      */
     public function variants()
     {
-        return $this->hasMany(self::class, 'parent_id');
+        return $this->hasMany(static::class, 'parent_id');
     }
 
     /**
@@ -54,7 +54,7 @@ class Product extends Model implements ProductContract
      */
     public function parent()
     {
-        return $this->belongsTo(self::class, 'parent_id');
+        return $this->belongsTo(static::class, 'parent_id');
     }
 
     /**
@@ -120,7 +120,7 @@ class Product extends Model implements ProductContract
      */
     public function related_products()
     {
-        return $this->belongsToMany(self::class, 'product_relations', 'parent_id', 'child_id')->limit(4);
+        return $this->belongsToMany(static::class, 'product_relations', 'parent_id', 'child_id')->limit(4);
     }
 
     /**
@@ -128,7 +128,7 @@ class Product extends Model implements ProductContract
      */
     public function up_sells()
     {
-        return $this->belongsToMany(self::class, 'product_up_sells', 'parent_id', 'child_id')->limit(4);
+        return $this->belongsToMany(static::class, 'product_up_sells', 'parent_id', 'child_id')->limit(4);
     }
 
     /**
@@ -136,7 +136,7 @@ class Product extends Model implements ProductContract
      */
     public function cross_sells()
     {
-        return $this->belongsToMany(self::class, 'product_cross_sells', 'parent_id', 'child_id')->limit(4);
+        return $this->belongsToMany(static::class, 'product_cross_sells', 'parent_id', 'child_id')->limit(4);
     }
 
     /**
@@ -214,7 +214,7 @@ class Product extends Model implements ProductContract
      */
     public function getAttribute($key)
     {
-        if (! method_exists(self::class, $key) && ! in_array($key, ['parent_id', 'attribute_family_id']) && ! isset($this->attributes[$key])) {
+        if (! method_exists(static::class, $key) && ! in_array($key, ['parent_id', 'attribute_family_id']) && ! isset($this->attributes[$key])) {
             if (isset($this->id)) {
                 $this->attributes[$key] = '';
 

--- a/packages/Webkul/Product/src/Models/ProductFlat.php
+++ b/packages/Webkul/Product/src/Models/ProductFlat.php
@@ -34,7 +34,7 @@ class ProductFlat extends Model implements ProductFlatContract
      */
     public function variants()
     {
-        return $this->hasMany(self::class, 'parent_id');
+        return $this->hasMany(static::class, 'parent_id');
     }
 
     /**


### PR DESCRIPTION
This is a fix to a bug I discovered after extending the product model from my own package. The original Product model has several references to "self" rather than "static", which cause unexpected behavior at times.