### PR TITLE
Take the fallback_locale from app.config when locale is not defined i…

### DIFF
--- a/packages/Webkul/Core/src/Core.php
+++ b/packages/Webkul/Core/src/Core.php
@@ -211,7 +211,13 @@ class Core
         if ($locale)
             return $locale;
 
-        return $locale = $this->localeRepository->findOneByField('code', app()->getLocale());
+        $locale = $this->localeRepository->findOneByField('code', app()->getLocale());
+
+        if(!$locale) {
+            $locale = $this->localeRepository->findOneByField('code', config('app.fallback_locale'));
+        }
+
+        return $locale;
     }
 
     /**


### PR DESCRIPTION
This fix takes the fallback_locale (en) from app.config if it's not defined in the shop. 