### PR TITLE
fix CatalogRuleIndex

### DIFF
--- a/packages/Webkul/CatalogRule/src/Helpers/CatalogRuleProduct.php
+++ b/packages/Webkul/CatalogRule/src/Helpers/CatalogRuleProduct.php
@@ -149,7 +149,7 @@ class CatalogRuleProduct
                 ) {
                     continue;
                 }
-                
+
                 $appliedAttributes[] = $condition['attribute'];
 
                 $chunks = explode('|', $condition['attribute']);
@@ -178,7 +178,7 @@ class CatalogRuleProduct
 
         return array_unique($validatedProductIds);
     }
-    
+
     /**
      * Add product attribute condition to query
      *
@@ -197,7 +197,7 @@ class CatalogRuleProduct
         $query = $query->leftJoin('product_attribute_values as ' . 'pav_' . $attribute->code, function($qb) use($attribute) {
             $qb = $qb->where('pav_' . $attribute->code . '.channel', $attribute->value_per_channel ? core()->getDefaultChannelCode() : null)
                      ->where('pav_' . $attribute->code . '.locale', $attribute->value_per_locale ? app()->getLocale() : null);
-            
+
             $qb->on('products.id', 'pav_' . $attribute->code . '.product_id')
                ->where('pav_' . $attribute->code . '.attribute_id', $attribute->id);
         });
@@ -256,9 +256,9 @@ class CatalogRuleProduct
         if (count($productIds)) {
             $this->catalogRuleProductRepository->getModel()->whereIn('product_id', $productIds)->delete();
         } else {
-            $this->catalogRuleProductRepository->deleteWhere([
+            $this->catalogRuleProductRepository->getModel()->where([
                 ['product_id', 'like', '%%']
-            ]);
+            ])->delete();
         }
     }
 }

--- a/packages/Webkul/CatalogRule/src/Helpers/CatalogRuleProductPrice.php
+++ b/packages/Webkul/CatalogRule/src/Helpers/CatalogRuleProductPrice.php
@@ -161,7 +161,7 @@ class CatalogRuleProductPrice
 
             case 'by_fixed':
                 $price = max(0, $price - $rule->discount_amount);
-                
+
                 break;
 
             case 'by_percent':
@@ -184,9 +184,9 @@ class CatalogRuleProductPrice
         if (count($productIds)) {
             $this->catalogRuleProductPriceRepository->getModel()->whereIn('product_id', $productIds)->delete();
         } else {
-            $this->catalogRuleProductPriceRepository->deleteWhere([
+            $this->catalogRuleProductPriceRepository->getModel()->where([
                 ['product_id', 'like', '%%']
-            ]);
+            ])->delete();
         }
     }
 


### PR DESCRIPTION
There was an error when creating the product index for catalog rules:

```
Argument 2 passed to Prettus\\Repository\\Events\\RepositoryEventBase::__construct() must be an instance of Illuminate\\Database\\Eloquent\\Model or null, instance of Illuminate\\Database\\Eloquent\\Builder given, called in /var/www/vendor/prettus/l5-repository/src/Prettus/Repository/Eloquent/BaseRepository.php on line 772
```

I found out that the Repositories which are used for that are not used correctly.