### PR TITLE
Add logging for catched exceptions

### DIFF
--- a/app/Console/Commands/GenerateProducts.php
+++ b/app/Console/Commands/GenerateProducts.php
@@ -61,6 +61,7 @@ class GenerateProducts extends Command
                     try {
                         $result = $this->generateProduct->create();
                     } catch (\Exception $e) {
+                        report($e);
                         continue;
                     }
 

--- a/packages/Webkul/Admin/src/Http/Controllers/Customer/CustomerController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Customer/CustomerController.php
@@ -122,7 +122,7 @@ class CustomerController extends Controller
         try {
             Mail::queue(new NewCustomerNotification($customer, $password));
         } catch (\Exception $e) {
-
+            report($e);
         }
 
         session()->flash('success', trans('admin::app.response.create-success', ['name' => 'Customer']));

--- a/packages/Webkul/Admin/src/Listeners/Order.php
+++ b/packages/Webkul/Admin/src/Listeners/Order.php
@@ -2,7 +2,6 @@
 
 namespace Webkul\Admin\Listeners;
 
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 use Webkul\Admin\Mail\NewOrderNotification;
 use Webkul\Admin\Mail\NewAdminNotification;

--- a/packages/Webkul/Admin/src/Listeners/Order.php
+++ b/packages/Webkul/Admin/src/Listeners/Order.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Admin\Listeners;
 
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 use Webkul\Admin\Mail\NewOrderNotification;
 use Webkul\Admin\Mail\NewAdminNotification;
@@ -10,13 +11,15 @@ use Webkul\Admin\Mail\NewShipmentNotification;
 use Webkul\Admin\Mail\NewInventorySourceNotification;
 use Webkul\Admin\Mail\CancelOrderNotification;
 use Webkul\Admin\Mail\NewRefundNotification;
+
 /**
  * Order event handler
  *
  * @author    Jitendra Singh <jitendra@webkul.com>
  * @copyright 2018 Webkul Software Pvt Ltd (http://www.webkul.com)
  */
-class Order {
+class Order
+{
 
     /**
      * @param mixed $order
@@ -30,7 +33,7 @@ class Order {
 
             Mail::queue(new NewAdminNotification($order));
         } catch (\Exception $e) {
-
+            report($e);
         }
     }
 
@@ -42,12 +45,13 @@ class Order {
     public function sendNewInvoiceMail($invoice)
     {
         try {
-            if ($invoice->email_sent)
+            if ($invoice->email_sent) {
                 return;
+            }
 
             Mail::queue(new NewInvoiceNotification($invoice));
         } catch (\Exception $e) {
-
+            report($e);
         }
     }
 
@@ -61,7 +65,7 @@ class Order {
         try {
             Mail::queue(new NewRefundNotification($refund));
         } catch (\Exception $e) {
-
+            report($e);
         }
     }
 
@@ -73,25 +77,28 @@ class Order {
     public function sendNewShipmentMail($shipment)
     {
         try {
-            if ($shipment->email_sent)
+            if ($shipment->email_sent) {
                 return;
+            }
 
             Mail::queue(new NewShipmentNotification($shipment));
 
             Mail::queue(new NewInventorySourceNotification($shipment));
         } catch (\Exception $e) {
-
+            report($e);
         }
     }
 
-     /*
+    /**
      * @param mixed $order
-     * */
-    public function sendCancelOrderMail($order){
-        try{
+     *
+     */
+    public function sendCancelOrderMail($order)
+    {
+        try {
             Mail::queue(new CancelOrderNotification($order));
-        }catch (\Exception $e){
-            \Log::error('Error occured when sending email '.$e->getMessage());
+        } catch (\Exception $e) {
+            report($e);
         }
     }
 }

--- a/packages/Webkul/Attribute/src/Http/Controllers/AttributeController.php
+++ b/packages/Webkul/Attribute/src/Http/Controllers/AttributeController.php
@@ -167,6 +167,7 @@ class AttributeController extends Controller
                         $this->attributeRepository->delete($value);
                     }
                 } catch (\Exception $e) {
+                    report($e);
                     $suppressFlash = true;
 
                     continue;

--- a/packages/Webkul/Attribute/src/Http/Controllers/AttributeFamilyController.php
+++ b/packages/Webkul/Attribute/src/Http/Controllers/AttributeFamilyController.php
@@ -154,7 +154,8 @@ class AttributeFamilyController extends Controller
 
                 return response()->json(['message' => true], 200);
             } catch (\Exception $e) {
-                session()->flash('error', trans( 'admin::app.response.delete-failed', ['name' => 'Family']));
+                report($e);
+                session()->flash('error', trans('admin::app.response.delete-failed', ['name' => 'Family']));
             }
         }
 
