### PR TITLE
fix still flickering locale factory

### DIFF
--- a/packages/Webkul/Core/src/Database/Factories/LocaleFactory.php
+++ b/packages/Webkul/Core/src/Database/Factories/LocaleFactory.php
@@ -6,12 +6,9 @@ use Webkul\Core\Models\Locale;
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 $factory->define(Locale::class, function (Faker $faker, array $attributes) {
 
-    $languageCode = $faker->languageCode;
-
-    $locale = Locale::query()->firstWhere('code', $languageCode);
-    if ($locale !== null) {
-        return $locale->id;
-    }
+    do {
+        $languageCode = $faker->languageCode;
+    } while (Locale::query()->where('code', $languageCode)->exists());
 
     return [
         'code'      => $languageCode,


### PR DESCRIPTION
In PR #2753 I aimed to prevent the LocaleFactory from flickering. 

Unfortunately, that was not successful. That is why I offer this new PR to be sure, that factory will not flicker anymore at any time: Using a Do-While, the factory is forced to find a new locale code, which is not used yet.