### PR TITLE
various fixes for cart rules and taxes

### DIFF
--- a/packages/Webkul/CartRule/src/Helpers/CartRule.php
+++ b/packages/Webkul/CartRule/src/Helpers/CartRule.php
@@ -124,7 +124,9 @@ class CartRule
 
         $this->processFreeShippingDiscount($cart);
 
-        $this->validateCouponCode();
+        if (! $this->checkCouponCode()) {
+            cart()->removeCouponCode();
+        }
     }
 
     /**
@@ -516,23 +518,26 @@ class CartRule
     }
 
     /**
-     * Check if coupon code is valid or not, if not remove from cart
+     * Check if coupon code is applied or not
      *
-     * @return void
+     * @return bool
      */
-    public function validateCouponCode()
+    public function checkCouponCode(): bool
     {
-        $cart = Cart::getCart();
+        $cart = cart()->getCart();
 
         if (! $cart->coupon_code) {
-            return;
+            return true;
         }
 
-        $coupon = $this->cartRuleCouponRepository->findOneByField('code', $cart->coupon_code);
-
-        if (! $coupon || ! in_array($coupon->cart_rule_id, explode(',', $cart->applied_cart_rule_ids))) {
-            Cart::removeCouponCode();
+        $coupons = $this->cartRuleCouponRepository->where(['code' => $cart->coupon_code])->get();
+        foreach ($coupons as $coupon) {
+            if (in_array($coupon->cart_rule_id, explode(',', $cart->applied_cart_rule_ids))) {
+                return true;
+            }
         }
+
+        return false;
     }
 
     /**

--- a/packages/Webkul/CartRule/src/Helpers/CartRule.php
+++ b/packages/Webkul/CartRule/src/Helpers/CartRule.php
@@ -324,16 +324,14 @@ class CartRule
                     break;
             }
 
-            $item->discount_amount = round(
-                min(
-                    $item->discount_amount + $discountAmount,
-                    $item->price * $quantity + $item->tax_amount
-                ),2);
-            $item->base_discount_amount = round(
-                min(
-                    $item->base_discount_amount + $baseDiscountAmount,
-                    $item->base_price * $quantity + $item->base_tax_amount
-                ), 2);
+            $item->discount_amount = min(
+                $item->discount_amount + $discountAmount,
+                $item->price * $quantity + $item->tax_amount
+            );
+            $item->base_discount_amount = min(
+                $item->base_discount_amount + $baseDiscountAmount,
+                $item->base_price * $quantity + $item->base_tax_amount
+            );
 
             $appliedRuleIds[$rule->id] = $rule->id;
 

--- a/packages/Webkul/Checkout/src/Cart.php
+++ b/packages/Webkul/Checkout/src/Cart.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Checkout;
 
+use Webkul\Checkout\Models\Cart as CartModel;
 use Webkul\Checkout\Models\CartAddress;
 use Webkul\Checkout\Repositories\CartRepository;
 use Webkul\Checkout\Repositories\CartItemRepository;
@@ -600,6 +601,8 @@ class Cart
             $cart->base_discount_amount += $shipping->base_discount_amount;
         }
 
+        $cart = $this->finalizeCartTotals($cart);
+
         $quantities = 0;
 
         foreach ($cart->items as $item) {
@@ -1050,6 +1053,25 @@ class Cart
             $cart->customer_first_name = $cart->billing_address->first_name;
             $cart->customer_last_name = $cart->billing_address->last_name;
         }
+    }
+
+    /**
+     * Round cart totals
+     *
+     * @param \Webkul\Checkout\Models\Cart $cart
+     *
+     * @return \Webkul\Checkout\Models\Cart
+     */
+    private function finalizeCartTotals(CartModel $cart): CartModel
+    {
+        $cart->discount_amount = round($cart->discount_amount, 2);
+        $cart->base_discount_amount = round($cart->base_discount_amount, 2);
+
+        $cart->grand_total = round($cart->grand_total, 2);
+        $cart->grand_total = round($cart->grand_total, 2);
+        $cart->base_grand_total = round($cart->base_grand_total, 2);
+
+        return $cart;
     }
 
     /**

--- a/packages/Webkul/Tax/src/Helpers/Tax.php
+++ b/packages/Webkul/Tax/src/Helpers/Tax.php
@@ -13,16 +13,16 @@ class Tax
     /**
      * Returns an array with tax rates and tax amount
      *
-     * @param \Webkul\Checkout\Contracts\Cart $cart
-     * @param bool                            $asBase
+     * @param object $that
+     * @param bool   $asBase
      *
      * @return array
      */
-    public static function getTaxRatesWithAmount(\Webkul\Checkout\Contracts\Cart $cart, bool $asBase = false): array
+    public static function getTaxRatesWithAmount(object $that, bool $asBase = false): array
     {
         $taxes = [];
 
-        foreach ($cart->items as $item) {
+        foreach ($that->items as $item) {
             $taxRate = (string) round((float) $item->tax_percent, self::TAX_RATE_PRECISION);
 
             if (! array_key_exists($taxRate, $taxes)) {
@@ -43,14 +43,14 @@ class Tax
     /**
      * Returns the total tax amount
      *
-     * @param \Webkul\Checkout\Contracts\Cart $cart
-     * @param bool                            $asBase
+     * @param object $that
+     * @param bool   $asBase
      *
      * @return float
      */
-    public static function getTaxTotal(\Webkul\Checkout\Contracts\Cart $cart, bool $asBase = false): float
+    public static function getTaxTotal(object $that, bool $asBase = false): float
     {
-        $taxes = self::getTaxRatesWithAmount($cart, $asBase);
+        $taxes = self::getTaxRatesWithAmount($that, $asBase);
 
         $result = 0;
 

--- a/tests/unit/CartRule/CartRuleCest.php
+++ b/tests/unit/CartRule/CartRuleCest.php
@@ -106,7 +106,6 @@ class expectedCartItem
 class expectedCart
 {
     public const CART_TOTAL_PRECISION = 2;
-    public const CART_GRAND_TOTAL_PRECISION = 4;
 
     public $customer_id;
     public $id;
@@ -141,13 +140,13 @@ class expectedCart
         $this->tax_total = round($this->tax_total, self::CART_TOTAL_PRECISION);
         $this->discount_amount = round($this->discount_amount, self::CART_TOTAL_PRECISION);
         $this->grand_total = round($this->sub_total + $this->tax_total - $this->discount_amount,
-            self::CART_GRAND_TOTAL_PRECISION);
+            self::CART_TOTAL_PRECISION);
 
         $this->base_sub_total = round($this->base_sub_total, self::CART_TOTAL_PRECISION);
         $this->base_tax_total = round($this->base_tax_total, self::CART_TOTAL_PRECISION);
         $this->base_discount_amount = round($this->base_discount_amount, self::CART_TOTAL_PRECISION);
         $this->base_grand_total = round($this->base_sub_total + $this->base_tax_total - $this->base_discount_amount,
-            self::CART_GRAND_TOTAL_PRECISION);
+            self::CART_TOTAL_PRECISION);
     }
 
     public function toArray(): array

--- a/tests/unit/Tax/Helpers/TaxCest.php
+++ b/tests/unit/Tax/Helpers/TaxCest.php
@@ -17,7 +17,6 @@ class TaxCest
     private const PRODUCT2_QTY = 7;
 
     private const CART_TOTAL_PRECISION = 2;
-    private const TAX_AMOUNT_PRECISION = 2;
 
     public function _before(UnitTester $I)
     {
@@ -73,16 +72,17 @@ class TaxCest
             'quantity'   => self::PRODUCT2_QTY,
         ]);
 
+        // rounded by precision of 2 because this are sums of corresponding tax categories
         $expectedTaxAmount1 = round(
             round(self::PRODUCT1_QTY * $product1->price, self::CART_TOTAL_PRECISION)
             * $tax1->tax_rate / 100,
-            self::TAX_AMOUNT_PRECISION
+            self::CART_TOTAL_PRECISION
         );
 
         $expectedTaxAmount2 = round(
             round(self::PRODUCT2_QTY * $product2->price, self::CART_TOTAL_PRECISION)
             * $tax2->tax_rate / 100,
-            self::TAX_AMOUNT_PRECISION
+            self::CART_TOTAL_PRECISION
         );
 
         $this->scenario = [
@@ -92,7 +92,7 @@ class TaxCest
                 (string)round((float)$tax2->tax_rate, 4) => $expectedTaxAmount2,
             ],
             'expectedTaxTotal' =>
-                round($expectedTaxAmount1 + $expectedTaxAmount2, self::TAX_AMOUNT_PRECISION),
+                round($expectedTaxAmount1 + $expectedTaxAmount2, self::CART_TOTAL_PRECISION),
         ];
     }
 


### PR DESCRIPTION
- fixed a bug in discount calculation for percentage bases coupons
- removed type hint of \Webkul\Checkout\Models\Cart in Helpers/Tax.php as we use this funktion in various places with different objects
- fix some rounding issues for tax and discount calculation (cart items will always have 4 digits, cart totals will have only 2 digits)
- also added test scenario in CartRuleCest to check this


**Edit:**

There is a bug in CartRule.php validateCouponCode()
- If you have two or more coupons with the _same coupon code_, function validateCouponCode() will possible fail in checking cart rules
- this bug is fixed too