### PR TITLE
Booking Products: Inject template only if exists

### DIFF
--- a/packages/Webkul/BookingProduct/src/Providers/EventServiceProvider.php
+++ b/packages/Webkul/BookingProduct/src/Providers/EventServiceProvider.php
@@ -2,8 +2,10 @@
 
 namespace Webkul\BookingProduct\Providers;
 
+use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Event;
+use Webkul\Theme\ViewRenderEventManager;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -14,8 +16,10 @@ class EventServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        Event::listen('bagisto.shop.products.view.short_description.after', function($viewRenderEventManager) {
-            $viewRenderEventManager->addTemplate('bookingproduct::shop.products.view.booking');
+        Event::listen('bagisto.shop.products.view.short_description.after', static function(ViewRenderEventManager $viewRenderEventManager) {
+            if (View::exists('bookingproduct::shop.' . core()->getCurrentChannel()->theme . '.products.view.booking')) {
+                $viewRenderEventManager->addTemplate('bookingproduct::shop.' . core()->getCurrentChannel()->theme . '.products.view.booking');
+            }
         });
 
         Event::listen('checkout.order.save.after', 'Webkul\BookingProduct\Listeners\Order@afterPlaceOrder');


### PR DESCRIPTION
The present PR checks if a view for the booking product details template exists for the current theme, and lets it being injected only then. 

Background:
With Booking Products, you provide an awesome and very powerful feature. Using our self-made theme, we did not adapt the views for it yet. The template is injected into the product details view, regardless if a view exists or not. That is why we have some templating issues now. 