### PR TITLE
Fire event if customer wants to "buy now"

### DIFF
--- a/packages/Webkul/API/Http/Controllers/Shop/CartController.php
+++ b/packages/Webkul/API/Http/Controllers/Shop/CartController.php
@@ -98,6 +98,10 @@ class CartController extends Controller
      */
     public function store($id)
     {
+        if (request()->get('is_buy_now')) {
+            Event::dispatch('shop.item.buy-now', $id);
+        }
+        
         Event::dispatch('checkout.cart.item.add.before', $id);
 
         $result = Cart::addProduct($id, request()->except('_token'));


### PR DESCRIPTION
If a customer wants to buy a single product directly, the CartController add() method fires an event. The same event has to be fired at api request. In this case it's store() method.