### PR TITLE
Added new view_render_event events

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/sales/invoices/view.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/sales/invoices/view.blade.php
@@ -12,16 +12,24 @@
         <div class="page-header">
             <div class="page-title">
                 <h1>
+                    {!! view_render_event('sales.invoice.title.before', ['order' => $order]) !!}
+
                     <i class="icon angle-left-icon back-link" onclick="history.length > 1 ? history.go(-1) : window.location = '{{ url('/admin/dashboard') }}';"></i>
 
                     {{ __('admin::app.sales.invoices.view-title', ['invoice_id' => $invoice->id]) }}
+
+                    {!! view_render_event('sales.invoice.title.after', ['order' => $order]) !!}
                 </h1>
             </div>
 
             <div class="page-action">
+                {!! view_render_event('sales.invoice.page_action.before', ['order' => $order]) !!}
+
                 <a href="{{ route('admin.sales.invoices.print', $invoice->id) }}" class="btn btn-lg btn-primary">
                     {{ __('admin::app.sales.invoices.print') }}
                 </a>
+
+                {!! view_render_event('sales.invoice.page_action.after', ['order' => $order]) !!}
             </div>
         </div>
 
@@ -47,6 +55,8 @@
                                     </span>
                                 </div>
 
+                                {!! view_render_event('sales.invoice.increment_id.after', ['order' => $order]) !!}
+
                                 <div class="row">
                                     <span class="title">
                                         {{ __('admin::app.sales.orders.order-date') }}
@@ -56,6 +66,8 @@
                                         {{ $order->created_at }}
                                     </span>
                                 </div>
+
+                                {!! view_render_event('sales.invoice.created_at.after', ['order' => $order]) !!}
 
                                 <div class="row">
                                     <span class="title">
@@ -67,6 +79,8 @@
                                     </span>
                                 </div>
 
+                                {!! view_render_event('sales.invoice.status_label.after', ['order' => $order]) !!}
+
                                 <div class="row">
                                     <span class="title">
                                         {{ __('admin::app.sales.orders.channel') }}
@@ -76,6 +90,8 @@
                                         {{ $order->channel_name }}
                                     </span>
                                 </div>
+
+                                {!! view_render_event('sales.invoice.channel_name.after', ['order' => $order]) !!}
                             </div>
                         </div>
 
@@ -95,6 +111,8 @@
                                     </span>
                                 </div>
 
+                                {!! view_render_event('sales.invoice.customer_name.after', ['order' => $order]) !!}
+
                                 <div class="row">
                                     <span class="title">
                                         {{ __('admin::app.sales.orders.email') }}
@@ -104,6 +122,8 @@
                                         {{ $invoice->address->email }}
                                     </span>
                                 </div>
+
+                                {!! view_render_event('sales.invoice.customer_email.after', ['order' => $order]) !!}
                             </div>
                         </div>
 
@@ -119,9 +139,9 @@
                             </div>
 
                             <div class="section-content">
-
                                 @include ('admin::sales.address', ['address' => $order->billing_address])
 
+                                {!! view_render_event('sales.invoice.billing_address.after', ['order' => $order]) !!}
                             </div>
                         </div>
 
@@ -132,9 +152,9 @@
                                 </div>
 
                                 <div class="section-content">
-
                                     @include ('admin::sales.address', ['address' => $order->shipping_address])
 
+                                    {!! view_render_event('sales.invoice.shipping_address.after', ['order' => $order]) !!}
                                 </div>
                             </div>
                         @endif
@@ -170,6 +190,8 @@
                                         {{ $order->order_currency_code }}
                                     </span>
                                 </div>
+
+                                {!! view_render_event('sales.invoice.payment-method.after', ['order' => $order]) !!}
                             </div>
                         </div>
 
@@ -199,6 +221,8 @@
                                             {{ core()->formatBasePrice($order->base_shipping_amount) }}
                                         </span>
                                     </div>
+
+                                    {!! view_render_event('sales.invoice.shipping-method.after', ['order' => $order]) !!}
                                 </div>
                             </div>
                         @endif
@@ -236,7 +260,7 @@
 
                                                 @if (isset($item->additional['attributes']))
                                                     <div class="item-options">
-                                                        
+
                                                         @foreach ($item->additional['attributes'] as $attribute)
                                                             <b>{{ $attribute['attribute_name'] }} : </b>{{ $attribute['option_label'] }}</br>
                                                         @endforeach

--- a/packages/Webkul/Admin/src/Resources/views/sales/orders/view.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/sales/orders/view.blade.php
@@ -146,9 +146,9 @@
                                     </div>
 
                                     <div class="section-content">
-
                                         @include ('admin::sales.address', ['address' => $order->billing_address])
 
+                                        {!! view_render_event('sales.order.billing-address.after', ['order' => $order]) !!}
                                     </div>
                                 </div>
 
@@ -159,9 +159,9 @@
                                         </div>
 
                                         <div class="section-content">
-
                                             @include ('admin::sales.address', ['address' => $order->shipping_address])
 
+                                            {!! view_render_event('sales.order.shipping-address.after', ['order' => $order]) !!}
                                         </div>
                                     </div>
                                 @endif
@@ -197,6 +197,8 @@
                                                 {{ $order->order_currency_code }}
                                             </span>
                                         </div>
+
+                                        {!! view_render_event('sales.order.payment-method.after', ['order' => $order]) !!}
                                     </div>
                                 </div>
 
@@ -226,6 +228,8 @@
                                                     {{ core()->formatBasePrice($order->base_shipping_amount) }}
                                                 </span>
                                             </div>
+
+                                            {!! view_render_event('sales.order.shipping-method.after', ['order' => $order]) !!}
                                         </div>
                                     </div>
                                 @endif

