### PR TITLE
add field company_name to bliss views

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/AddressDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/AddressDataGrid.php
@@ -83,6 +83,15 @@ class AddressDataGrid extends DataGrid
         ]);
 
         $this->addColumn([
+            'index'      => 'company_name',
+            'label'      => trans('admin::app.customers.addresses.company-name'),
+            'type'       => 'string',
+            'searchable' => true,
+            'sortable'   => true,
+            'filterable' => true,
+        ]);
+
+        $this->addColumn([
             'index'      => 'address1',
             'label'      => trans('admin::app.customers.addresses.address-1'),
             'type'       => 'string',

--- a/packages/Webkul/Admin/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en/app.php
@@ -901,6 +901,7 @@ return [
             'address-list' => 'Address\'s List',
             'order-list' => 'Order\'s List',
             'address-id' => 'Address ID',
+            'company-name' => 'Company Name',
             'address-1' => 'Address 1',
             'city' => 'City',
             'state-name' => 'State',

--- a/packages/Webkul/Admin/src/Resources/views/sales/address.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/sales/address.blade.php
@@ -1,6 +1,7 @@
-{{ $address->name }}</br>
+{{ $address->company_name ?? '' }}</br>
+<b>{{ $address->name }}</b></br>
 {{ $address->address1 }}</br>
 {{ $address->city }}</br>
  {{ $address->state }}</br>
 {{ core()->country_name($address->country) }} {{ $address->postcode }}</br></br>
-{{ __('shop::app.checkout.onepage.contact') }} : {{ $address->phone }} 
+{{ __('shop::app.checkout.onepage.contact') }} : {{ $address->phone }}

--- a/packages/Webkul/Shop/src/Resources/views/checkout/onepage/customer-info.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/checkout/onepage/customer-info.blade.php
@@ -17,6 +17,10 @@
                     </label>
 
                     <ul class="address-card-list" style="float: right; width: 85%;">
+                        <li class="mb-5" v-if="addresses.company-name != ''">
+                            @{{ addresses.company_name }}
+                        </li>
+
                         <li class="mb-10">
                             <b>@{{ allAddress.first_name }} @{{ allAddress.last_name }},</b>
                         </li>
@@ -269,8 +273,12 @@
                         </label>
 
                         <ul class="address-card-list" style="float: right; width: 85%;">
+                            <li class="mb-5" v-if="addresses.company-name != ''">
+                                @{{ addresses.company_name }}
+                            </li>
+
                             <li class="mb-10">
-                                <b>@{{ allAddress.first_name }} @{{ allAddress.last_name }},</b>
+                                <b>@{{ addresses.first_name }} @{{ addresses.last_name }},</b>
                             </li>
 
                             <li class="mb-5">

--- a/packages/Webkul/Shop/src/Resources/views/checkout/onepage/review.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/checkout/onepage/review.blade.php
@@ -13,7 +13,10 @@
                 <div class="card-content">
                     <ul>
                         <li class="mb-10">
-                            {{ $billingAddress->first_name }} {{ $billingAddress->last_name }}
+                            {{ $billingAddress->company_name ?? '' }}
+                        </li>
+                        <li class="mb-10">
+                            <b>{{ $billingAddress->first_name }} {{ $billingAddress->last_name }}</b>
                         </li>
                         <li class="mb-10">
                             {{ $billingAddress->address1 }},<br/> {{ $billingAddress->state }}
@@ -41,7 +44,10 @@
                 <div class="card-content">
                     <ul>
                         <li class="mb-10">
-                            {{ $shippingAddress->first_name }} {{ $shippingAddress->last_name }}
+                            {{ $shippingAddress->company_name ?? '' }}
+                        </li>
+                        <li class="mb-10">
+                            <b>{{ $shippingAddress->first_name }} {{ $shippingAddress->last_name }}</b>
                         </li>
                         <li class="mb-10">
                             {{ $shippingAddress->address1 }},<br/> {{ $shippingAddress->state }}


### PR DESCRIPTION
As mentioned in https://github.com/bagisto/bagisto/issues/2415, addresses company name should be shown in orders summary.

With this PR this is done for admin frontend and bliss theme.

@jitendra-webkul please have a look at it.
Thank you