### PR TITLE
Fixed duplicate view_render_event for product descriptions

### DIFF
--- a/packages/Webkul/Shop/src/Resources/views/products/view.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/products/view.blade.php
@@ -79,7 +79,7 @@
                             </div>
                         </accordian>
 
-                        {!! view_render_event('bagisto.shop.products.view.description.before', ['product' => $product]) !!}
+                        {!! view_render_event('bagisto.shop.products.view.description.after', ['product' => $product]) !!}
 
                         @include ('shop::products.view.attributes')
 


### PR DESCRIPTION
The following view render event was declared twice, both before and after the product description:
`{!! view_render_event('bagisto.shop.products.view.description.before', ['product' => $product]) !!}`

I fixed the second instance to be bagisto.shop.products.view.description.**after**