--- a/packages/Webkul/Admin/src/Resources/views/sales/orders/view.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/sales/orders/view.blade.php
@@ -12,13 +12,19 @@
 
             <div class="page-title">
                 <h1>
+                    {!! view_render_event('sales.order.title.before', ['order' => $order]) !!}
+
                     <i class="icon angle-left-icon back-link" onclick="history.length > 1 ? history.go(-1) : window.location = '{{ url('/admin/dashboard') }}';"></i>
 
                     {{ __('admin::app.sales.orders.view-title', ['order_id' => $order->increment_id]) }}
+
+                    {!! view_render_event('sales.order.title.after', ['order' => $order]) !!}
                 </h1>
             </div>
 
             <div class="page-action">
+                {!! view_render_event('sales.order.page_action.before', ['order' => $order]) !!}
+
                 @if ($order->canCancel())
                     <a href="{{ route('admin.sales.orders.cancel', $order->id) }}" class="btn btn-lg btn-primary" v-alert:message="'{{ __('admin::app.sales.orders.cancel-confirm-msg') }}'">
                         {{ __('admin::app.sales.orders.cancel-btn-title') }}
@@ -42,6 +48,8 @@
                         {{ __('admin::app.sales.orders.shipment-btn-title') }}
                     </a>
                 @endif
+
+                {!! view_render_event('sales.order.page_action.after', ['order' => $order]) !!}
             </div>
         </div>
 
@@ -72,6 +80,8 @@
                                             </span>
                                         </div>
 
+                                        {!! view_render_event('sales.order.created_at.after', ['order' => $order]) !!}
+
                                         <div class="row">
                                             <span class="title">
                                                 {{ __('admin::app.sales.orders.order-status') }}
@@ -82,6 +92,8 @@
                                             </span>
                                         </div>
 
+                                        {!! view_render_event('sales.order.status_label.after', ['order' => $order]) !!}
+
                                         <div class="row">
                                             <span class="title">
                                                 {{ __('admin::app.sales.orders.channel') }}
@@ -91,6 +103,8 @@
                                                 {{ $order->channel_name }}
                                             </span>
                                         </div>
+
+                                        {!! view_render_event('sales.order.channel_name.after', ['order' => $order]) !!}
                                     </div>
                                 </div>
 
@@ -110,6 +124,8 @@
                                             </span>
                                         </div>
 
+                                        {!! view_render_event('sales.order.customer_full_name.after', ['order' => $order]) !!}
+
                                         <div class="row">
                                             <span class="title">
                                                 {{ __('admin::app.sales.orders.email') }}
@@ -119,6 +135,8 @@
                                                 {{ $order->customer_email }}
                                             </span>
                                         </div>
+
+                                        {!! view_render_event('sales.order.customer_email.after', ['order' => $order]) !!}
 
                                         @if (! is_null($order->customer))
                                             <div class="row">
@@ -131,6 +149,8 @@
                                                 </span>
                                             </div>
                                         @endif
+
+                                        {!! view_render_event('sales.order.customer_group.after', ['order' => $order]) !!}
                                     </div>
                                 </div>
 
@@ -148,7 +168,7 @@
                                     <div class="section-content">
                                         @include ('admin::sales.address', ['address' => $order->billing_address])
 
-                                        {!! view_render_event('sales.order.billing-address.after', ['order' => $order]) !!}
+                                        {!! view_render_event('sales.order.billing_address.after', ['order' => $order]) !!}
                                     </div>
                                 </div>
 
@@ -161,7 +181,7 @@
                                         <div class="section-content">
                                             @include ('admin::sales.address', ['address' => $order->shipping_address])
 
-                                            {!! view_render_event('sales.order.shipping-address.after', ['order' => $order]) !!}
+                                            {!! view_render_event('sales.order.shipping_address.after', ['order' => $order]) !!}
                                         </div>
                                     </div>
                                 @endif

--- a/packages/Webkul/Shop/src/Resources/views/customers/account/address/create.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/customers/account/address/create.blade.php
@@ -32,17 +32,23 @@
                         <span class="control-error" v-if="errors.has('company_name')">@{{ errors.first('company_name') }}</span>
                     </div>
 
+                    {!! view_render_event('bagisto.shop.customers.account.address.create_form_controls.company_name.after') !!}
+
                     <div class="control-group" :class="[errors.has('first_name') ? 'has-error' : '']">
                         <label for="first_name" class="required">{{ __('shop::app.customer.account.address.create.first_name') }}</label>
                         <input value="{{ old('first_name') }}" type="text" class="control" name="first_name" v-validate="'required'" data-vv-as="&quot;{{ __('shop::app.customer.account.address.create.first_name') }}&quot;">
                         <span class="control-error" v-if="errors.has('first_name')">@{{ errors.first('first_name') }}</span>
                     </div>
 
+                    {!! view_render_event('bagisto.shop.customers.account.address.create_form_controls.first_name.after') !!}
+
                     <div class="control-group" :class="[errors.has('last_name') ? 'has-error' : '']">
                         <label for="last_name" class="required">{{ __('shop::app.customer.account.address.create.last_name') }}</label>
                         <input value="{{ old('last_name') }}" type="text" class="control" name="last_name" v-validate="'required'" data-vv-as="&quot;{{ __('shop::app.customer.account.address.create.last_name') }}&quot;">
                         <span class="control-error" v-if="errors.has('last_name')">@{{ errors.first('last_name') }}</span>
                     </div>
+
+                    {!! view_render_event('bagisto.shop.customers.account.address.create_form_controls.last_name.after') !!}
 
                     <div class="control-group" :class="[errors.has('vat_id') ? 'has-error' : '']">
                         <label for="vat_id">{{ __('shop::app.customer.account.address.create.vat_id') }}