@@ -177,16 +178,18 @@ class AttributeFamilyController extends Controller
                 try {
                     $this->attributeFamilyRepository->delete($value);
                 } catch (\Exception $e) {
+                    report($e);
                     $suppressFlash = true;
 
                     continue;
                 }
             }
 
-            if (! $suppressFlash)
+            if (!$suppressFlash) {
                 session()->flash('success', ('admin::app.datagrid.mass-ops.delete-success'));
-            else
+            } else {
                 session()->flash('info', trans('admin::app.datagrid.mass-ops.partial-action', ['resource' => 'Attribute Family']));
+            }
 
             return redirect()->back();
         } else {

--- a/packages/Webkul/CatalogRule/src/Helpers/CatalogRuleIndex.php
+++ b/packages/Webkul/CatalogRule/src/Helpers/CatalogRuleIndex.php
@@ -65,7 +65,7 @@ class CatalogRuleIndex
 
             $this->catalogRuleProductPriceHelper->indexRuleProductPrice(1000);
         } catch (\Exception $e) {
-
+            report($e);
         }
     }
 
@@ -80,7 +80,7 @@ class CatalogRuleIndex
         try {
             if (! $product->getTypeInstance()->priceRuleCanBeApplied())
                 return;
-                
+
             $productIds = $product->getTypeInstance()->isComposite()
                             ? $product->getTypeInstance()->getChildrenIds()
                             : [$product->id];
@@ -93,7 +93,7 @@ class CatalogRuleIndex
 
             $this->catalogRuleProductPriceHelper->indexRuleProductPrice(1000, $product);
         } catch (\Exception $e) {
-
+            report($e);
         }
     }
 

--- a/packages/Webkul/Core/src/Http/Controllers/CurrencyController.php
+++ b/packages/Webkul/Core/src/Http/Controllers/CurrencyController.php
@@ -144,6 +144,7 @@ class CurrencyController extends Controller
 
                 return response()->json(['message' => true], 200);
             } catch (\Exception $e) {
+                report($e);
                 session()->flash('error', trans('admin::app.response.delete-failed', ['name' => 'Currency']));
             }
         }

--- a/packages/Webkul/Core/src/Http/Controllers/ExchangeRateController.php
+++ b/packages/Webkul/Core/src/Http/Controllers/ExchangeRateController.php
@@ -200,6 +200,7 @@ class ExchangeRateController extends Controller
 
                 return response()->json(['message' => true], 200);
             } catch (\Exception $e) {
+                report($e);
                 session()->flash('error', trans('admin::app.response.delete-error', ['name' => 'Exchange rate']));
             }
         }

--- a/packages/Webkul/Core/src/Http/Controllers/SubscriptionController.php
+++ b/packages/Webkul/Core/src/Http/Controllers/SubscriptionController.php
@@ -104,6 +104,7 @@ class SubscriptionController extends Controller
 
             return response()->json(['message' => true], 200);
         } catch (\Exception $e) {
+            report($e);
             session()->flash('error', trans('admin::app.response.delete-failed', ['name' => 'Subscriber']));
         }
 

