### PR TITLE
Feature/allow to configure outgoing emails

### DIFF
--- a/packages/Webkul/Admin/src/Config/system.php
+++ b/packages/Webkul/Admin/src/Config/system.php
@@ -187,6 +187,11 @@ return [
                 'type'  => 'boolean',
             ],
             [
+                'name'  => 'emails.general.notifications.registration',
+                'title' => 'admin::app.admin.emails.notifications.registration',
+                'type'  => 'boolean',
+            ],
+            [
                 'name'  => 'emails.general.notifications.customer',
                 'title' => 'admin::app.admin.emails.notifications.customer',
                 'type'  => 'boolean',

--- a/packages/Webkul/Admin/src/Config/system.php
+++ b/packages/Webkul/Admin/src/Config/system.php
@@ -2,171 +2,230 @@
 
 return [
     [
-        'key' => 'general',
+        'key'  => 'general',
         'name' => 'admin::app.admin.system.general',
         'sort' => 1,
     ], [
-        'key' => 'general.general',
+        'key'  => 'general.general',
         'name' => 'admin::app.admin.system.general',
         'sort' => 1,
     ], [
-        'key' => 'general.general.locale_options',
-        'name' => 'admin::app.admin.system.locale-options',
-        'sort' => 1,
+        'key'    => 'general.general.locale_options',
+        'name'   => 'admin::app.admin.system.locale-options',
+        'sort'   => 1,
         'fields' => [
             [
-                'name' => 'weight_unit',
-                'title' => 'admin::app.admin.system.weight-unit',
-                'type' => 'select',
-                'options' => [
+                'name'          => 'weight_unit',
+                'title'         => 'admin::app.admin.system.weight-unit',
+                'type'          => 'select',
+                'options'       => [
                     [
                         'title' => 'lbs',
-                        'value' => 'lbs'
+                        'value' => 'lbs',
                     ], [
                         'title' => 'kgs',
-                        'value' => 'kgs'
-                    ]
+                        'value' => 'kgs',
+                    ],
                 ],
                 'channel_based' => true,
-            ]
-        ]
+            ],
+        ],
     ], [
-        'key' => 'general.content',
+        'key'  => 'general.content',
         'name' => 'admin::app.admin.system.content',
         'sort' => 2,
     ], [
-        'key' => 'general.content.footer',
-        'name' => 'admin::app.admin.system.footer',
-        'sort' => 1,
+        'key'    => 'general.content.footer',
+        'name'   => 'admin::app.admin.system.footer',
+        'sort'   => 1,
         'fields' => [
             [
-                'name' => 'footer_content',
-                'title' => 'admin::app.admin.system.footer-content',
-                'type' => 'text',
+                'name'          => 'footer_content',
+                'title'         => 'admin::app.admin.system.footer-content',
+                'type'          => 'text',
                 'channel_based' => true,
-                'locale_based' => true
+                'locale_based'  => true,
             ], [
-                'name' => 'footer_toggle',
-                'title' => 'admin::app.admin.system.footer-toggle',
-                'type' => 'select',
-                'options' => [
+                'name'          => 'footer_toggle',
+                'title'         => 'admin::app.admin.system.footer-toggle',
+                'type'          => 'select',
+                'options'       => [
                     [
                         'title' => 'True',
-                        'value' => 1
+                        'value' => 1,
                     ], [
                         'title' => 'False',
-                        'value' => 0
-                    ]
+                        'value' => 0,
+                    ],
                 ],
-                'locale_based' => true,
+                'locale_based'  => true,
                 'channel_based' => true,
-            ]
-        ]
+            ],
+        ],
     ], [
-        'key' => 'general.design',
+        'key'  => 'general.design',
         'name' => 'admin::app.admin.system.design',
         'sort' => 3,
     ], [
-        'key' => 'general.design.admin_logo',
-        'name' => 'admin::app.admin.system.admin-logo',
-        'sort' => 1,
+        'key'    => 'general.design.admin_logo',
+        'name'   => 'admin::app.admin.system.admin-logo',
+        'sort'   => 1,
         'fields' => [
             [
-                'name' => 'logo_image',
-                'title' => 'admin::app.admin.system.logo-image',
-                'type' => 'image',
+                'name'          => 'logo_image',
+                'title'         => 'admin::app.admin.system.logo-image',
+                'type'          => 'image',
                 'channel_based' => true,
-                'validation' => 'mimes:jpeg,bmp,png,jpg'
-            ]
-        ]
+                'validation'    => 'mimes:jpeg,bmp,png,jpg',
+            ],
+        ],
     ], [
-        'key' => 'catalog',
+        'key'  => 'catalog',
         'name' => 'admin::app.admin.system.catalog',
-        'sort' => 2
-    ], [
-        'key' => 'catalog.products',
-        'name' => 'admin::app.admin.system.products',
-        'sort' => 2
-    ], [
-        'key' => 'catalog.products.guest-checkout',
-        'name' => 'admin::app.admin.system.guest-checkout',
-        'sort' => 1,
-        'fields' => [
-            [
-                'name' => 'allow-guest-checkout',
-                'title' => 'admin::app.admin.system.allow-guest-checkout',
-                'type' => 'boolean'
-            ]
-        ]
-    ], [
-        'key' => 'catalog.products.review',
-        'name' => 'admin::app.admin.system.review',
         'sort' => 2,
+    ], [
+        'key'  => 'catalog.products',
+        'name' => 'admin::app.admin.system.products',
+        'sort' => 2,
+    ], [
+        'key'    => 'catalog.products.guest-checkout',
+        'name'   => 'admin::app.admin.system.guest-checkout',
+        'sort'   => 1,
         'fields' => [
             [
-                'name' => 'guest_review',
-                'title' => 'admin::app.admin.system.allow-guest-review',
-                'type' => 'boolean'
-            ]
-        ]
+                'name'  => 'allow-guest-checkout',
+                'title' => 'admin::app.admin.system.allow-guest-checkout',
+                'type'  => 'boolean',
+            ],
+        ],
     ], [
-        'key' => 'catalog.inventory',
+        'key'    => 'catalog.products.review',
+        'name'   => 'admin::app.admin.system.review',
+        'sort'   => 2,
+        'fields' => [
+            [
+                'name'  => 'guest_review',
+                'title' => 'admin::app.admin.system.allow-guest-review',
+                'type'  => 'boolean',
+            ],
+        ],
+    ], [
+        'key'  => 'catalog.inventory',
         'name' => 'admin::app.admin.system.inventory',
         'sort' => 1,
     ], [
-        'key' => 'catalog.inventory.stock_options',
-        'name' => 'admin::app.admin.system.stock-options',
-        'sort' => 1,
+        'key'    => 'catalog.inventory.stock_options',
+        'name'   => 'admin::app.admin.system.stock-options',
+        'sort'   => 1,
         'fields' => [
             [
-                'name' => 'backorders',
-                'title' => 'admin::app.admin.system.allow-backorders',
-                'type' => 'boolean',
-                'channel_based' => true
-            ]
-        ]
+                'name'          => 'backorders',
+                'title'         => 'admin::app.admin.system.allow-backorders',
+                'type'          => 'boolean',
+                'channel_based' => true,
+            ],
+        ],
     ], [
-        'key' => 'customer',
+        'key'  => 'customer',
         'name' => 'admin::app.admin.system.customer',
         'sort' => 3,
     ], [
-        'key' => 'customer.settings',
+        'key'  => 'customer.settings',
         'name' => 'admin::app.admin.system.settings',
         'sort' => 1,
     ], [
-        'key' => 'customer.settings.address',
-        'name' => 'admin::app.admin.system.address',
-        'sort' => 1,
+        'key'    => 'customer.settings.address',
+        'name'   => 'admin::app.admin.system.address',
+        'sort'   => 1,
         'fields' => [
             [
-                'name' => 'street_lines',
-                'title' => 'admin::app.admin.system.street-lines',
-                'type' => 'text',
-                'validation' => 'between:1,4',
-                'channel_based' => true
-            ]
-        ]
-    ], [
-        'key' => 'customer.settings.newsletter',
-        'name' => 'admin::app.admin.system.newsletter',
-        'sort' => 2,
-        'fields' => [
-            [
-                'name' => 'subscription',
-                'title' => 'admin::app.admin.system.newsletter-subscription',
-                'type' => 'boolean',
-            ]
+                'name'          => 'street_lines',
+                'title'         => 'admin::app.admin.system.street-lines',
+                'type'          => 'text',
+                'validation'    => 'between:1,4',
+                'channel_based' => true,
+            ],
         ],
     ], [
-        'key' => 'customer.settings.email',
-        'name' => 'admin::app.admin.system.email',
-        'sort' => 3,
+        'key'    => 'customer.settings.newsletter',
+        'name'   => 'admin::app.admin.system.newsletter',
+        'sort'   => 2,
         'fields' => [
             [
-                'name' => 'verification',
+                'name'  => 'subscription',
+                'title' => 'admin::app.admin.system.newsletter-subscription',
+                'type'  => 'boolean',
+            ],
+        ],
+    ], [
+        'key'    => 'customer.settings.email',
+        'name'   => 'admin::app.admin.system.email',
+        'sort'   => 3,
+        'fields' => [
+            [
+                'name'  => 'verification',
                 'title' => 'admin::app.admin.system.email-verification',
-                'type' => 'boolean'
-            ]
+                'type'  => 'boolean',
+            ],
+        ],
+    ], [
+        'key'  => 'emails',
+        'name' => 'admin::app.admin.emails',
+        'sort' => 1,
+    ], [
+        'key'  => 'emails.general',
+        'name' => 'admin::app.admin.emails.verification',
+        'sort' => 1,
+    ], [
+        'key'    => 'emails.general.notifications',
+        'name'   => 'admin::app.admin.emails.verification',
+        'sort'   => 1,
+        'fields' => [
+            [
+                'name'  => 'emails.general.notifications.verification',
+                'title' => 'admin::app.admin.emails.general.verification',
+                'type'  => 'boolean',
+            ],
+            [
+                'name'  => 'emails.general.notifications.customer',
+                'title' => 'admin::app.admin.emails.general.customer',
+                'type'  => 'boolean',
+            ],
+            [
+                'name'  => 'emails.general.notifications.new-order',
+                'title' => 'admin::app.admin.emails.general.customer-notification',
+                'type'  => 'boolean',
+            ],
+            [
+                'name'  => 'emails.general.notifications.new-admin',
+                'title' => 'admin::app.admin.emails.general.new-admin',
+                'type'  => 'boolean',
+            ],
+            [
+                'name'  => 'emails.general.notifications.new-invoice',
+                'title' => 'admin::app.admin.emails.general.new-invoice',
+                'type'  => 'boolean',
+            ],
+            [
+                'name'  => 'emails.general.notifications.new-refund',
+                'title' => 'admin::app.admin.emails.general.new-refund',
+                'type'  => 'boolean',
+            ],
+            [
+                'name'  => 'emails.general.notifications.new-shipment',
+                'title' => 'admin::app.admin.emails.general.new-shipment',
+                'type'  => 'boolean',
+            ],
+            [
+                'name'  => 'emails.general.notifications.new-inventory-source',
+                'title' => 'admin::app.admin.emails.general.new-inventory-source',
+                'type'  => 'boolean',
+            ],
+            [
+                'name'  => 'emails.general.notifications.cancel-order',
+                'title' => 'admin::app.admin.emails.general.cancel-order',
+                'type'  => 'boolean',
+            ],
         ],
     ],
 ];