@@ -52,6 +58,8 @@
                         v-validate="''" data-vv-as="&quot;{{ __('shop::app.customer.account.address.create.vat_id') }}&quot;">
                         <span class="control-error" v-if="errors.has('vat_id')">@{{ errors.first('vat_id') }}</span>
                     </div>
+
+                    {!! view_render_event('bagisto.shop.customers.account.address.create_form_controls.vat_id.after') !!}
 
                     <div class="control-group" :class="[errors.has('address1[]') ? 'has-error' : '']">
                         <label for="address1" class="required">{{ __('shop::app.customer.account.address.create.street-address') }}</label>
@@ -67,7 +75,11 @@
                         </div>
                     @endif
 
+                    {!! view_render_event('bagisto.shop.customers.account.address.create_form_controls.street-address.after') !!}
+
                     @include ('shop::customers.account.address.country-state', ['countryCode' => old('country'), 'stateCode' => old('state')])
+
+                    {!! view_render_event('bagisto.shop.customers.account.address.create_form_controls.country-state.after') !!}
 
                     <div class="control-group" :class="[errors.has('city') ? 'has-error' : '']">
                         <label for="city" class="required">{{ __('shop::app.customer.account.address.create.city') }}</label>
@@ -75,11 +87,15 @@
                         <span class="control-error" v-if="errors.has('city')">@{{ errors.first('city') }}</span>
                     </div>
 
+                    {!! view_render_event('bagisto.shop.customers.account.address.create_form_controls.city.after') !!}
+
                     <div class="control-group" :class="[errors.has('postcode') ? 'has-error' : '']">
                         <label for="postcode" class="required">{{ __('shop::app.customer.account.address.create.postcode') }}</label>
                         <input value="{{ old('postcode') }}" type="text" class="control" name="postcode" v-validate="'required'" data-vv-as="&quot;{{ __('shop::app.customer.account.address.create.postcode') }}&quot;">
                         <span class="control-error" v-if="errors.has('postcode')">@{{ errors.first('postcode') }}</span>
                     </div>
+
+                    {!! view_render_event('bagisto.shop.customers.account.address.create_form_controls.postcode.after') !!}
 
                     <div class="control-group" :class="[errors.has('phone') ? 'has-error' : '']">
                         <label for="phone" class="required">{{ __('shop::app.customer.account.address.create.phone') }}</label>

--- a/packages/Webkul/Shop/src/Resources/views/customers/account/address/edit.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/customers/account/address/edit.blade.php
@@ -33,17 +33,23 @@
                         <span class="control-error" v-if="errors.has('company_name')">@{{ errors.first('company_name') }}</span>
                     </div>
 
+                    {!! view_render_event('bagisto.shop.customers.account.address.edit_form_controls.company_name.after') !!}
+
                     <div class="control-group" :class="[errors.has('first_name') ? 'has-error' : '']">
                         <label for="first_name" class="required">{{ __('shop::app.customer.account.address.create.first_name') }}</label>
                         <input type="text" class="control" name="first_name" v-validate="'required'" value="{{ old('first_name') ?: $address->first_name }}" data-vv-as="&quot;{{ __('shop::app.customer.account.address.create.first_name') }}&quot;">
                         <span class="control-error" v-if="errors.has('first_name')">@{{ errors.first('first_name') }}</span>
                     </div>
 
+                    {!! view_render_event('bagisto.shop.customers.account.address.edit_form_controls.first_name.after') !!}
+
                     <div class="control-group" :class="[errors.has('last_name') ? 'has-error' : '']">
                         <label for="last_name" class="required">{{ __('shop::app.customer.account.address.create.last_name') }}</label>
                         <input type="text" class="control" name="last_name" v-validate="'required'" value="{{ old('last_name') ?: $address->last_name }}" data-vv-as="&quot;{{ __('shop::app.customer.account.address.create.last_name') }}&quot;">
                         <span class="control-error" v-if="errors.has('last_name')">@{{ errors.first('last_name') }}</span>
                     </div>
+
+                    {!! view_render_event('bagisto.shop.customers.account.address.edit_form_controls.last_name.after') !!}
 
                     <div class="control-group" :class="[errors.has('vat_id') ? 'has-error' : '']">
                         <label for="vat_id">{{ __('shop::app.customer.account.address.create.vat_id') }}
@@ -53,6 +59,8 @@
                         v-validate="''" data-vv-as="&quot;{{ __('shop::app.customer.account.address.create.vat_id') }}&quot;">
                         <span class="control-error" v-if="errors.has('vat_id')">@{{ errors.first('vat_id') }}</span>
                     </div>
+
+                    {!! view_render_event('bagisto.shop.customers.account.address.edit_form_controls.vat_id.after') !!}
 
                     <?php $addresses = explode(PHP_EOL, $address->address1); ?>
 
@@ -70,7 +78,11 @@
                         </div>
                     @endif
 
+                    {!! view_render_event('bagisto.shop.customers.account.address.edit_form_controls.street-addres.after') !!}
+
                     @include ('shop::customers.account.address.country-state', ['countryCode' => old('country') ?? $address->country, 'stateCode' => old('state') ?? $address->state])
+
+                    {!! view_render_event('bagisto.shop.customers.account.address.edit_form_controls.country-state.after') !!}
 
                     <div class="control-group" :class="[errors.has('city') ? 'has-error' : '']">
                         <label for="city" class="required">{{ __('shop::app.customer.account.address.create.city') }}</label>
@@ -78,11 +90,15 @@
                         <span class="control-error" v-if="errors.has('city')">@{{ errors.first('city') }}</span>
                     </div>
 
