### PR TITLE
Fixed undefined $state variable when using State based tax rates.

### DIFF
--- a/packages/Webkul/Checkout/src/Cart.php
+++ b/packages/Webkul/Checkout/src/Cart.php
@@ -687,7 +687,7 @@ class Cart
             if ($address === null) {
                 $address = new class() {
                     public $country;
-
+                    public $state;
                     public $postcode;
 
                     function __construct()


### PR DESCRIPTION
**BUGS:**
Error when adding product to cart: "Undefined property: class@anonymous::$state"
