### PR TITLE
Fixed: #1648, fix password confirmation issue, when deleting user

### DIFF
--- a/packages/Webkul/Ui/src/Resources/views/datagrid/table.blade.php
+++ b/packages/Webkul/Ui/src/Resources/views/datagrid/table.blade.php
@@ -707,11 +707,16 @@
 
                     doAction: function(e) {
                         var element = e.currentTarget;
-
+                        var password = null;
                         if (confirm('{{__('ui::app.datagrid.massaction.delete') }}')) {
+                            // prompting user to enter password
+                            password = prompt('Enter password');
+                            if(! password) {return}
+
                             axios.post(element.getAttribute('data-action'), {
                                 _token : element.getAttribute('data-token'),
-                                _method : element.getAttribute('data-method')
+                                _method : element.getAttribute('data-method'),
+                                password: password
                             }).then(function(response) {
                                 this.result = response;
                                 location.reload();

--- a/packages/Webkul/User/src/Http/Controllers/UserController.php
+++ b/packages/Webkul/User/src/Http/Controllers/UserController.php
@@ -7,6 +7,7 @@ use Webkul\User\Repositories\AdminRepository;
 use Webkul\User\Repositories\RoleRepository;
 use Webkul\User\Http\Requests\UserForm;
 use Hash;
+use Illuminate\Http\Request;
 
 /**
  * Admin user controller
@@ -158,9 +159,15 @@ class UserController extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\JsonResponse|\Illuminate\View\View 
      */
-    public function destroy($id)
+    public function destroy($id, Request $request)
     {
         $user = $this->adminRepository->findOrFail($id);
+
+        // checking is given password is same as admin password
+        if (! Hash::check($request->password, auth()->guard('admin')->user()->password)) {
+            session()->flash('error', trans('admin::app.error.401.message'));
+            return response()->json(['message' => false], 401);
+        }
 
         if ($this->adminRepository->count() == 1) {
             session()->flash('error', trans('admin::app.response.last-delete-error', ['name' => 'Admin']));


### PR DESCRIPTION
**BUGS:**
Fixes #1648

When admin clicks on delete user icon now s/he will get a prompt asking for password confirmation. 