--- a/packages/Webkul/Customer/src/Http/Controllers/ForgotPasswordController.php
+++ b/packages/Webkul/Customer/src/Http/Controllers/ForgotPasswordController.php
@@ -71,6 +71,7 @@ class ForgotPasswordController extends Controller
                     ['email' => trans($response)]
                 );
         } catch (\Exception $e) {
+            report($e);
             session()->flash('error', trans($e->getMessage()));
 
             return redirect()->back();

--- a/packages/Webkul/Customer/src/Http/Controllers/RegistrationController.php
+++ b/packages/Webkul/Customer/src/Http/Controllers/RegistrationController.php
@@ -114,17 +114,18 @@ class RegistrationController extends Controller
 
                     session()->flash('success', trans('shop::app.customer.signup-form.success-verify'));
                 } catch (\Exception $e) {
+                    report($e);
                     session()->flash('info', trans('shop::app.customer.signup-form.success-verify-email-unsent'));
                 }
             } else {
-                 try {
+                try {
                     Mail::queue(new RegistrationEmail(request()->all()));
 
                     session()->flash('success', trans('shop::app.customer.signup-form.success-verify')); //customer registered successfully
                 } catch (\Exception $e) {
+                    report($e);
                     session()->flash('info', trans('shop::app.customer.signup-form.success-verify-email-unsent'));
                 }
-
 
                 session()->flash('success', trans('shop::app.customer.signup-form.success'));
             }
@@ -177,6 +178,7 @@ class RegistrationController extends Controller
                 \Cookie::queue(\Cookie::forget('email-for-resend'));
             }
         } catch (\Exception $e) {
+            report($e);
             session()->flash('error', trans('shop::app.customer.signup-form.verification-not-sent'));
 
             return redirect()->back();

--- a/packages/Webkul/Customer/src/Http/Controllers/WishlistController.php
+++ b/packages/Webkul/Customer/src/Http/Controllers/WishlistController.php
@@ -172,6 +172,7 @@ class WishlistController extends Controller
 
             return redirect()->back();
         } catch (\Exception $e) {
+            report($e);
             session()->flash('warning', $e->getMessage());
 
             return redirect()->route('shop.productOrCategory.index',  $wishlistItem->product->url_key);

--- a/packages/Webkul/Inventory/src/Http/Controllers/InventorySourceController.php
+++ b/packages/Webkul/Inventory/src/Http/Controllers/InventorySourceController.php
@@ -168,6 +168,7 @@ class InventorySourceController extends Controller
 
                 return response()->json(['message' => true], 200);
             } catch (\Exception $e) {
+                report($e);
                 session()->flash('error', trans('admin::app.response.delete-failed', ['name' => 'Inventory source']));
             }
         }

--- a/packages/Webkul/Product/src/Http/Controllers/ProductController.php
+++ b/packages/Webkul/Product/src/Http/Controllers/ProductController.php
@@ -245,6 +245,7 @@ class ProductController extends Controller
 
             return response()->json(['message' => true], 200);
         } catch (\Exception $e) {
+            report($e);
             session()->flash('error', trans('admin::app.response.delete-failed', ['name' => 'Product']));
         }
 

--- a/packages/Webkul/Product/src/Http/Controllers/ReviewController.php
+++ b/packages/Webkul/Product/src/Http/Controllers/ReviewController.php
@@ -105,6 +105,7 @@ class ReviewController extends Controller
 
             return response()->json(['message' => true], 200);
         } catch (\Exception $e) {
+            report($e);
             session()->flash('success', trans('admin::app.response.delete-failed', ['name' => 'Review']));
         }
 

--- a/packages/Webkul/Shop/src/Http/Controllers/CartController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/CartController.php
@@ -182,6 +182,8 @@ class CartController extends Controller
                 'message' => trans('shop::app.checkout.total.invalid-coupon')
             ]);
         } catch (\Exception $e) {
+            report($e);
+
             return response()->json([
                 'success' => false,
                 'message' => trans('shop::app.checkout.total.coupon-apply-issue')

--- a/packages/Webkul/Shop/src/Http/Controllers/SubscriptionController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/SubscriptionController.php
@@ -75,6 +75,7 @@ class SubscriptionController extends Controller
 
                 session()->flash('success', trans('shop::app.subscription.subscribed'));
             } catch (\Exception $e) {
+                report($e);
                 session()->flash('error', trans('shop::app.subscription.not-subscribed'));
 
                 $mailSent = false;

--- a/packages/Webkul/Tax/src/Http/Controllers/TaxRateController.php
+++ b/packages/Webkul/Tax/src/Http/Controllers/TaxRateController.php
@@ -282,6 +282,7 @@ class TaxRateController extends Controller
                     }
                 }
             } catch (\Exception $e) {
+                report($e);
                 $failure = new Failure(1, 'rows', [0 => trans('admin::app.export.enough-row-error')]);
 
                 session()->flash('error', $failure->errors()[0]);


### PR DESCRIPTION
**As-is**
There are several try-catch-sections inside bagisto. Very often the thrown exception is not handled at all or just as a flash-message for the user.

**Suggestion**
Add the `report()` helper-function of laravel to all try-catch-sections (see https://laravel.com/docs/6.x/errors#report-method for details). This function creates an entry in laravel's error log (default: `storage/logs/laravel.log`) but does not render an error page for the user. In addition, the exception is shown in the debug bar.