+                    {!! view_render_event('bagisto.shop.customers.account.address.edit_form_controls.create.after') !!}
+
                     <div class="control-group" :class="[errors.has('postcode') ? 'has-error' : '']">
                         <label for="postcode" class="required">{{ __('shop::app.customer.account.address.create.postcode') }}</label>
                         <input type="text" class="control" name="postcode" v-validate="'required'" value="{{ old('postcode') ?: $address->postcode }}" data-vv-as="&quot;{{ __('shop::app.customer.account.address.create.postcode') }}&quot;">
                         <span class="control-error" v-if="errors.has('postcode')">@{{ errors.first('postcode') }}</span>
                     </div>
+
+                    {!! view_render_event('bagisto.shop.customers.account.address.edit_form_controls.postcode.after') !!}
 
                     <div class="control-group" :class="[errors.has('phone') ? 'has-error' : '']">
                         <label for="phone" class="required">{{ __('shop::app.customer.account.address.create.phone') }}</label>

--- a/packages/Webkul/Shop/src/Resources/views/customers/account/orders/view.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/customers/account/orders/view.blade.php
@@ -463,9 +463,9 @@
                                 </div>
 
                                 <div class="box-content">
-
                                     @include ('admin::sales.address', ['address' => $order->billing_address])
 
+                                    {!! view_render_event('bagisto.shop.customers.account.orders.view.billing-address.after', ['order' => $order]) !!}
                                 </div>
                             </div>
 
@@ -476,9 +476,9 @@
                                     </div>
 
                                     <div class="box-content">
-
                                         @include ('admin::sales.address', ['address' => $order->shipping_address])
 
+                                        {!! view_render_event('bagisto.shop.customers.account.orders.view.shipping-address.after', ['order' => $order]) !!}
                                     </div>
                                 </div>
 
@@ -488,9 +488,9 @@
                                     </div>
 
                                     <div class="box-content">
-
                                         {{ $order->shipping_title }}
 
+                                        {!! view_render_event('bagisto.shop.customers.account.orders.view.shipping-method.after', ['order' => $order]) !!}
                                     </div>
                                 </div>
                             @endif
@@ -502,6 +502,8 @@
 
                                 <div class="box-content">
                                     {{ core()->getConfigData('sales.paymentmethods.' . $order->payment->method . '.title') }}
+
+                                    {!! view_render_event('bagisto.shop.customers.account.orders.view.payment-method.after', ['order' => $order]) !!}
                                 </div>
                             </div>
                         </div>

--- a/packages/Webkul/Shop/src/Resources/views/customers/account/profile/edit.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/customers/account/profile/edit.blade.php
@@ -35,12 +35,16 @@
                         <span class="control-error" v-if="errors.has('first_name')">@{{ errors.first('first_name') }}</span>
                     </div>
 
+                    {!! view_render_event('bagisto.shop.customers.account.profile.edit.first_name.after') !!}
+
                     <div class="control-group" :class="[errors.has('last_name') ? 'has-error' : '']">
                         <label for="last_name" class="required">{{ __('shop::app.customer.account.profile.lname') }}</label>
 
                         <input type="text" class="control" name="last_name" value="{{ old('last_name') ?? $customer->last_name }}" v-validate="'required'" data-vv-as="&quot;{{ __('shop::app.customer.account.profile.lname') }}&quot;">
                         <span class="control-error" v-if="errors.has('last_name')">@{{ errors.first('last_name') }}</span>
                     </div>
+
+                    {!! view_render_event('bagisto.shop.customers.account.profile.edit.last_name.after') !!}
 
                     <div class="control-group" :class="[errors.has('gender') ? 'has-error' : '']">
                         <label for="email" class="required">{{ __('shop::app.customer.account.profile.gender') }}</label>
@@ -54,11 +58,15 @@
                         <span class="control-error" v-if="errors.has('gender')">@{{ errors.first('gender') }}</span>
                     </div>
 
+                    {!! view_render_event('bagisto.shop.customers.account.profile.edit.gender.after') !!}
+
                     <div class="control-group"  :class="[errors.has('date_of_birth') ? 'has-error' : '']">
                         <label for="date_of_birth">{{ __('shop::app.customer.account.profile.dob') }}</label>
                         <input type="date" class="control" name="date_of_birth" value="{{ old('date_of_birth') ?? $customer->date_of_birth }}" v-validate="" data-vv-as="&quot;{{ __('shop::app.customer.account.profile.dob') }}&quot;">
                         <span class="control-error" v-if="errors.has('date_of_birth')">@{{ errors.first('date_of_birth') }}</span>
                     </div>
+
+                    {!! view_render_event('bagisto.shop.customers.account.profile.edit.date_of_birth.after') !!}
 
                     <div class="control-group" :class="[errors.has('email') ? 'has-error' : '']">
                         <label for="email" class="required">{{ __('shop::app.customer.account.profile.email') }}</label>
@@ -66,11 +74,15 @@
                         <span class="control-error" v-if="errors.has('email')">@{{ errors.first('email') }}</span>
                     </div>
 
+                    {!! view_render_event('bagisto.shop.customers.account.profile.edit.email.after') !!}
+
                     <div class="control-group" :class="[errors.has('oldpassword') ? 'has-error' : '']">
                         <label for="password">{{ __('shop::app.customer.account.profile.opassword') }}</label>
                         <input type="password" class="control" name="oldpassword" data-vv-as="&quot;{{ __('shop::app.customer.account.profile.opassword') }}&quot;" v-validate="'min:6'">
                         <span class="control-error" v-if="errors.has('oldpassword')">@{{ errors.first('oldpassword') }}</span>
                     </div>
