### PR TITLE
Added missing space for configurable/grouped product price.

### DIFF
--- a/packages/Webkul/Product/src/Type/Configurable.php
+++ b/packages/Webkul/Product/src/Type/Configurable.php
@@ -397,6 +397,7 @@ class Configurable extends AbstractType
     public function getPriceHtml()
     {
         return '<span class="price-label">' . trans('shop::app.products.price-label') . '</span>'
+            . ' '
             . '<span class="final-price">' . core()->currency($this->getMinimalPrice()) . '</span>';
     }
 

--- a/packages/Webkul/Product/src/Type/Grouped.php
+++ b/packages/Webkul/Product/src/Type/Grouped.php
@@ -147,6 +147,7 @@ class Grouped extends AbstractType
     public function getPriceHtml()
     {
         return '<span class="price-label">' . trans('shop::app.products.starting-at') . '</span>'
+            . ' '
             . '<span class="final-price">' . core()->currency($this->getMinimalPrice()) . '</span>';
     }
 


### PR DESCRIPTION
**BUGS:**
There is no space between the wording for configurable/grouped products.

**Expected:** "As low as $100"
**Actual:** "As low as$100"