### PR TITLE
add option to OrderItemFactory to use existing product

### DIFF
--- a/packages/Webkul/Sales/src/Database/Factories/OrderItemFactory.php
+++ b/packages/Webkul/Sales/src/Database/Factories/OrderItemFactory.php
@@ -7,10 +7,14 @@ use Webkul\Product\Models\Product;
 use Webkul\Sales\Models\Order;
 use Webkul\Sales\Models\OrderItem;
 
-$factory->define(OrderItem::class, function (Faker $faker) {
+$factory->define(OrderItem::class, function (Faker $faker, array $attributes) {
     $now = date("Y-m-d H:i:s");
 
-    $product = factory(Product::class, 'simple')->create();
+    if (isset($attributes['product_id'])) {
+        $product = Product::where('id', $attributes['product_id'])->first();
+    } else {
+        $product = factory(Product::class)->create();
+    }
 
     return [
         'sku'          => $product->sku,


### PR DESCRIPTION
This PR offers the possibility to the OrderItemFactory to use an existing product as order item, passed by product ID, rather than creating a new product.