### PR TITLE
Products: Fix for missing or invalid sort direction

### DIFF
--- a/packages/Webkul/Product/src/Helpers/Toolbar.php
+++ b/packages/Webkul/Product/src/Helpers/Toolbar.php
@@ -83,8 +83,9 @@ class Toolbar extends AbstractProduct
     public function isOrderCurrent($key)
     {
         $params = request()->input();
+        $orderDirection = $params['order'] ?? 'asc';
 
-        if (isset($params['sort']) && $key == $params['sort'] . '-' . $params['order']) {
+        if (isset($params['sort']) && $key == $params['sort'] . '-' . $orderDirection) {
             return true;
         } elseif (! isset($params['sort'])) {
             $sortBy = core()->getConfigData('catalog.products.storefront.sort_by')

--- a/packages/Webkul/Product/src/Repositories/ProductRepository.php
+++ b/packages/Webkul/Product/src/Repositories/ProductRepository.php
@@ -140,18 +140,20 @@ class ProductRepository extends Repository
             if (isset($params['search']))
                 $qb->where('product_flat.name', 'like', '%' . urldecode($params['search']) . '%');
 
+            # sort direction
+            $orderDirection = 'asc';
+            if( isset($params['order']) && in_array($params['order'], ['desc', 'asc']) ){
+                $orderDirection = $params['order'];
+            }
+
             if (isset($params['sort'])) {
                 $attribute = $this->attributeRepository->findOneByField('code', $params['sort']);
 
                 if ($attribute) {
-                    if ($params['sort'] == 'price') {
-                        if ($attribute->code == 'price') {
-                            $qb->orderBy('min_price', $params['order']);
-                        } else {
-                            $qb->orderBy($attribute->code, $params['order']);
-                        }
+                    if ($attribute->code == 'price') {
+                        $qb->orderBy('min_price', $orderDirection);
                     } else {
-                        $qb->orderBy($params['sort'] == 'created_at' ? 'product_flat.created_at' : $attribute->code, $params['order']);
+                        $qb->orderBy($params['sort'] == 'created_at' ? 'product_flat.created_at' : $attribute->code, $orderDirection);
                     }
                 }
             }


### PR DESCRIPTION
**BUGS:**
Exception gets thrown when order is not specified in product sorting, or if the given order is invalid (not 'asc' or 'desc')