### PR TITLE
generate a dummy brand in GenerateProducts.php

### DIFF
--- a/packages/Webkul/Product/src/Helpers/GenerateProduct.php
+++ b/packages/Webkul/Product/src/Helpers/GenerateProduct.php
@@ -2,10 +2,17 @@
 
 namespace Webkul\Product\Helpers;
 
+use Webkul\Attribute\Models\Attribute;
+use Webkul\Attribute\Models\AttributeOption;
 use Webkul\Product\Repositories\ProductRepository as Product;
 use Webkul\Attribute\Repositories\AttributeFamilyRepository as AttributeFamily;
 use Illuminate\Support\Str;
 
+/**
+ * Class GenerateProduct
+ *
+ * @package Webkul\Product\Helpers
+ */
 class GenerateProduct
 {
     /**
@@ -28,18 +35,50 @@ class GenerateProduct
         $this->product = $product;
 
         $this->types = [
-            'text', 'textarea', 'boolean', 'select', 'multiselect', 'datetime', 'date', 'price', 'image', 'file', 'checkbox'
+            'text',
+            'textarea',
+            'boolean',
+            'select',
+            'multiselect',
+            'datetime',
+            'date',
+            'price',
+            'image',
+            'file',
+            'checkbox',
         ];
 
         $this->attributeFamily = $attributeFamily;
     }
 
+    /**
+     * This brand option needs to be available so that the generated product
+     * can be linked to the order_brands table after checkout.
+     */
+    public function generateDemoBrand()
+    {
+        $brand = Attribute::where(['code' => 'brand'])->first();
+
+        if (! AttributeOption::where(['attribute_id' => $brand->id])->exists()) {
+
+            AttributeOption::create([
+                'admin_name'   => 'Webkul Demo Brand (c) 2020',
+                'attribute_id' => $brand->id,
+            ]);
+        }
+
+
+    }
+
+    /**
+     * @return mixed
+     */
     public function create()
     {
         $attributes = $this->getDefaultFamilyAttributes();
 
         $attributeFamily = $this->attributeFamily->findWhere([
-            'code' => 'default'
+            'code' => 'default',
         ]);
 
         $sku = Str::random(10);
@@ -59,7 +98,11 @@ class GenerateProduct
 
         foreach ($attributes as $attribute) {
             if ($attribute->type == 'text') {
-                if ($attribute->code == 'width' || $attribute->code == 'height' || $attribute->code == 'depth' || $attribute->code == 'weight') {
+                if ($attribute->code == 'width'
+                    || $attribute->code == 'height'
+                    || $attribute->code == 'depth'
+                    || $attribute->code == 'weight'
+                ) {
                     $data[$attribute->code] = $faker->randomNumber(3);
                 } else if ($attribute->code == 'url_key') {
                     $data[$attribute->code] = strtolower($sku);
@@ -72,7 +115,7 @@ class GenerateProduct
                 $data[$attribute->code] = $faker->text;
 
                 if ($attribute->code == 'description' || $attribute->code == 'short_description') {
-                    $data[$attribute->code] = '<p>'. $data[$attribute->code] . '</p>';
+                    $data[$attribute->code] = '<p>' . $data[$attribute->code] . '</p>';
                 }
             } else if ($attribute->type == 'boolean') {
                 $data[$attribute->code] = $faker->boolean;
@@ -117,7 +160,7 @@ class GenerateProduct
             } else if ($attribute->code == 'checkbox') {
                 $options = $attribute->options;
 
-                 if ($options->count()) {
+                if ($options->count()) {
                     $option = $options->first()->id;
 
                     $optionArray = [];
@@ -135,20 +178,23 @@ class GenerateProduct
 
         $data['locale'] = core()->getCurrentLocale()->code;
 
+        $brand = Attribute::where(['code' => 'brand'])->first();
+        $data['brand'] = AttributeOption::where(['attribute_id' => $brand->id])->first()->id ?? '';
+
         $data['channel'] = $channel->code;
 
         $data['channels'] = [
-            0 => $channel->id
+            0 => $channel->id,
         ];
 
         $inventorySource = $channel->inventory_sources[0];
 
         $data['inventories'] = [
-            $inventorySource->id => 10
+            $inventorySource->id => 10,
         ];
 
         $data['categories'] = [
-            0 => $channel->root_category->id
+            0 => $channel->root_category->id,
         ];
 
         $updated = $this->product->update($data, $product->id);
@@ -159,7 +205,7 @@ class GenerateProduct
     public function getDefaultFamilyAttributes()
     {
         $attributeFamily = $this->attributeFamily->findWhere([
-            'code' => 'default'
+            'code' => 'default',
         ]);
 
         $attributes = collect();


### PR DESCRIPTION
 to fix brand linking issue after checkout of generated product.

Currently, when generating products via `artisan bagisto:generate products 666` the generated products can not be bought because there is no brand associated with it. This PR fixes this issue.

It also introduces a fancy progress bar like:

![grafik](https://user-images.githubusercontent.com/654271/75251351-b6d32780-57da-11ea-9b3f-19ec4cfb1c3c.png)



