### PR TITLE
Fix tax rate rounding

### DIFF
--- a/packages/Webkul/Tax/src/Helpers/Tax.php
+++ b/packages/Webkul/Tax/src/Helpers/Tax.php
@@ -7,7 +7,8 @@ class Tax
     /**
      * @var int
      */
-    private const TAX_PRECISION = 2;
+    private const TAX_RATE_PRECISION = 4;
+    private const TAX_AMOUNT_PRECISION = 2;
 
     /**
      * Returns an array with tax rates and tax amount
@@ -20,7 +21,7 @@ class Tax
         $taxes = [];
 
         foreach ($that->items as $item) {
-            $taxRate = (string) round((float) $item->tax_percent, self::TAX_PRECISION);
+            $taxRate = (string) round((float) $item->tax_percent, self::TAX_RATE_PRECISION);
 
             if (! array_key_exists($taxRate, $taxes)) {
                 $taxes[$taxRate] = 0;
@@ -29,9 +30,9 @@ class Tax
             $taxes[$taxRate] += $asBase ? $item->base_tax_amount : $item->tax_amount;
         }
 
-        // finaly round tax amounts now (to reduce rounding differences)
+        // finally round tax amounts now (to reduce rounding differences)
         foreach ($taxes as $taxRate => $taxAmount) {
-            $taxes[$taxRate] = round($taxAmount, self::TAX_PRECISION);
+            $taxes[$taxRate] = round($taxAmount, self::TAX_AMOUNT_PRECISION);
         }
 
         return $taxes;

--- a/packages/Webkul/Tax/src/Helpers/Tax.php
+++ b/packages/Webkul/Tax/src/Helpers/Tax.php
@@ -7,7 +7,7 @@ class Tax
     /**
      * @var int
      */
-    public const TAX_PRECISION = 4;
+    private const TAX_PRECISION = 2;
 
     /**
      * Returns an array with tax rates and tax amount
@@ -29,6 +29,11 @@ class Tax
             $taxes[$taxRate] += $asBase ? $item->base_tax_amount : $item->tax_amount;
         }
 
+        // finaly round tax amounts now (to reduce rounding differences)
+        foreach ($taxes as $taxRate => $taxAmount) {
+            $taxes[$taxRate] = round($taxAmount, self::TAX_PRECISION);
+        }
+
         return $taxes;
     }
 
@@ -45,7 +50,7 @@ class Tax
         $result = 0;
 
         foreach ($taxes as $taxRate => $taxAmount) {
-            $result += round($taxAmount, 2);
+            $result += $taxAmount;
         }
 
         return $result;

--- a/tests/unit/Tax/Helpers/TaxCest.php
+++ b/tests/unit/Tax/Helpers/TaxCest.php
@@ -73,10 +73,10 @@ class TaxCest
             'object'           => Cart::getCart(),
             'expectedTaxRates' => [
                 (string)round((float)$tax1->tax_rate, 4)
-                => round(11 * $product1->price * $tax1->tax_rate / 100, 4),
+                => round(11 * $product1->price * $tax1->tax_rate / 100, 2),
 
                 (string)round((float)$tax2->tax_rate, 4)
-                => round(7 * $product2->price * $tax2->tax_rate / 100, 4),
+                => round(7 * $product2->price * $tax2->tax_rate / 100, 2),
             ],
             'expectedTaxTotal' =>
                 round(

--- a/tests/unit/Tax/Helpers/TaxCest.php
+++ b/tests/unit/Tax/Helpers/TaxCest.php
@@ -72,10 +72,10 @@ class TaxCest
         $this->scenario = [
             'object'           => Cart::getCart(),
             'expectedTaxRates' => [
-                (string)round((float)$tax1->tax_rate, \Webkul\Tax\Helpers\Tax::TAX_PRECISION)
+                (string)round((float)$tax1->tax_rate, 4)
                 => round(11 * $product1->price * $tax1->tax_rate / 100, 4),
 
-                (string)round((float)$tax2->tax_rate, \Webkul\Tax\Helpers\Tax::TAX_PRECISION)
+                (string)round((float)$tax2->tax_rate, 4)
                 => round(7 * $product2->price * $tax2->tax_rate / 100, 4),
             ],
             'expectedTaxTotal' =>


### PR DESCRIPTION
**BUG**

We found a bug in how tax amounts are displayed.

Lets suppose we have a simple product.
It's price is 1.50€ and tax_rate is 19%.

What I see in cart is this:
```
Tax 19%       0.28€
Grand Total   1.79€
```

Calculation of grand_total is correct but, the displayed tax_amount is wrongly rounded.
This is fixed by moving rounding position.