### PR TITLE
add option to allow params in menu.php

### DIFF
--- a/packages/Webkul/Core/src/Tree.php
+++ b/packages/Webkul/Core/src/Tree.php
@@ -76,7 +76,7 @@ class Tree {
         $item['children'] = [];
 
 		if ($type == 'menu') {
-            $item['url'] = route($item['route']);
+            $item['url'] = route($item['route'], $item['params'] ?? []);
 
 			if (strpos($this->current, $item['url']) !== false) {
                 $this->currentKey = $item['key'];


### PR DESCRIPTION
Feature #1707 

# Proposal
Allow a new key in menu.php in order to configure parameters of routes. The new key `params` is optional