### PR TITLE
Removed remnants of laravel-web-console

### DIFF
--- a/packages/Webkul/Admin/src/Resources/lang/ar/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ar/app.php
@@ -729,7 +729,6 @@ return [
         ],
         'development' => [
             'title' => 'تطوير',
-            'webconsole' => 'وحدة تحكم الويب',
         ]
     ],
 

--- a/packages/Webkul/Admin/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en/app.php
@@ -838,7 +838,6 @@ return [
         ],
         'development' => [
             'title' => 'Development',
-            'webconsole' => 'Web Console',
         ]
     ],
 

--- a/packages/Webkul/Admin/src/Resources/lang/fa/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/fa/app.php
@@ -764,7 +764,6 @@ return [
         ],
         'development' => [
             'title' => 'توسعه',
-            'webconsole' => 'کنسول وب',
         ]
     ],
 

--- a/packages/Webkul/Admin/src/Resources/lang/pt_BR/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/pt_BR/app.php
@@ -755,7 +755,6 @@ return [
         ],
         'development' => [
             'title' => 'Desenvolvimento',
-            'webconsole' => 'Console da Web',
         ]
     ],
     'customers' => [

--- a/packages/Webkul/Admin/src/Resources/views/settings/development/dashboard.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/development/dashboard.blade.php
@@ -13,16 +13,7 @@
         </div>
 
         <div class="page-content">
-            <a href="{{ route('admin.development.webconsole') }}" target="_blank">
-                <div class="rad-info-box">
-                    <p>
-                        <span class="heading">{{ __('admin::app.settings.development.webconsole') }}</span>
-                    </p>
-                    <p>
-                        <i class="icon cms-icon"></i>
-                    </p>
-                </div>
-            </a>
+
         </div>
     </div>
 @stop


### PR DESCRIPTION
Removed remnants of laravel-web-console from development view and language files:
- removed route to webconsole from blade
- removed translations for webconsole

This PR is an addition to #1791 and #1819.