### PR TITLE
Make API routes accessable 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -131,7 +131,8 @@
             "set -e",
             "@php artisan migrate:fresh --env=testing",
             "vendor/bin/codecept run unit",
-            "vendor/bin/codecept run functional"
+            "vendor/bin/codecept run functional",
+            "vendor/bin/codecept run trigger"
         ]
     },
     "config": {

--- a/packages/Webkul/Shop/src/Http/Controllers/ProductsCategoriesProxyController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/ProductsCategoriesProxyController.php
@@ -3,11 +3,7 @@
 
 namespace Webkul\Shop\Http\Controllers;
 
-use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Illuminate\Support\Facades\DB;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Webkul\Category\Models\CategoryTranslation;
-use Webkul\Product\Models\ProductFlat;
+use Illuminate\Http\Request;
 use Webkul\Category\Repositories\CategoryRepository;
 use Webkul\Product\Repositories\ProductRepository;
 
@@ -51,26 +47,31 @@ class ProductsCategoriesProxyController extends Controller
     }
 
     /**
-     * Display a listing of the resource which can be a category or a product.
+     * Show product or category view. If neither category nor product matches,
+     * abort with code 404.
      *
-     *
-     * @param string $slugOrPath
+     * @param Request $request
      *
      * @return \Illuminate\View\View
      */
-    public function index(string $slugOrPath)
+    public function index(Request $request)
     {
+        $slugOrPath = trim($request->getPathInfo(), '/');
 
-        if ($category = $this->categoryRepository->findByPath($slugOrPath)) {
+        if (preg_match('/^([a-z0-9-]+\/?)+$/', $slugOrPath)) {
 
-            return view($this->_config['category_view'], compact('category'));
-        }
+            if ($category = $this->categoryRepository->findByPath($slugOrPath)) {
 
-        if ($product = $this->productRepository->findBySlug($slugOrPath)) {
+                return view($this->_config['category_view'], compact('category'));
+            }
 
-            $customer = auth()->guard('customer')->user();
+            if ($product = $this->productRepository->findBySlug($slugOrPath)) {
 
-            return view($this->_config['product_view'], compact('product', 'customer'));
+                $customer = auth()->guard('customer')->user();
+
+                return view($this->_config['product_view'], compact('product', 'customer'));
+            }
+
         }
 
         abort(404);

--- a/packages/Webkul/Shop/src/Http/routes.php
+++ b/packages/Webkul/Shop/src/Http/routes.php
@@ -297,13 +297,10 @@ Route::group(['middleware' => ['web', 'locale', 'theme', 'currency']], function 
 
     Route::get('page/{slug}', 'Webkul\CMS\Http\Controllers\Shop\PagePresenterController@presenter')->name('shop.cms.page');
 
-    Route::get('{slugOrPath}', \Webkul\Shop\Http\Controllers\ProductsCategoriesProxyController::class . '@index')
+    Route::fallback(\Webkul\Shop\Http\Controllers\ProductsCategoriesProxyController::class . '@index')
         ->defaults('_config', [
             'product_view' => 'shop::products.view',
             'category_view' => 'shop::products.index'
         ])
-        ->where('slugOrPath', '^([a-z0-9-]+\/?)+$')
         ->name('shop.productOrCategory.index');
-
-    Route::fallback('Webkul\Shop\Http\Controllers\HomeController@notFound');
 });


### PR DESCRIPTION
Replaced wildcard route for products and categories with fallback route (old route 'shop.productOrCategory.index' caused API routes to not be callable).