--- a/packages/Webkul/Admin/src/Config/system.php
+++ b/packages/Webkul/Admin/src/Config/system.php
@@ -170,60 +170,60 @@ return [
         ],
     ], [
         'key'  => 'emails',
-        'name' => 'admin::app.admin.emails',
+        'name' => 'admin::app.admin.emails.email',
         'sort' => 1,
     ], [
         'key'  => 'emails.general',
-        'name' => 'admin::app.admin.emails.verification',
+        'name' => 'admin::app.admin.emails.notification_label',
         'sort' => 1,
     ], [
         'key'    => 'emails.general.notifications',
-        'name'   => 'admin::app.admin.emails.verification',
+        'name'   => 'admin::app.admin.emails.notification_label',
         'sort'   => 1,
         'fields' => [
             [
                 'name'  => 'emails.general.notifications.verification',
-                'title' => 'admin::app.admin.emails.general.verification',
+                'title' => 'admin::app.admin.emails.notifications.verification',
                 'type'  => 'boolean',
             ],
             [
                 'name'  => 'emails.general.notifications.customer',
-                'title' => 'admin::app.admin.emails.general.customer',
+                'title' => 'admin::app.admin.emails.notifications.customer',
                 'type'  => 'boolean',
             ],
             [
                 'name'  => 'emails.general.notifications.new-order',
-                'title' => 'admin::app.admin.emails.general.customer-notification',
+                'title' => 'admin::app.admin.emails.notifications.new-order',
                 'type'  => 'boolean',
             ],
             [
                 'name'  => 'emails.general.notifications.new-admin',
-                'title' => 'admin::app.admin.emails.general.new-admin',
+                'title' => 'admin::app.admin.emails.notifications.new-admin',
                 'type'  => 'boolean',
             ],
             [
                 'name'  => 'emails.general.notifications.new-invoice',
-                'title' => 'admin::app.admin.emails.general.new-invoice',
+                'title' => 'admin::app.admin.emails.notifications.new-invoice',
                 'type'  => 'boolean',
             ],
             [
                 'name'  => 'emails.general.notifications.new-refund',
-                'title' => 'admin::app.admin.emails.general.new-refund',
+                'title' => 'admin::app.admin.emails.notifications.new-refund',
                 'type'  => 'boolean',
             ],
             [
                 'name'  => 'emails.general.notifications.new-shipment',
-                'title' => 'admin::app.admin.emails.general.new-shipment',
+                'title' => 'admin::app.admin.emails.notifications.new-shipment',
                 'type'  => 'boolean',
             ],
             [
                 'name'  => 'emails.general.notifications.new-inventory-source',
-                'title' => 'admin::app.admin.emails.general.new-inventory-source',
+                'title' => 'admin::app.admin.emails.notifications.new-inventory-source',
                 'type'  => 'boolean',
             ],
             [
                 'name'  => 'emails.general.notifications.cancel-order',
-                'title' => 'admin::app.admin.emails.general.cancel-order',
+                'title' => 'admin::app.admin.emails.notifications.cancel-order',
                 'type'  => 'boolean',
             ],
         ],

--- a/packages/Webkul/Admin/src/Http/Controllers/Customer/CustomerController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Customer/CustomerController.php
@@ -120,7 +120,10 @@ class CustomerController extends Controller
         $customer = $this->customerRepository->create($data);
 
         try {
-            Mail::queue(new NewCustomerNotification($customer, $password));
+            $configKey = 'emails.general.notifications.emails.general.notifications.customer';
+            if (core()->getConfigData($configKey)) {
+                Mail::queue(new NewCustomerNotification($customer, $password));
+            }
         } catch (\Exception $e) {
             report($e);
         }

--- a/packages/Webkul/Admin/src/Listeners/Order.php
+++ b/packages/Webkul/Admin/src/Listeners/Order.php
@@ -28,9 +28,15 @@ class Order
     public function sendNewOrderMail($order)
     {
         try {
-            Mail::queue(new NewOrderNotification($order));
+            $configKey = 'emails.general.notifications.emails.general.notifications.new-order';
+            if (core()->getConfigData($configKey)) {
+                Mail::queue(new NewOrderNotification($order));
+            }
 
-            Mail::queue(new NewAdminNotification($order));
+            $configKey = 'emails.general.notifications.emails.general.notifications.new-admin';
+            if (core()->getConfigData($configKey)) {
+                Mail::queue(new NewAdminNotification($order));
+            }
         } catch (\Exception $e) {
             report($e);
         }
@@ -48,7 +54,10 @@ class Order
                 return;
             }
 
-            Mail::queue(new NewInvoiceNotification($invoice));
+            $configKey = 'emails.general.notifications.emails.general.notifications.new-invoice';
+            if (core()->getConfigData($configKey)) {
+                Mail::queue(new NewInvoiceNotification($invoice));
+            }
         } catch (\Exception $e) {
             report($e);
         }