+
+                    {!! view_render_event('bagisto.shop.customers.account.profile.edit.oldpassword.after') !!}
 
                     <div class="control-group" :class="[errors.has('password') ? 'has-error' : '']">
                         <label for="password">{{ __('shop::app.customer.account.profile.password') }}</label>
@@ -78,6 +90,8 @@
                         <input type="password" id="password" class="control" name="password" data-vv-as="&quot;{{ __('shop::app.customer.account.profile.password') }}&quot;" v-validate="'min:6'">
                         <span class="control-error" v-if="errors.has('password')">@{{ errors.first('password') }}</span>
                     </div>
+
+                    {!! view_render_event('bagisto.shop.customers.account.profile.edit.password.after') !!}
 
                     <div class="control-group" :class="[errors.has('password_confirmation') ? 'has-error' : '']">
                         <label for="password">{{ __('shop::app.customer.account.profile.cpassword') }}</label>

--- a/packages/Webkul/Shop/src/Resources/views/customers/account/profile/index.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/customers/account/profile/index.blade.php
@@ -38,20 +38,28 @@
                         <td>{{ $customer->first_name }}</td>
                     </tr>
 
+                    {!! view_render_event('bagisto.shop.customers.account.profile.view.table.first_name.after') !!}
+
                     <tr>
                         <td>{{ __('shop::app.customer.account.profile.lname') }}</td>
                         <td>{{ $customer->last_name }}</td>
                     </tr>
+
+                    {!! view_render_event('bagisto.shop.customers.account.profile.view.table.last_name.after') !!}
 
                     <tr>
                         <td>{{ __('shop::app.customer.account.profile.gender') }}</td>
                         <td>{{ $customer->gender }}</td>
                     </tr>
 
+                    {!! view_render_event('bagisto.shop.customers.account.profile.view.table.gender.after') !!}
+
                     <tr>
                         <td>{{ __('shop::app.customer.account.profile.dob') }}</td>
                         <td>{{ $customer->date_of_birth }}</td>
                     </tr>
+
+                    {!! view_render_event('bagisto.shop.customers.account.profile.view.table.date_of_birth.after') !!}
 
                     <tr>
                         <td>{{ __('shop::app.customer.account.profile.email') }}</td>

--- a/packages/Webkul/Shop/src/Resources/views/customers/signup/index.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/customers/signup/index.blade.php
@@ -27,11 +27,15 @@
                 <span class="control-error" v-if="errors.has('first_name')">@{{ errors.first('first_name') }}</span>
             </div>
 
+            {!! view_render_event('bagisto.shop.customers.signup_form_controls.firstname.after') !!}
+
             <div class="control-group" :class="[errors.has('last_name') ? 'has-error' : '']">
                 <label for="last_name" class="required">{{ __('shop::app.customer.signup-form.lastname') }}</label>
                 <input type="text" class="control" name="last_name" v-validate="'required'" value="{{ old('last_name') }}" data-vv-as="&quot;{{ __('shop::app.customer.signup-form.lastname') }}&quot;">
                 <span class="control-error" v-if="errors.has('last_name')">@{{ errors.first('last_name') }}</span>
             </div>
+
+            {!! view_render_event('bagisto.shop.customers.signup_form_controls.lastname.after') !!}
 
             <div class="control-group" :class="[errors.has('email') ? 'has-error' : '']">
                 <label for="email" class="required">{{ __('shop::app.customer.signup-form.email') }}</label>
@@ -39,11 +43,15 @@
                 <span class="control-error" v-if="errors.has('email')">@{{ errors.first('email') }}</span>
             </div>
 
+            {!! view_render_event('bagisto.shop.customers.signup_form_controls.email.after') !!}
+
             <div class="control-group" :class="[errors.has('password') ? 'has-error' : '']">
                 <label for="password" class="required">{{ __('shop::app.customer.signup-form.password') }}</label>
                 <input type="password" class="control" name="password" v-validate="'required|min:6'" ref="password" value="{{ old('password') }}" data-vv-as="&quot;{{ __('shop::app.customer.signup-form.password') }}&quot;">
                 <span class="control-error" v-if="errors.has('password')">@{{ errors.first('password') }}</span>
             </div>
+
+            {!! view_render_event('bagisto.shop.customers.signup_form_controls.password.after') !!}
 
             <div class="control-group" :class="[errors.has('password_confirmation') ? 'has-error' : '']">
                 <label for="password_confirmation" class="required">{{ __('shop::app.customer.signup-form.confirm_pass') }}</label>

--- a/packages/Webkul/Velocity/src/Resources/views/shop/customers/account/address/create.blade.php
+++ b/packages/Webkul/Velocity/src/Resources/views/shop/customers/account/address/create.blade.php
@@ -26,17 +26,23 @@
                     <span class="control-error" v-if="errors.has('company_name')">@{{ errors.first('company_name') }}</span>
                 </div>
 
+                {!! view_render_event('bagisto.shop.customers.account.address.create_form_controls.company_name.after') !!}
+
                 <div class="control-group" :class="[errors.has('first_name') ? 'has-error' : '']">
                     <label for="first_name" class="mandatory">{{ __('shop::app.customer.account.address.create.first_name') }}</label>
                     <input type="text" class="control" name="first_name" value="{{ old('first_name') }}" v-validate="'required'" data-vv-as="&quot;{{ __('shop::app.customer.account.address.create.first_name') }}&quot;">
                     <span class="control-error" v-if="errors.has('first_name')">@{{ errors.first('first_name') }}</span>
                 </div>
 
