### PR TITLE
bugfix: show multiple flash messages in admin panel

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/layouts/master.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/layouts/master.blade.php
@@ -55,15 +55,11 @@
         <script type="text/javascript">
             window.flashMessages = [];
 
-            @if ($success = session('success'))
-                window.flashMessages = [{'type': 'alert-success', 'message': "{{ $success }}" }];
-            @elseif ($warning = session('warning'))
-                window.flashMessages = [{'type': 'alert-warning', 'message': "{{ $warning }}" }];
-            @elseif ($error = session('error'))
-                window.flashMessages = [{'type': 'alert-error', 'message': "{{ $error }}" }];
-            @elseif ($info = session('info'))
-                window.flashMessages = [{'type': 'alert-info', 'message': "{{ $info }}" }];
-            @endif
+            @foreach (['success', 'warning', 'error', 'info'] as $key)
+                @if ($value = session($key))
+                    window.flashMessages.push({'type': 'alert-{{ $key }}', 'message': "{{ $value }}" });
+                @endif
+            @endforeach
 
             window.serverErrors = [];
             @if (isset($errors))

--- a/packages/Webkul/Tax/src/Providers/TaxServiceProvider.php
+++ b/packages/Webkul/Tax/src/Providers/TaxServiceProvider.php
@@ -22,6 +22,6 @@ class TaxServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        // $this->loadFactoriesFrom(__DIR__ . '/../Database/Factories');
+        $this->loadFactoriesFrom(__DIR__ . '/../Database/Factories');
     }
 }


### PR DESCRIPTION
This PR aims the possibility to flash more than one message in the admin panel. For now, only one message per request is shown, the last flashed message, to be clear.

Example scenario:
By using an event listener, it is possible to manipulate form data in the admin panel. For instance, to add a custom field to the channel's editing form and to store the data in a custom database table.

If for that custom data the validation fails, the listener may throw a flash message to inform the admin about. The rest of the process should not be touched or interrupted. That means, the original bagisto channel data should be processed and stored as usual. 
And after that, a success message might be thrown, that overwrites any other message thrown by the listener before.

With this small PR, it is possible to show more than one flash message per request.