@@ -62,7 +71,10 @@ class Order
     public function sendNewRefundMail($refund)
     {
         try {
-            Mail::queue(new NewRefundNotification($refund));
+            $configKey = 'emails.general.notifications.emails.general.notifications.new-refund';
+            if (core()->getConfigData($configKey)) {
+                Mail::queue(new NewRefundNotification($refund));
+            }
         } catch (\Exception $e) {
             report($e);
         }
@@ -80,9 +92,15 @@ class Order
                 return;
             }
 
-            Mail::queue(new NewShipmentNotification($shipment));
+            $configKey = 'emails.general.notifications.emails.general.notifications.new-shipment';
+            if (core()->getConfigData($configKey)) {
+                Mail::queue(new NewShipmentNotification($shipment));
+            }
 
-            Mail::queue(new NewInventorySourceNotification($shipment));
+            $configKey = 'emails.general.notifications.emails.general.notifications.new-inventory-source';
+            if (core()->getConfigData($configKey)) {
+                Mail::queue(new NewInventorySourceNotification($shipment));
+            }
         } catch (\Exception $e) {
             report($e);
         }
@@ -95,7 +113,10 @@ class Order
     public function sendCancelOrderMail($order)
     {
         try {
-            Mail::queue(new CancelOrderNotification($order));
+            $configKey = 'emails.general.notifications.emails.general.notifications.cancel-order';
+            if (core()->getConfigData($configKey)) {
+                Mail::queue(new CancelOrderNotification($order));
+            }
         } catch (\Exception $e) {
             report($e);
         }

--- a/packages/Webkul/Admin/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en/app.php
@@ -1206,6 +1206,22 @@ return [
     ],
 
     'admin' => [
+        'emails' => [
+            'email' => 'Email',
+            'notification_label' => 'Notifications',
+            'notifications' => [
+                'verification' => 'Send verification E-mail',
+                'customer' => 'Send customer E-mail',
+                'new-order' => 'Send Order Confirmation E-mail',
+                'new-admin' => 'Send Admin Invitation E-mail',
+                'new-invoice' => 'Send Invoice Confirmation E-mail',
+                'new-refund' => 'Send Refund Notification E-mail',
+                'new-shipment' => 'Send Shipment Notification E-mail',
+                'new-inventory-source' => 'Send Inventory Source Notification E-mail',
+                'cancel-order' => 'Send cancel Order Notification E-mail',
+            ],
+
+        ],
         'system' => [
             'catalog' => 'Catalog',
             'products' => 'Products',

--- a/packages/Webkul/Admin/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en/app.php
@@ -1211,6 +1211,7 @@ return [
             'notification_label' => 'Notifications',
             'notifications' => [
                 'verification' => 'Send verification E-mail',
+                'registration' => 'Send registration E-mail',
                 'customer' => 'Send customer E-mail',
                 'new-order' => 'Send Order Confirmation E-mail',
                 'new-admin' => 'Send Admin Invitation E-mail',

--- a/packages/Webkul/Core/src/Database/Seeders/ConfigTableSeeder.php
+++ b/packages/Webkul/Core/src/Database/Seeders/ConfigTableSeeder.php
@@ -36,6 +36,16 @@ class ConfigTableSeeder extends Seeder
 
         DB::table('core_config')->insert([
             'id'           => 3,
+            'code'         => 'emails.general.notifications.emails.general.notifications.registration',
+            'value'        => '1',
+            'channel_code' => null,
+            'locale_code'  => null,
+            'created_at'   => $now,
+            'updated_at'   => $now,
+        ]);
+
+        DB::table('core_config')->insert([
+            'id'           => 4,
             'code'         => 'emails.general.notifications.emails.general.notifications.customer',
             'value'        => '1',
             'channel_code' => null,

--- a/packages/Webkul/Core/src/Database/Seeders/ConfigTableSeeder.php
+++ b/packages/Webkul/Core/src/Database/Seeders/ConfigTableSeeder.php
@@ -26,7 +26,7 @@ class ConfigTableSeeder extends Seeder
 
         DB::table('core_config')->insert([
             'id'           => 2,
-            'code'         => 'emails.general.notifications.verification',
+            'code'         => 'emails.general.notifications.emails.general.notifications.verification',
             'value'        => '1',
             'channel_code' => null,
             'locale_code'  => null,
@@ -36,7 +36,7 @@ class ConfigTableSeeder extends Seeder
 
         DB::table('core_config')->insert([
             'id'           => 3,
-            'code'         => 'emails.general.notifications.customer',
+            'code'         => 'emails.general.notifications.emails.general.notifications.customer',
             'value'        => '1',
             'channel_code' => null,
             'locale_code'  => null,
@@ -46,7 +46,7 @@ class ConfigTableSeeder extends Seeder
 
         DB::table('core_config')->insert([
             'id'           => 5,
-            'code'         => 'emails.general.notifications.new-order',
+            'code'         => 'emails.general.notifications.emails.general.notifications.new-order',
             'value'        => '1',
             'channel_code' => null,
             'locale_code'  => null,
@@ -56,7 +56,7 @@ class ConfigTableSeeder extends Seeder
 
         DB::table('core_config')->insert([
             'id'           => 6,
-            'code'         => 'emails.general.notifications.new-admin',
+            'code'         => 'emails.general.notifications.emails.general.notifications.new-admin',
             'value'        => '1',
             'channel_code' => null,
             'locale_code'  => null,
@@ -66,7 +66,7 @@ class ConfigTableSeeder extends Seeder
 
         DB::table('core_config')->insert([
             'id'           => 7,
-            'code'         => 'emails.general.notifications.new-invoice',
+            'code'         => 'emails.general.notifications.emails.general.notifications.new-invoice',
             'value'        => '1',
             'channel_code' => null,
             'locale_code'  => null,
@@ -76,7 +76,7 @@ class ConfigTableSeeder extends Seeder
 
         DB::table('core_config')->insert([
             'id'           => 8,
-            'code'         => 'emails.general.notifications.new-refund',
+            'code'         => 'emails.general.notifications.emails.general.notifications.new-refund',
             'value'        => '1',
             'channel_code' => null,
             'locale_code'  => null,
@@ -86,7 +86,7 @@ class ConfigTableSeeder extends Seeder
 
         DB::table('core_config')->insert([
             'id'           => 9,
-            'code'         => 'emails.general.notifications.new-shipment',
+            'code'         => 'emails.general.notifications.emails.general.notifications.new-shipment',
             'value'        => '1',
             'channel_code' => null,
             'locale_code'  => null,
@@ -96,7 +96,7 @@ class ConfigTableSeeder extends Seeder
 
         DB::table('core_config')->insert([
             'id'           => 10,
-            'code'         => 'emails.general.notifications.new-inventory-source',
+            'code'         => 'emails.general.notifications.emails.general.notifications.new-inventory-source',
             'value'        => '1',
             'channel_code' => null,
             'locale_code'  => null,
@@ -106,7 +106,7 @@ class ConfigTableSeeder extends Seeder
 
         DB::table('core_config')->insert([
             'id'           => 11,
-            'code'         => 'emails.general.notifications.cancel-order',
+            'code'         => 'emails.general.notifications.emails.general.notifications.cancel-order',
             'value'        => '1',
             'channel_code' => null,
             'locale_code'  => null,

--- a/packages/Webkul/Core/src/Database/Seeders/ConfigTableSeeder.php
+++ b/packages/Webkul/Core/src/Database/Seeders/ConfigTableSeeder.php
@@ -15,13 +15,104 @@ class ConfigTableSeeder extends Seeder
         $now = Carbon::now();
 
         DB::table('core_config')->insert([
-            'id' => 1,
-            'code' => 'catalog.products.guest-checkout.allow-guest-checkout',
-            'value' => '1',
+            'id'           => 1,
+            'code'         => 'catalog.products.guest-checkout.allow-guest-checkout',
+            'value'        => '1',
             'channel_code' => null,
-            'locale_code' => null,
-            'created_at' => $now,
-            'updated_at' => $now
+            'locale_code'  => null,
+            'created_at'   => $now,
+            'updated_at'   => $now,
         ]);
+
+        DB::table('core_config')->insert([
+            'id'           => 2,
+            'code'         => 'emails.verification',
+            'value'        => '1',
+            'channel_code' => null,
+            'locale_code'  => null,
+            'created_at'   => $now,
+            'updated_at'   => $now,
+        ]);
+
+        DB::table('core_config')->insert([
+            'id'           => 3,
+            'code'         => 'emails.customer-notification',
+            'value'        => '1',
+            'channel_code' => null,
+            'locale_code'  => null,
+            'created_at'   => $now,
+            'updated_at'   => $now,
+        ]);
+
+        DB::table('core_config')->insert([
+            'id'           => 5,
+            'code'         => 'emails.new-order-notification',
+            'value'        => '1',
+            'channel_code' => null,
+            'locale_code'  => null,
+            'created_at'   => $now,
+            'updated_at'   => $now,
+        ]);
+
+        DB::table('core_config')->insert([
+            'id'           => 6,
+            'code'         => 'emails.new-admin-notification',
+            'value'        => '1',
+            'channel_code' => null,
+            'locale_code'  => null,
+            'created_at'   => $now,
+            'updated_at'   => $now,
+        ]);
+
+        DB::table('core_config')->insert([
+            'id'           => 7,
+            'code'         => 'emails.new-invoice-notification',
+            'value'        => '1',
+            'channel_code' => null,
+            'locale_code'  => null,
+            'created_at'   => $now,
+            'updated_at'   => $now,
+        ]);
+
+        DB::table('core_config')->insert([
+            'id'           => 8,
+            'code'         => 'emails.new-refund-notification',
+            'value'        => '1',
+            'channel_code' => null,
+            'locale_code'  => null,
+            'created_at'   => $now,
+            'updated_at'   => $now,
+        ]);
+
+        DB::table('core_config')->insert([
+            'id'           => 9,
+            'code'         => 'emails.new-shipment-notification',
+            'value'        => '1',
+            'channel_code' => null,
+            'locale_code'  => null,
+            'created_at'   => $now,
+            'updated_at'   => $now,
+        ]);
+
+        DB::table('core_config')->insert([
+            'id'           => 10,
+            'code'         => 'emails.new-inventory-source-notification',
+            'value'        => '1',
+            'channel_code' => null,
+            'locale_code'  => null,
+            'created_at'   => $now,
+            'updated_at'   => $now,
+        ]);
+
+        DB::table('core_config')->insert([
+            'id'           => 11,
+            'code'         => 'emails.cancel-order-notification',
+            'value'        => '1',
+            'channel_code' => null,
+            'locale_code'  => null,
+            'created_at'   => $now,
+            'updated_at'   => $now,
+        ]);
+
     }
 }

--- a/packages/Webkul/Core/src/Database/Seeders/ConfigTableSeeder.php
+++ b/packages/Webkul/Core/src/Database/Seeders/ConfigTableSeeder.php
@@ -26,7 +26,7 @@ class ConfigTableSeeder extends Seeder
 
         DB::table('core_config')->insert([
             'id'           => 2,
-            'code'         => 'emails.verification',
+            'code'         => 'emails.general.notifications.verification',
             'value'        => '1',
             'channel_code' => null,
             'locale_code'  => null,
@@ -36,7 +36,7 @@ class ConfigTableSeeder extends Seeder
 
         DB::table('core_config')->insert([
             'id'           => 3,
-            'code'         => 'emails.customer-notification',
+            'code'         => 'emails.general.notifications.customer',
             'value'        => '1',
             'channel_code' => null,
             'locale_code'  => null,
@@ -46,7 +46,7 @@ class ConfigTableSeeder extends Seeder
 
         DB::table('core_config')->insert([
             'id'           => 5,
-            'code'         => 'emails.new-order-notification',
+            'code'         => 'emails.general.notifications.new-order',
             'value'        => '1',
             'channel_code' => null,
             'locale_code'  => null,
@@ -56,7 +56,7 @@ class ConfigTableSeeder extends Seeder
 
         DB::table('core_config')->insert([
             'id'           => 6,
-            'code'         => 'emails.new-admin-notification',
+            'code'         => 'emails.general.notifications.new-admin',
             'value'        => '1',
             'channel_code' => null,
             'locale_code'  => null,
@@ -66,7 +66,7 @@ class ConfigTableSeeder extends Seeder
 
         DB::table('core_config')->insert([
             'id'           => 7,
-            'code'         => 'emails.new-invoice-notification',
+            'code'         => 'emails.general.notifications.new-invoice',
             'value'        => '1',
             'channel_code' => null,
             'locale_code'  => null,
@@ -76,7 +76,7 @@ class ConfigTableSeeder extends Seeder
 
         DB::table('core_config')->insert([
             'id'           => 8,
-            'code'         => 'emails.new-refund-notification',
+            'code'         => 'emails.general.notifications.new-refund',
             'value'        => '1',
             'channel_code' => null,
             'locale_code'  => null,
@@ -86,7 +86,7 @@ class ConfigTableSeeder extends Seeder
 
         DB::table('core_config')->insert([
             'id'           => 9,
-            'code'         => 'emails.new-shipment-notification',
+            'code'         => 'emails.general.notifications.new-shipment',
             'value'        => '1',
             'channel_code' => null,
             'locale_code'  => null,
@@ -96,7 +96,7 @@ class ConfigTableSeeder extends Seeder
 
         DB::table('core_config')->insert([
             'id'           => 10,
-            'code'         => 'emails.new-inventory-source-notification',
+            'code'         => 'emails.general.notifications.new-inventory-source',
             'value'        => '1',
             'channel_code' => null,
             'locale_code'  => null,
@@ -106,13 +106,12 @@ class ConfigTableSeeder extends Seeder
 
         DB::table('core_config')->insert([
             'id'           => 11,
-            'code'         => 'emails.cancel-order-notification',
+            'code'         => 'emails.general.notifications.cancel-order',
             'value'        => '1',
             'channel_code' => null,
             'locale_code'  => null,
             'created_at'   => $now,
             'updated_at'   => $now,
         ]);
-
     }
 }

--- a/packages/Webkul/Customer/src/Http/Controllers/RegistrationController.php
+++ b/packages/Webkul/Customer/src/Http/Controllers/RegistrationController.php
@@ -31,23 +31,24 @@ class RegistrationController extends Controller
      * CustomerRepository object
      *
      * @var Object
-    */
+     */
     protected $customerRepository;
 
     /**
      * CustomerGroupRepository object
      *
      * @var Object
-    */
+     */
     protected $customerGroupRepository;
 
     /**
      * Create a new Repository instance.
      *
-     * @param  \Webkul\Customer\Repositories\CustomerRepository      $customer
-     * @param  \Webkul\Customer\Repositories\CustomerGroupRepository $customerGroupRepository
+     * @param \Webkul\Customer\Repositories\CustomerRepository      $customer
+     * @param \Webkul\Customer\Repositories\CustomerGroupRepository $customerGroupRepository
+     *
      * @return void
-    */
+     */
     public function __construct(
         CustomerRepository $customerRepository,
         CustomerGroupRepository $customerGroupRepository
@@ -79,9 +80,9 @@ class RegistrationController extends Controller
     {
         $this->validate(request(), [
             'first_name' => 'string|required',
-            'last_name' => 'string|required',
-            'email' => 'email|required|unique:customers,email',
-            'password' => 'confirmed|min:6|required',
+            'last_name'  => 'string|required',
+            'email'      => 'email|required|unique:customers,email',
+            'password'   => 'confirmed|min:6|required',
         ]);
 
         $data = request()->input();
@@ -110,7 +111,10 @@ class RegistrationController extends Controller
         if ($customer) {
             if (core()->getConfigData('customer.settings.email.verification')) {
                 try {
-                    Mail::queue(new VerificationEmail($verificationData));
+                    $configKey = 'emails.general.notifications.emails.general.notifications.verification';
+                    if (core()->getConfigData($configKey)) {
+                        Mail::queue(new VerificationEmail($verificationData));
+                    }
 
                     session()->flash('success', trans('shop::app.customer.signup-form.success-verify'));
                 } catch (\Exception $e) {
@@ -119,7 +123,10 @@ class RegistrationController extends Controller
                 }
             } else {
                 try {
-                    Mail::queue(new RegistrationEmail(request()->all()));
+                    $configKey = 'emails.general.notifications.emails.general.notifications.registration';
+                    if (core()->getConfigData($configKey)) {
+                        Mail::queue(new RegistrationEmail(request()->all()));
+                    }
 
                     session()->flash('success', trans('shop::app.customer.signup-form.success-verify')); //customer registered successfully
                 } catch (\Exception $e) {


### PR DESCRIPTION
Currently it is not possible to configure which notification type is being sent via bagisto. Depending on the shop where the bagisto ecommerce framework is used, it may not be wanted to have all the 12 notification types that bagisto has by default is sent via email to customers or admins. 

Prior to this PR i would need to configure this really complicated by overriding bagisto code.

With this PR the admin can configure which types of email notifications bagisto will send in the admin backend:

![grafik](https://user-images.githubusercontent.com/654271/74669101-c6cd8480-51a6-11ea-945a-2bb79643f3f7.png)

When doing a fresh installation of bagisto, all email types are enabled by default. If upgrading, one would need to run the `ConfigTableSeeder` or set all desired notifications to 'enabled' manually.

The bagisto team would keep in mind to keep care of potential notification types that are being added in the future.
