### PR TITLE
Rename WAMP to WampServer to match with official | Fix typo for XAMPP

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Bagisto is using power of both of these frameworks and making best out of it out
 
 ### Requirements
 
-* **OS**: Ubuntu 16.04 LTS or higher / Windows 7 or Higher (WAMP / XAMP).
+* **OS**: Ubuntu 16.04 LTS or higher / Windows 7 or Higher (WampServer / XAMPP).
 * **SERVER**: Apache 2 or NGINX.
 * **RAM**: 3 GB or higher.
 * **PHP**: 7.1.3 or higher.


### PR DESCRIPTION
Rename WAMP to WampServer to match with official | Fix typo for XAMPP