### PR TITLE
company_name and vat_id address->cart->order (addresses) fixes

### DIFF
--- a/packages/Webkul/Checkout/src/Cart.php
+++ b/packages/Webkul/Checkout/src/Cart.php
@@ -212,7 +212,7 @@ class Cart
             'items_count'           => 1,
         ];
 
-        //Authentication details
+        // Fill in the customer data, as far as possible:
         if ($this->getCurrentCustomer()->check()) {
             $cartData['customer_id'] = $this->getCurrentCustomer()->user()->id;
             $cartData['is_guest'] = 0;

--- a/packages/Webkul/Checkout/src/Models/CartAddress.php
+++ b/packages/Webkul/Checkout/src/Models/CartAddress.php
@@ -9,7 +9,21 @@ class CartAddress extends Model implements CartAddressContract
 {
     protected $table = 'cart_address';
 
-    protected $fillable = ['first_name', 'last_name', 'email', 'address1', 'city', 'state', 'postcode',  'country', 'phone', 'address_type', 'cart_id'];
+    protected $fillable = [
+        'first_name',
+        'last_name',
+        'email',
+        'company_name',
+        'vat_id',
+        'address1',
+        'city',
+        'state',
+        'postcode',
+        'country',
+        'phone',
+        'address_type',
+        'cart_id',
+        ];
 
     /**
      * Get the shipping rates for the cart address.

--- a/packages/Webkul/Customer/src/Database/Migrations/2020_02_25_181902_propagate_company_name.php
+++ b/packages/Webkul/Customer/src/Database/Migrations/2020_02_25_181902_propagate_company_name.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class PropagateCompanyName extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('cart_address', function (Blueprint $table) {
+            $table->string('company_name')->nullable()->after('email');
+            $table->string('vat_id')->nullable()->after('company_name');
+
+        });
+
+        Schema::table('order_address', function (Blueprint $table) {
+            $table->string('company_name')->nullable()->after('email');
+            $table->string('vat_id')->nullable()->after('company_name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('cart_address', function (Blueprint $table) {
+            $table->dropColumn('company_name');
+            $table->dropColumn('vat_id');
+        });
+
+        Schema::table('order_address', function (Blueprint $table) {
+            $table->dropColumn('company_name');
+            $table->dropColumn('vat_id');
+        });
+    }
+}

--- a/packages/Webkul/Sales/src/Models/OrderAddress.php
+++ b/packages/Webkul/Sales/src/Models/OrderAddress.php
@@ -11,6 +11,24 @@ class OrderAddress extends Model implements OrderAddressContract
 
     protected $guarded = ['id', 'created_at', 'updated_at'];
 
+    protected $fillable = [
+        'first_name',
+        'last_name',
+        'email',
+        'company_name',
+        'vat_id',
+        'address1',
+        'address2',
+        'city',
+        'state',
+        'postcode',
+        'country',
+        'phone',
+        'address_type',
+        'cart_id',
+        'customer_id',
+    ];
+
     /**
      * Get of the customer fullname.
      */


### PR DESCRIPTION
Currently, when doing the checkout in a b2b shop (business to business) the information about the company_name and vat_id of the buyer gets lost during the checkout process. We need to propagate the company_name and vat_id from address through cart to order addresses. I just forgot this in the initial feature request i made a month ago. This PR fixes this.
