### PR TITLE
add missing api_token columns to database (table customers and admins)

### DIFF
--- a/packages/Webkul/Core/src/Database/Migrations/2020_01_02_201029_add_api_token_columns.php
+++ b/packages/Webkul/Core/src/Database/Migrations/2020_01_02_201029_add_api_token_columns.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddApiTokenColumns extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // @see https://laravel.com/docs/6.x/api-authentication#database-preparation
+
+        Schema::table('users', function ($table) {
+            $table
+                ->string('api_token', 80)
+                ->after('password')
+                ->unique()
+                ->nullable()
+                ->default(null);
+        });
+
+        Schema::table('admins', function ($table) {
+            $table
+                ->string('api_token', 80)
+                ->after('password')
+                ->unique()
+                ->nullable()
+                ->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('api_token');
+        });
+
+        Schema::table('admins', function (Blueprint $table) {
+            $table->dropColumn('api_token');
+        });
+    }
+}

--- a/packages/Webkul/Core/src/Database/Migrations/2020_01_02_201029_add_api_token_columns.php
+++ b/packages/Webkul/Core/src/Database/Migrations/2020_01_02_201029_add_api_token_columns.php
@@ -15,7 +15,7 @@ class AddApiTokenColumns extends Migration
     {
         // @see https://laravel.com/docs/6.x/api-authentication#database-preparation
 
-        Schema::table('users', function ($table) {
+        Schema::table('customers', function ($table) {
             $table
                 ->string('api_token', 80)
                 ->after('password')
@@ -41,7 +41,7 @@ class AddApiTokenColumns extends Migration
      */
     public function down()
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('customers', function (Blueprint $table) {
             $table->dropColumn('api_token');
         });
 

--- a/packages/Webkul/Customer/src/Http/Controllers/RegistrationController.php
+++ b/packages/Webkul/Customer/src/Http/Controllers/RegistrationController.php
@@ -2,6 +2,8 @@
 
 namespace Webkul\Customer\Http\Controllers;
 
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Mail;
 use Webkul\Customer\Mail\RegistrationEmail;
@@ -85,6 +87,7 @@ class RegistrationController extends Controller
         $data = request()->input();
 
         $data['password'] = bcrypt($data['password']);
+        $data['api_token'] = Str::random(80);
 
         if (core()->getConfigData('customer.settings.email.verification')) {
             $data['is_verified'] = 0;

--- a/packages/Webkul/Customer/src/Models/Customer.php
+++ b/packages/Webkul/Customer/src/Models/Customer.php
@@ -17,9 +17,9 @@ class Customer extends Authenticatable implements CustomerContract, JWTSubject
 
     protected $table = 'customers';
 
-    protected $fillable = ['first_name', 'last_name', 'gender', 'date_of_birth', 'email', 'phone', 'password', 'customer_group_id', 'subscribed_to_news_letter', 'is_verified', 'token', 'notes', 'status'];
+    protected $fillable = ['first_name', 'last_name', 'gender', 'date_of_birth', 'email', 'phone', 'password', 'api_token', 'customer_group_id', 'subscribed_to_news_letter', 'is_verified', 'token', 'notes', 'status'];
 
-    protected $hidden = ['password', 'remember_token'];
+    protected $hidden = ['password', 'api_token', 'remember_token'];
 
     /**
      * Get the customer full name.

--- a/packages/Webkul/User/src/Database/Seeders/AdminsTableSeeder.php
+++ b/packages/Webkul/User/src/Database/Seeders/AdminsTableSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\User\Database\Seeders;
 
+use Illuminate\Support\Str;
 use Illuminate\Database\Seeder;
 use DB;
 
@@ -16,6 +17,9 @@ class AdminsTableSeeder extends Seeder
                 'name' => 'Example',
                 'email' => 'admin@example.com',
                 'password' => bcrypt('admin123'),
+                'api_token' => Str::random(80),
+                'created_at' => date('Y-m-d H:i:s'),
+                'updated_at' => date('Y-m-d H:i:s'),
                 'status' => 1,
                 'role_id' => 1,
             ]);

--- a/packages/Webkul/User/src/Http/Controllers/UserController.php
+++ b/packages/Webkul/User/src/Http/Controllers/UserController.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\User\Http\Controllers;
 
+use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Event;
 use Webkul\User\Repositories\AdminRepository;
 use Webkul\User\Repositories\RoleRepository;
@@ -61,7 +62,7 @@ class UserController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\View\View 
+     * @return \Illuminate\View\View
      */
     public function index()
     {
@@ -71,7 +72,7 @@ class UserController extends Controller
     /**
      * Show the form for creating a new resource.
      *
-     * @return \Illuminate\View\View 
+     * @return \Illuminate\View\View
      */
     public function create()
     {
@@ -90,8 +91,10 @@ class UserController extends Controller
     {
         $data = $request->all();
 
-        if (isset($data['password']) && $data['password'])
+        if (isset($data['password']) && $data['password']) {
             $data['password'] = bcrypt($data['password']);
+            $data['api_token'] = Str::random(80);
+        }
 
         Event::fire('user.admin.create.before');
 
@@ -108,7 +111,7 @@ class UserController extends Controller
      * Show the form for editing the specified resource.
      *
      * @param integer $id
-     * @return \Illuminate\View\View 
+     * @return \Illuminate\View\View
      */
     public function edit($id)
     {
@@ -130,10 +133,11 @@ class UserController extends Controller
     {
         $data = $request->all();
 
-        if (! $data['password'])
+        if (! $data['password']) {
             unset($data['password']);
-        else
+        } else {
             $data['password'] = bcrypt($data['password']);
+        }
 
         if (isset($data['status'])) {
             $data['status'] = 1;
@@ -156,7 +160,7 @@ class UserController extends Controller
      * Remove the specified resource from storage.
      *
      * @param  int  $id
-     * @return \Illuminate\Http\JsonResponse|\Illuminate\View\View 
+     * @return \Illuminate\Http\JsonResponse|\Illuminate\View\View
      */
     public function destroy($id)
     {

--- a/packages/Webkul/User/src/Models/Admin.php
+++ b/packages/Webkul/User/src/Models/Admin.php
@@ -19,7 +19,7 @@ class Admin extends Authenticatable implements AdminContract
      * @var array
      */
     protected $fillable = [
-        'name', 'email', 'password', 'role_id', 'status',
+        'name', 'email', 'password', 'api_token', 'role_id', 'status',
     ];
 
     /**
@@ -28,7 +28,7 @@ class Admin extends Authenticatable implements AdminContract
      * @var array
      */
     protected $hidden = [
-        'password', 'remember_token',
+        'password', 'api_token', 'remember_token',
     ];
 
     /**


### PR DESCRIPTION
In order to use authenticated API routes (that are protected by `auth:api` or `auth:admin-api` guard) we need to have the api_token columns in the corresponding tables.