### PR TITLE
Hide $0 bundle option price in cart

### DIFF
--- a/packages/Webkul/Product/src/Type/Bundle.php
+++ b/packages/Webkul/Product/src/Type/Bundle.php
@@ -560,7 +560,14 @@ class Bundle extends AbstractType
                     $bundleOptionQuantities[$optionId] = $qty;
                 }
 
-                $labels[] = $qty . ' x ' . $optionProduct->product->name . ' ' . core()->currency($optionProduct->product->getTypeInstance()->getMinimalPrice());
+                $label = $qty . ' x ' . $optionProduct->product->name;
+
+                $price = $optionProduct->product->getTypeInstance()->getMinimalPrice();
+                if($price != 0){
+                    $label .= ' ' . core()->currency($price);
+                }
+
+                $labels[] = $label;
             }
 
             if (count($labels)) {


### PR DESCRIPTION
**ENHANCEMENT:**
If a bundle has a $0 item, do not display the price in cart.