### PR TITLE
#979 fix image scaling issues

### DIFF
--- a/packages/Webkul/Product/src/CacheFilters/Large.php
+++ b/packages/Webkul/Product/src/CacheFilters/Large.php
@@ -9,6 +9,8 @@ class Large implements FilterInterface
 {
     public function applyFilter(Image $image)
     {
-        return $image->resize(480, 480);
+        return $image->resize(480, null, function ($constraint) {
+            $constraint->aspectRatio();
+        });
     }
 }

--- a/packages/Webkul/Product/src/CacheFilters/Medium.php
+++ b/packages/Webkul/Product/src/CacheFilters/Medium.php
@@ -9,6 +9,12 @@ class Medium implements FilterInterface
 {
     public function applyFilter(Image $image)
     {
-        return $image->resize(280, 350);
+        $width = 280;
+        $height = 280;
+        $image->resize($width, $height, function ($constraint) {
+            $constraint->aspectRatio();
+        });
+
+        return $image->resizeCanvas($width, $height, 'center', false, '#fff');
     }
 }

--- a/packages/Webkul/Product/src/CacheFilters/Small.php
+++ b/packages/Webkul/Product/src/CacheFilters/Small.php
@@ -9,6 +9,12 @@ class Small implements FilterInterface
 {
     public function applyFilter(Image $image)
     {
-        return $image->resize(120, 120);
+        $width = 120;
+        $height = 120;
+        $image->resize($width, $height, function ($constraint) {
+            $constraint->aspectRatio();
+        });
+
+        return $image->resizeCanvas($width, $height, 'center', false, '#fff');
     }
 }

--- a/packages/Webkul/Shop/src/Resources/assets/sass/app.scss
+++ b/packages/Webkul/Shop/src/Resources/assets/sass/app.scss
@@ -688,8 +688,8 @@ section.slider-block {
             }
 
             li img {
-                height: 500px;
-                width:100%;
+                max-height: 500px;
+                max-width: 100%;
             }
         }
 
@@ -1488,8 +1488,8 @@ section.slider-block {
                 width: 100%;
 
                 img {
-                    height: 400px;
-                    width:100%;
+                    max-height: 400px;
+                    max-width: 100%;
                 }
             }
         }
@@ -4316,17 +4316,15 @@ section.review {
         float: left;
 
         img {
-            width: 100%;
+            max-width: 100%;
 
             &:first-child {
                 padding-bottom: 20px;
-                height: 50%;
                 display: block;
             }
 
             &:last-child {
                 padding-top: 20px;
-                height: 50%;
                 display: block;
             }
         }


### PR DESCRIPTION
Fixing image scaling according to the issue #979 

- resizing images inside Small/Medium/Large.php considering the aspect ratio and adding whitespace to it, so that the images have the same size and the thumbnails on the product detail page don't get distorted
- making a couple scss changes, because it's not a good idea to provide a fixed width and height for images. The images will get distorted if we do that 