+                {!! view_render_event('bagisto.shop.customers.account.address.create_form_controls.first_name.after') !!}
+
                 <div class="control-group" :class="[errors.has('last_name') ? 'has-error' : '']">
                     <label for="last_name" class="mandatory">{{ __('shop::app.customer.account.address.create.last_name') }}</label>
                     <input type="text" class="control" name="last_name" value="{{ old('last_name') }}" v-validate="'required'" data-vv-as="&quot;{{ __('shop::app.customer.account.address.create.last_name') }}&quot;">
                     <span class="control-error" v-if="errors.has('last_name')">@{{ errors.first('last_name') }}</span>
                 </div>
+
+                {!! view_render_event('bagisto.shop.customers.account.address.create_form_controls.last_name.after') !!}
 
                 <div class="control-group" :class="[errors.has('vat_id') ? 'has-error' : '']">
                     <label for="vat_id">{{ __('shop::app.customer.account.address.create.vat_id') }}
@@ -45,6 +51,8 @@
                     <input type="text" class="control" name="vat_id" value="{{ old('vat_id') }}" v-validate="" data-vv-as="&quot;{{ __('shop::app.customer.account.address.create.vat_id') }}&quot;">
                     <span class="control-error" v-if="errors.has('vat_id')">@{{ errors.first('vat_id') }}</span>
                 </div>
+
+                {!! view_render_event('bagisto.shop.customers.account.address.create_form_controls.vat_id.after') !!}
 
                 @php
                     $addresses = explode(PHP_EOL, (old('address1') ?? ''));
@@ -64,7 +72,11 @@
                     @endfor
                 @endif
 
+                {!! view_render_event('bagisto.shop.customers.account.address.create_form_controls.street-address.after') !!}
+
                 @include ('shop::customers.account.address.country-state', ['countryCode' => old('country'), 'stateCode' => old('state')])
+
+                {!! view_render_event('bagisto.shop.customers.account.address.create_form_controls.country-state.after') !!}
 
                 <div class="control-group" :class="[errors.has('city') ? 'has-error' : '']">
                     <label for="city" class="mandatory">{{ __('shop::app.customer.account.address.create.city') }}</label>
@@ -72,11 +84,15 @@
                     <span class="control-error" v-if="errors.has('city')">@{{ errors.first('city') }}</span>
                 </div>
 
+                {!! view_render_event('bagisto.shop.customers.account.address.create_form_controls.city.after') !!}
+
                 <div class="control-group" :class="[errors.has('postcode') ? 'has-error' : '']">
                     <label for="postcode" class="mandatory">{{ __('shop::app.customer.account.address.create.postcode') }}</label>
                     <input type="text" class="control" name="postcode" value="{{ old('postcode') }}" v-validate="'required'" data-vv-as="&quot;{{ __('shop::app.customer.account.address.create.postcode') }}&quot;">
                     <span class="control-error" v-if="errors.has('postcode')">@{{ errors.first('postcode') }}</span>
                 </div>
+
+                {!! view_render_event('bagisto.shop.customers.account.address.create_form_controls.postcode.after') !!}
 
                 <div class="control-group" :class="[errors.has('phone') ? 'has-error' : '']">
                     <label for="phone" class="mandatory">{{ __('shop::app.customer.account.address.create.phone') }}</label>

--- a/packages/Webkul/Velocity/src/Resources/views/shop/customers/account/address/edit.blade.php
+++ b/packages/Webkul/Velocity/src/Resources/views/shop/customers/account/address/edit.blade.php
@@ -21,7 +21,6 @@
 
             {!! view_render_event('bagisto.shop.customers.account.address.edit_form_controls.before', ['address' => $address]) !!}
 
-
             <?php $addresses = explode(PHP_EOL, (old('address1') ?? $address->address1)); ?>
 
             <div class="control-group" :class="[errors.has('company_name') ? 'has-error' : '']">
@@ -30,17 +29,23 @@
                 <span class="control-error" v-if="errors.has('company_name')">@{{ errors.first('company_name') }}</span>
             </div>
 
+            {!! view_render_event('bagisto.shop.customers.account.address.edit_form_controls.company_name.after') !!}
+
             <div class="control-group" :class="[errors.has('first_name') ? 'has-error' : '']">
                 <label for="first_name" class="mandatory">{{ __('shop::app.customer.account.address.create.first_name') }}</label>
                 <input type="text" class="control" name="first_name" value="{{ old('first_name') ?? $address->first_name }}" v-validate="'required'" data-vv-as="&quot;{{ __('shop::app.customer.account.address.create.first_name') }}&quot;">
                 <span class="control-error" v-if="errors.has('first_name')">@{{ errors.first('first_name') }}</span>
             </div>
 
+            {!! view_render_event('bagisto.shop.customers.account.address.edit_form_controls.first_name.after') !!}
+
             <div class="control-group" :class="[errors.has('last_name') ? 'has-error' : '']">
                 <label for="last_name" class="mandatory">{{ __('shop::app.customer.account.address.create.last_name') }}</label>
                 <input type="text" class="control" name="last_name" value="{{ old('last_name') ?? $address->last_name }}" v-validate="'required'" data-vv-as="&quot;{{ __('shop::app.customer.account.address.create.last_name') }}&quot;">
                 <span class="control-error" v-if="errors.has('last_name')">@{{ errors.first('last_name') }}</span>
             </div>
+
+            {!! view_render_event('bagisto.shop.customers.account.address.edit_form_controls.last_name.after') !!}
 
             <div class="control-group" :class="[errors.has('vat_id') ? 'has-error' : '']">
                 <label for="vat_id">{{ __('shop::app.customer.account.address.create.vat_id') }}
