### PR TITLE
prevent locale factory from flickering

### DIFF
--- a/packages/Webkul/Core/src/Database/Factories/LocaleFactory.php
+++ b/packages/Webkul/Core/src/Database/Factories/LocaleFactory.php
@@ -5,8 +5,16 @@ use Webkul\Core\Models\Locale;
 
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 $factory->define(Locale::class, function (Faker $faker, array $attributes) {
+
+    $languageCode = $faker->languageCode;
+
+    $locale = Locale::query()->firstWhere('code', $languageCode);
+    if ($locale !== null) {
+        return $locale->id;
+    }
+
     return [
-        'code'      => $faker->languageCode,
+        'code'      => $languageCode,
         'name'      => $faker->country,
         'direction' => 'ltr',
     ];


### PR DESCRIPTION
The LocaleFactory uses a random locale code to generate a new Locale. If some Locales have been seeded yet, the factory uses to flicker. For instance, there already is a locale for English, and the factory's random local code is "en", then an integrity constraint exception for duplicated locale code is thrown.

This PR lets the LocaleFactory return an existing Locale with the randomly generated locale code. If no Locale having that code exists yet, it creates a new one.