### PR TITLE
Bugfix: Exception while applying catalog rule

### DIFF
--- a/packages/Webkul/Product/src/Helpers/ProductType.php
+++ b/packages/Webkul/Product/src/Helpers/ProductType.php
@@ -28,6 +28,7 @@ class ProductType extends AbstractProduct
      */
     public static function getAllTypesHavingVariants(): array
     {
+        $havingVariants = [];
         foreach (config('product_types') as $type) {
             if (self::hasVariants($type['key'])) {
                 array_push($havingVariants, $type['key']);


### PR DESCRIPTION
## Bug:
When applying a catalog rule, an exception occurs, warning that array_push needs to be given an array.

To reproduce the exception: 
- create a new catalog rule
- click "Apply"

Screenshot: 
![image](https://user-images.githubusercontent.com/57894757/71577536-e1fc0c00-2af4-11ea-940f-0d9851fd6fd7.png)

## Fix:
I initialised the array.