@@ -49,6 +54,8 @@
                 <input type="text" class="control" name="vat_id" value="{{ old('vat_id') ?? $address->vat_id }}" v-validate="" data-vv-as="&quot;{{ __('shop::app.customer.account.address.create.vat_id') }}&quot;">
                 <span class="control-error" v-if="errors.has('vat_id')">@{{ errors.first('vat_id') }}</span>
             </div>
+
+            {!! view_render_event('bagisto.shop.customers.account.address.edit_form_controls.vat_id.after') !!}
 
             <div class="control-group" :class="[errors.has('address1[]') ? 'has-error' : '']">
                 <label for="address_0" class="mandatory">{{ __('shop::app.customer.account.address.edit.street-address') }}</label>
@@ -64,7 +71,11 @@
                 @endfor
             @endif
 
+            {!! view_render_event('bagisto.shop.customers.account.address.edit_form_controls.street-addres.after') !!}
+
             @include ('shop::customers.account.address.country-state', ['countryCode' => old('country') ?? $address->country, 'stateCode' => old('state') ?? $address->state])
+
+            {!! view_render_event('bagisto.shop.customers.account.address.edit_form_controls.country-state.after') !!}
 
             <div class="control-group" :class="[errors.has('city') ? 'has-error' : '']">
                 <label for="city" class="mandatory">{{ __('shop::app.customer.account.address.create.city') }}</label>
@@ -72,11 +83,15 @@
                 <span class="control-error" v-if="errors.has('city')">@{{ errors.first('city') }}</span>
             </div>
 
+            {!! view_render_event('bagisto.shop.customers.account.address.edit_form_controls.create.after') !!}
+
             <div class="control-group" :class="[errors.has('postcode') ? 'has-error' : '']">
                 <label for="postcode" class="mandatory">{{ __('shop::app.customer.account.address.create.postcode') }}</label>
                 <input type="text" class="control" name="postcode" value="{{ old('postcode') ?? $address->postcode }}" v-validate="'required'" data-vv-as="&quot;{{ __('shop::app.customer.account.address.create.postcode') }}&quot;">
                 <span class="control-error" v-if="errors.has('postcode')">@{{ errors.first('postcode') }}</span>
             </div>
+
+            {!! view_render_event('bagisto.shop.customers.account.address.edit_form_controls.postcode.after') !!}
 
             <div class="control-group" :class="[errors.has('phone') ? 'has-error' : '']">
                 <label for="phone" class="mandatory">{{ __('shop::app.customer.account.address.create.phone') }}</label>

--- a/packages/Webkul/Velocity/src/Resources/views/shop/customers/account/orders/view.blade.php
+++ b/packages/Webkul/Velocity/src/Resources/views/shop/customers/account/orders/view.blade.php
@@ -489,9 +489,9 @@
                                 </div>
 
                                 <div class="box-content">
-
                                     @include ('admin::sales.address', ['address' => $order->billing_address])
 
+                                    {!! view_render_event('bagisto.shop.customers.account.orders.view.billing-address.after', ['order' => $order]) !!}
                                 </div>
                             </div>
 
@@ -502,9 +502,9 @@
                                     </div>
 
                                     <div class="box-content">
-
                                         @include ('admin::sales.address', ['address' => $order->shipping_address])
 
+                                        {!! view_render_event('bagisto.shop.customers.account.orders.view.shipping-address.after', ['order' => $order]) !!}
                                     </div>
                                 </div>
 
@@ -514,9 +514,9 @@
                                     </div>
 
                                     <div class="box-content">
-
                                         {{ $order->shipping_title }}
 
+                                        {!! view_render_event('bagisto.shop.customers.account.orders.view.shipping-method.after', ['order' => $order]) !!}
                                     </div>
                                 </div>
                             @endif
@@ -528,6 +528,8 @@
 
                                 <div class="box-content">
                                     {{ core()->getConfigData('sales.paymentmethods.' . $order->payment->method . '.title') }}
+
+                                    {!! view_render_event('bagisto.shop.customers.account.orders.view.payment-method.after', ['order' => $order]) !!}
                                 </div>
                             </div>
                         </div>

--- a/packages/Webkul/Velocity/src/Resources/views/shop/customers/account/profile/edit.blade.php
+++ b/packages/Webkul/Velocity/src/Resources/views/shop/customers/account/profile/edit.blade.php
@@ -15,7 +15,7 @@
         </h1>
     </div>
 
-    {!! view_render_event('bagisto.shop.customers.account.profile.view.before', ['customer' => $customer]) !!}
+    {!! view_render_event('bagisto.shop.customers.account.profile.edit.before', ['customer' => $customer]) !!}
 
         <div class="profile-update-form">
             <form
@@ -23,8 +23,9 @@
                 @submit.prevent="onSubmit"
                 class="account-table-content"
                 action="{{ route('customer.profile.edit') }}">
-
                 @csrf
+
+                {!! view_render_event('bagisto.shop.customers.account.profile.edit.before', ['customer' => $customer]) !!}
 
                 <div :class="`row ${errors.has('first_name') ? 'has-error' : ''}`">
                     <label class="col-12 mandatory">
@@ -37,6 +38,8 @@
                     </div>
                 </div>
 
+                {!! view_render_event('bagisto.shop.customers.account.profile.edit.first_name.after') !!}
+
                 <div class="row">
                     <label class="col-12">
                         {{ __('shop::app.customer.account.profile.lname') }}
@@ -46,6 +49,8 @@
                         <input value="{{ $customer->last_name }}" name="last_name" type="text" />
                     </div>
                 </div>
+
+                {!! view_render_event('bagisto.shop.customers.account.profile.edit.last_name.after') !!}
 
                 <div :class="`row ${errors.has('gender') ? 'has-error' : ''}`">
                     <label class="col-12 mandatory">
