### PR TITLE
Bugfix: Channel assigned to tax category

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/tax/tax-categories/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/tax/tax-categories/create.blade.php
@@ -26,22 +26,6 @@
                 <div class="form-container">
                     @csrf()
 
-                    <div class="control-group" :class="[errors.has('channel') ? 'has-error' : '']">
-                        <label for="channel" class="required">{{ __('admin::app.configuration.tax-categories.select-channel') }}</label>
-
-                        <select class="control" name="channel_id">
-                            @foreach (core()->getAllChannels() as $channelModel)
-
-                                <option value="{{ $channelModel->id }}">
-                                    {{ $channelModel->name }}
-                                </option>
-
-                            @endforeach
-                        </select>
-
-                        <span class="control-error" v-if="errors.has('channel')">@{{ errors.first('channel') }}</span>
-                    </div>
-
                     <div class="control-group" :class="[errors.has('code') ? 'has-error' : '']">
                         <label for="code" class="required">{{ __('admin::app.configuration.tax-categories.code') }}</label>
 
@@ -67,7 +51,7 @@
                     </div>
 
                     <?php $selectedOptions = old('taxrates') ?: [] ?>
-                    
+
                     <div class="control-group" :class="[errors.has('taxrates[]') ? 'has-error' : '']">
                         <label for="taxrates" class="required">{{ __('admin::app.configuration.tax-categories.select-taxrates') }}</label>
 

--- a/packages/Webkul/Admin/src/Resources/views/tax/tax-categories/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/tax/tax-categories/edit.blade.php
@@ -27,22 +27,6 @@
                 <div class="form-container">
                     @csrf()
                     @method('PUT')
-                    <div class="control-group" :class="[errors.has('channel') ? 'has-error' : '']">
-                        <label for="channel" class="required">{{ __('admin::app.settings.tax-categories.select-channel') }}</label>
-
-                        <select class="control" name="channel_id">
-                            @foreach (core()->getAllChannels() as $channelModel)
-
-                                <option @if ($taxCategory->channel_id == $channelModel->id) selected @endif value="{{ $channelModel->id }}">
-                                    {{ $channelModel->name }}
-                                </option>
-
-                            @endforeach
-                        </select>
-
-                        <span class="control-error" v-if="errors.has('channel')">@{{ errors.first('channel') }}</span>
-                    </div>
-
                     <div class="control-group" :class="[errors.has('code') ? 'has-error' : '']">
                         <label for="code" class="required">{{ __('admin::app.settings.tax-categories.code') }}</label>
 

--- a/packages/Webkul/Tax/src/Database/Factories/TaxCategoryFactory.php
+++ b/packages/Webkul/Tax/src/Database/Factories/TaxCategoryFactory.php
@@ -7,9 +7,6 @@ use Webkul\Tax\Models\TaxCategory;
 
 $factory->define(TaxCategory::class, function (Faker $faker) {
     return [
-        'channel_id'  => function () {
-            return core()->getCurrentChannel()->id;
-        },
         'code'        => $faker->uuid,
         'name'        => $faker->words(2, true),
         'description' => $faker->sentence(10),

--- a/packages/Webkul/Tax/src/Database/Migrations/2020_04_16_130351_remove_channel_from_tax_category.php
+++ b/packages/Webkul/Tax/src/Database/Migrations/2020_04_16_130351_remove_channel_from_tax_category.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RemoveChannelFromTaxCategory extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('tax_categories', function (Blueprint $table) {
+            $table->dropForeign('tax_categories_channel_id_foreign');
+            $table->dropColumn('channel_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('tax_categories', function (Blueprint $table) {
+            $table->integer('channel_id')->unsigned()->after('id');
+            $table->foreign('channel_id')->references('id')->on('channels')->onDelete('cascade');
+        });
+    }
+}

--- a/packages/Webkul/Tax/src/Http/Controllers/TaxCategoryController.php
+++ b/packages/Webkul/Tax/src/Http/Controllers/TaxCategoryController.php
@@ -68,7 +68,6 @@ class TaxCategoryController extends Controller
         $data = request()->input();
 
         $this->validate(request(), [
-            'channel_id'  => 'required|numeric',
             'code'        => 'required|string|unique:tax_categories,code',
             'name'        => 'required|string',
             'description' => 'required|string',
@@ -111,7 +110,6 @@ class TaxCategoryController extends Controller
     public function update($id)
     {
         $this->validate(request(), [
-            'channel_id'  => 'required|numeric',
             'code'        => 'required|string|unique:tax_categories,code,' . $id,
             'name'        => 'required|string',
             'description' => 'required|string',

--- a/packages/Webkul/Tax/src/Models/TaxCategory.php
+++ b/packages/Webkul/Tax/src/Models/TaxCategory.php
@@ -16,7 +16,6 @@ class TaxCategory extends Model implements TaxCategoryContract
     protected $table = 'tax_categories';
 
     protected $fillable = [
-       'channel_id',
        'code',
        'name',
        'description',

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,0 +1,4 @@
+{
+    "/js/app.js": "/js/app.js",
+    "/css/app.css": "/css/app.css"
+}


### PR DESCRIPTION
The present PR removes the channel from the tax category.

**Fixed Bug:**

When creating or editing a tax category, selecting a channel is required. This is unnecessary, because: 
1. The tax category is assigned to a product, and the product is assigned to a channel. Thus, the tax category is only available to the product if bought in that channel.
2. When editing a product, it is not checked which tax category can be selected for the current product channel. 

My conclusion is hence, that assigning a channel to a tax category does not have any consequences on the one hand, and is not necessary on the other hand.

