### PR TITLE
Generate product command bug fix

### DIFF
--- a/packages/Webkul/Product/src/Type/AbstractType.php
+++ b/packages/Webkul/Product/src/Type/AbstractType.php
@@ -197,7 +197,9 @@ abstract class AbstractType
             }
         }
 
-        if (request()->route()->getName() != 'admin.catalog.products.massupdate') {
+        $route = request()->route() ? request()->route()->getName() : ""; 
+
+        if ($route != 'admin.catalog.products.massupdate') {
             if  (isset($data['categories']))
                 $product->categories()->sync($data['categories']);
 


### PR DESCRIPTION
**BUGS:**

After updating to latest master with build containing multiple product types the command php artisan bagisto:generate product n was not working.