@@ -93,6 +98,8 @@
                     </div>
                 </div>
 
+                {!! view_render_event('bagisto.shop.customers.account.profile.edit.gender.after') !!}
+
                 <div :class="`row ${errors.has('date_of_birth') ? 'has-error' : ''}`">
                     <label class="col-12">
                         {{ __('shop::app.customer.account.profile.dob') }}
@@ -112,6 +119,8 @@
                     </div>
                 </div>
 
+                {!! view_render_event('bagisto.shop.customers.account.profile.edit.date_of_birth.after') !!}
+
                 <div class="row">
                     <label class="col-12 mandatory">
                         {{ __('shop::app.customer.account.profile.email') }}
@@ -123,6 +132,8 @@
                     </div>
                 </div>
 
+                {!! view_render_event('bagisto.shop.customers.account.profile.edit.email.after') !!}
+
                 <div class="row">
                     <label class="col-12">
                         {{ __('velocity::app.shop.general.enter-current-password') }}
@@ -132,6 +143,8 @@
                         <input value="" name="oldpassword" type="password" />
                     </div>
                 </div>
+
+                {!! view_render_event('bagisto.shop.customers.account.profile.edit.oldpassword.after') !!}
 
                 <div class="row">
                     <label class="col-12">
@@ -151,6 +164,8 @@
                     </div>
                 </div>
 
+                {!! view_render_event('bagisto.shop.customers.account.profile.edit.password.after') !!}
+
                 <div class="row">
                     <label class="col-12">
                         {{ __('velocity::app.shop.general.confirm-new-password') }}
@@ -166,6 +181,8 @@
                     </div>
                 </div>
 
+                {!! view_render_event('bagisto.shop.customers.account.profile.edit_form_controls.after', ['customer' => $customer]) !!}
+
                 <button
                     type="submit"
                     class="theme-btn mb20">
@@ -174,5 +191,5 @@
             </form>
         </div>
 
-    {!! view_render_event('bagisto.shop.customers.account.profile.view.after', ['customer' => $customer]) !!}
+    {!! view_render_event('bagisto.shop.customers.account.profile.edit.after', ['customer' => $customer]) !!}
 @endsection

--- a/packages/Webkul/Velocity/src/Resources/views/shop/customers/account/profile/index.blade.php
+++ b/packages/Webkul/Velocity/src/Resources/views/shop/customers/account/profile/index.blade.php
@@ -46,20 +46,28 @@
                         <td>{{ $customer->first_name }}</td>
                     </tr>
 
+                    {!! view_render_event('bagisto.shop.customers.account.profile.view.table.first_name.after') !!}
+
                     <tr>
                         <td>{{ __('shop::app.customer.account.profile.lname') }}</td>
                         <td>{{ $customer->last_name }}</td>
                     </tr>
+
+                    {!! view_render_event('bagisto.shop.customers.account.profile.view.table.last_name.after') !!}
 
                     <tr>
                         <td>{{ __('shop::app.customer.account.profile.gender') }}</td>
                         <td>{{ $customer->gender ?? '-' }}</td>
                     </tr>
 
+                    {!! view_render_event('bagisto.shop.customers.account.profile.view.table.gender.after') !!}
+
                     <tr>
                         <td>{{ __('shop::app.customer.account.profile.dob') }}</td>
                         <td>{{ $customer->date_of_birth ?? '-' }}</td>
                     </tr>
+
+                    {!! view_render_event('bagisto.shop.customers.account.profile.view.table.date_of_birth.after') !!}
 
                     <tr>
                         <td>{{ __('shop::app.customer.account.profile.email') }}</td>

--- a/packages/Webkul/Velocity/src/Resources/views/shop/customers/signup/index.blade.php
+++ b/packages/Webkul/Velocity/src/Resources/views/shop/customers/signup/index.blade.php
@@ -58,6 +58,8 @@
                             </span>
                         </div>
 
+                        {!! view_render_event('bagisto.shop.customers.signup_form_controls.firstname.after') !!}
+
                         <div class="control-group" :class="[errors.has('last_name') ? 'has-error' : '']">
                             <label for="last_name" class="required label-style">
                                 {{ __('shop::app.customer.signup-form.lastname') }}
@@ -75,6 +77,8 @@
                                 @{{ errors.first('last_name') }}
                             </span>
                         </div>
+
+                        {!! view_render_event('bagisto.shop.customers.signup_form_controls.lastname.after') !!}
 
                         <div class="control-group" :class="[errors.has('email') ? 'has-error' : '']">
                             <label for="email" class="required label-style">
@@ -94,6 +98,8 @@
                             </span>
                         </div>
 
+                        {!! view_render_event('bagisto.shop.customers.signup_form_controls.email.after') !!}
+
                         <div class="control-group" :class="[errors.has('password') ? 'has-error' : '']">
                             <label for="password" class="required label-style">
                                 {{ __('shop::app.customer.signup-form.password') }}
@@ -112,6 +118,8 @@
                                 @{{ errors.first('password') }}
                             </span>
                         </div>
+
+                        {!! view_render_event('bagisto.shop.customers.signup_form_controls.password.after') !!}
 
                         <div class="control-group" :class="[errors.has('password_confirmation') ? 'has-error' : '']">
                             <label for="password_confirmation" class="required label-style">


### PR DESCRIPTION
Hello Guys

To allow better customizations, for example, a package to create a new customer or shipping attribute, and to be able to inject this new attribute input in the forms I created a new view_render_event after every customer form input or profile attribute.

Also, I fixed the names of the Velocity profile edit view that were wrong.

For last I added some events in the order view page (storefront and admin), I want to be able to inject some payment information on this page from my new payment module.

Cheers