### PR TITLE
slackened condition to save downloadable purchase link

### DIFF
--- a/packages/Webkul/Sales/src/Repositories/DownloadableLinkPurchasedRepository.php
+++ b/packages/Webkul/Sales/src/Repositories/DownloadableLinkPurchasedRepository.php
@@ -55,7 +55,7 @@ class DownloadableLinkPurchasedRepository extends Repository
      */
     public function saveLinks($orderItem)
     {
-        if ($orderItem->type != 'downloadable' || ! isset($orderItem->additional['links']))
+        if (stristr($orderItem->type,'downloadable') === false || ! isset($orderItem->additional['links']))
             return;
 
         foreach ($orderItem->additional['links'] as $linkId) {


### PR DESCRIPTION
Dear Bagisto team,

In our shop, we created a custom downloadable product type, that exists next to the Bagisto downloadable product type and thus, has a different product_type key. Therefor, our downloadable links are not saved at the moment, when the product is purchased. 
That is why we unclenched the condition a bit, to be able to use the function with our custom downloadable type.

If you would accept this small adaptation, it would be very much appreciated.