### PR TITLE
Replace diacritics

### DIFF
--- a/packages/Webkul/Ui/src/Resources/assets/js/directives/slugify-target.vue
+++ b/packages/Webkul/Ui/src/Resources/assets/js/directives/slugify-target.vue
@@ -7,8 +7,10 @@
 
                     target.value = e.target.value.toString()
                         .toLowerCase()
+                        
+                        .normalize('NFKD') // Normalize Unicode
                         .replace(/[^\w- ]+/g, '')
-
+                              
                         // replace whitespaces with dashes
                         .replace(/ +/g, '-')
 


### PR DESCRIPTION
Replace diacritics (ó, ł, ź, ă,ş,ţ etc) with their "normal" form (o, l, z, a,s,t)

**BUGS:**

Slugify-target directives actually remove diacritics in my language, added normalize causes replace this letters for friendly RFC 1738 letters.
