### PR TITLE
introduce the ability to copy a cart rule

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/CartRuleDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/CartRuleDataGrid.php
@@ -2,8 +2,8 @@
 
 namespace Webkul\Admin\DataGrids;
 
-use Illuminate\Support\Facades\DB;
 use Webkul\Ui\DataGrid\DataGrid;
+use Illuminate\Support\Facades\DB;
 
 class CartRuleDataGrid extends DataGrid
 {
@@ -142,10 +142,18 @@ class CartRuleDataGrid extends DataGrid
         ]);
 
         $this->addAction([
+            'title'  => trans('admin::app.datagrid.copy'),
+            'method' => 'GET',
+            'route'  => 'admin.cart-rules.copy',
+            'icon'   => 'icon note-icon',
+        ]);
+
+        $this->addAction([
             'title'  => trans('admin::app.datagrid.delete'),
             'method' => 'POST',
             'route'  => 'admin.cart-rules.delete',
             'icon'   => 'icon trash-icon',
         ]);
+
     }
 }

--- a/packages/Webkul/Admin/src/Http/routes.php
+++ b/packages/Webkul/Admin/src/Http/routes.php
@@ -7,69 +7,69 @@ Route::group(['middleware' => ['web']], function () {
 
         // Login Routes
         Route::get('/login', 'Webkul\User\Http\Controllers\SessionController@create')->defaults('_config', [
-            'view' => 'admin::users.sessions.create'
+            'view' => 'admin::users.sessions.create',
         ])->name('admin.session.create');
 
         //login post route to admin auth controller
         Route::post('/login', 'Webkul\User\Http\Controllers\SessionController@store')->defaults('_config', [
-            'redirect' => 'admin.dashboard.index'
+            'redirect' => 'admin.dashboard.index',
         ])->name('admin.session.store');
 
         // Forget Password Routes
         Route::get('/forget-password', 'Webkul\User\Http\Controllers\ForgetPasswordController@create')->defaults('_config', [
-            'view' => 'admin::users.forget-password.create'
+            'view' => 'admin::users.forget-password.create',
         ])->name('admin.forget-password.create');
 
         Route::post('/forget-password', 'Webkul\User\Http\Controllers\ForgetPasswordController@store')->name('admin.forget-password.store');
 
         // Reset Password Routes
         Route::get('/reset-password/{token}', 'Webkul\User\Http\Controllers\ResetPasswordController@create')->defaults('_config', [
-            'view' => 'admin::users.reset-password.create'
+            'view' => 'admin::users.reset-password.create',
         ])->name('admin.reset-password.create');
 
         Route::post('/reset-password', 'Webkul\User\Http\Controllers\ResetPasswordController@store')->defaults('_config', [
-            'redirect' => 'admin.dashboard.index'
+            'redirect' => 'admin.dashboard.index',
         ])->name('admin.reset-password.store');
 
 
         // Admin Routes
         Route::group(['middleware' => ['admin']], function () {
             Route::get('/logout', 'Webkul\User\Http\Controllers\SessionController@destroy')->defaults('_config', [
-                'redirect' => 'admin.session.create'
+                'redirect' => 'admin.session.create',
             ])->name('admin.session.destroy');
 
             // Dashboard Route
             Route::get('dashboard', 'Webkul\Admin\Http\Controllers\DashboardController@index')->defaults('_config', [
-                'view' => 'admin::dashboard.index'
+                'view' => 'admin::dashboard.index',
             ])->name('admin.dashboard.index');
 
             //Customer Management Routes
             Route::get('customers', 'Webkul\Admin\Http\Controllers\Customer\CustomerController@index')->defaults('_config', [
-                'view' => 'admin::customers.index'
+                'view' => 'admin::customers.index',
             ])->name('admin.customer.index');
 
-            Route::get('customers/create', 'Webkul\Admin\Http\Controllers\Customer\CustomerController@create')->defaults('_config',[
-                'view' => 'admin::customers.create'
+            Route::get('customers/create', 'Webkul\Admin\Http\Controllers\Customer\CustomerController@create')->defaults('_config', [
+                'view' => 'admin::customers.create',
             ])->name('admin.customer.create');
 
-            Route::post('customers/create', 'Webkul\Admin\Http\Controllers\Customer\CustomerController@store')->defaults('_config',[
-                'redirect' => 'admin.customer.index'
+            Route::post('customers/create', 'Webkul\Admin\Http\Controllers\Customer\CustomerController@store')->defaults('_config', [
+                'redirect' => 'admin.customer.index',
             ])->name('admin.customer.store');
 
-            Route::get('customers/edit/{id}', 'Webkul\Admin\Http\Controllers\Customer\CustomerController@edit')->defaults('_config',[
-                'view' => 'admin::customers.edit'
+            Route::get('customers/edit/{id}', 'Webkul\Admin\Http\Controllers\Customer\CustomerController@edit')->defaults('_config', [
+                'view' => 'admin::customers.edit',
             ])->name('admin.customer.edit');
 
-            Route::get('customers/note/{id}', 'Webkul\Admin\Http\Controllers\Customer\CustomerController@createNote')->defaults('_config',[
-                'view' => 'admin::customers.note'
+            Route::get('customers/note/{id}', 'Webkul\Admin\Http\Controllers\Customer\CustomerController@createNote')->defaults('_config', [
+                'view' => 'admin::customers.note',
             ])->name('admin.customer.note.create');
 
-            Route::put('customers/note/{id}', 'Webkul\Admin\Http\Controllers\Customer\CustomerController@storeNote')->defaults('_config',[
-                'redirect' => 'admin.customer.index'
+            Route::put('customers/note/{id}', 'Webkul\Admin\Http\Controllers\Customer\CustomerController@storeNote')->defaults('_config', [
+                'redirect' => 'admin.customer.index',
             ])->name('admin.customer.note.store');
 
             Route::put('customers/edit/{id}', 'Webkul\Admin\Http\Controllers\Customer\CustomerController@update')->defaults('_config', [
-                'redirect' => 'admin.customer.index'
+                'redirect' => 'admin.customer.index',
             ])->name('admin.customer.update');
 
             Route::post('customers/delete/{id}', 'Webkul\Admin\Http\Controllers\Customer\CustomerController@destroy')->name('admin.customer.delete');
@@ -78,95 +78,95 @@ Route::group(['middleware' => ['web']], function () {
 
             Route::post('customers/masssupdate', 'Webkul\Admin\Http\Controllers\Customer\CustomerController@massUpdate')->name('admin.customer.mass-update');
 
-            Route::get('reviews', 'Webkul\Product\Http\Controllers\ReviewController@index')->defaults('_config',[
-                'view' => 'admin::customers.reviews.index'
+            Route::get('reviews', 'Webkul\Product\Http\Controllers\ReviewController@index')->defaults('_config', [
+                'view' => 'admin::customers.reviews.index',
             ])->name('admin.customer.review.index');
 
             //Customer's addresses routes
             Route::get('customers/{id}/addresses', 'Webkul\Admin\Http\Controllers\Customer\AddressController@index')->defaults('_config', [
-                'view' => 'admin::customers.addresses.index'
+                'view' => 'admin::customers.addresses.index',
             ])->name('admin.customer.addresses.index');
 
-            Route::get('customers/{id}/addresses/create', 'Webkul\Admin\Http\Controllers\Customer\AddressController@create')->defaults('_config',[
-                'view' => 'admin::customers.addresses.create'
+            Route::get('customers/{id}/addresses/create', 'Webkul\Admin\Http\Controllers\Customer\AddressController@create')->defaults('_config', [
+                'view' => 'admin::customers.addresses.create',
             ])->name('admin.customer.addresses.create');
 
-            Route::post('customers/{id}/addresses/create', 'Webkul\Admin\Http\Controllers\Customer\AddressController@store')->defaults('_config',[
-                'redirect' => 'admin.customer.addresses.index'
+            Route::post('customers/{id}/addresses/create', 'Webkul\Admin\Http\Controllers\Customer\AddressController@store')->defaults('_config', [
+                'redirect' => 'admin.customer.addresses.index',
             ])->name('admin.customer.addresses.store');
 
-            Route::get('customers/addresses/edit/{id}', 'Webkul\Admin\Http\Controllers\Customer\AddressController@edit')->defaults('_config',[
-                'view' => 'admin::customers.addresses.edit'
+            Route::get('customers/addresses/edit/{id}', 'Webkul\Admin\Http\Controllers\Customer\AddressController@edit')->defaults('_config', [
+                'view' => 'admin::customers.addresses.edit',
             ])->name('admin.customer.addresses.edit');
 
             Route::put('customers/addresses/edit/{id}', 'Webkul\Admin\Http\Controllers\Customer\AddressController@update')->defaults('_config', [
-                'redirect' => 'admin.customer.addresses.index'
+                'redirect' => 'admin.customer.addresses.index',
             ])->name('admin.customer.addresses.update');
 
             Route::post('customers/addresses/delete/{id}', 'Webkul\Admin\Http\Controllers\Customer\AddressController@destroy')->defaults('_config', [
-                'redirect' => 'admin.customer.addresses.index'
+                'redirect' => 'admin.customer.addresses.index',
             ])->name('admin.customer.addresses.delete');
 
             //mass destroy
             Route::post('customers/{id}/addresses', 'Webkul\Admin\Http\Controllers\Customer\AddressController@massDestroy')->defaults('_config', [
-                'redirect' => 'admin.customer.addresses.index'
+                'redirect' => 'admin.customer.addresses.index',
             ])->name('admin.customer.addresses.massdelete');
 
             // Configuration routes
             Route::get('configuration/{slug?}/{slug2?}', 'Webkul\Admin\Http\Controllers\ConfigurationController@index')->defaults('_config', [
-                'view' => 'admin::configuration.index'
+                'view' => 'admin::configuration.index',
             ])->name('admin.configuration.index');
 
             Route::post('configuration/{slug?}/{slug2?}', 'Webkul\Admin\Http\Controllers\ConfigurationController@store')->defaults('_config', [
-                'redirect' => 'admin.configuration.index'
+                'redirect' => 'admin.configuration.index',
             ])->name('admin.configuration.index.store');
 
             Route::get('configuration/{slug?}/{slug2?}/{path}', 'Webkul\Admin\Http\Controllers\ConfigurationController@download')->defaults('_config', [
-                'redirect' => 'admin.configuration.index'
+                'redirect' => 'admin.configuration.index',
             ])->name('admin.configuration.download');
 
             // Reviews Routes
-            Route::get('reviews/edit/{id}', 'Webkul\Product\Http\Controllers\ReviewController@edit')->defaults('_config',[
-                'view' => 'admin::customers.reviews.edit'
+            Route::get('reviews/edit/{id}', 'Webkul\Product\Http\Controllers\ReviewController@edit')->defaults('_config', [
+                'view' => 'admin::customers.reviews.edit',
             ])->name('admin.customer.review.edit');
 
             Route::put('reviews/edit/{id}', 'Webkul\Product\Http\Controllers\ReviewController@update')->defaults('_config', [
-                'redirect' => 'admin.customer.review.index'
+                'redirect' => 'admin.customer.review.index',
             ])->name('admin.customer.review.update');
 
             Route::post('reviews/delete/{id}', 'Webkul\Product\Http\Controllers\ReviewController@destroy')->defaults('_config', [
-                'redirect' => 'admin.customer.review.index'
+                'redirect' => 'admin.customer.review.index',
             ])->name('admin.customer.review.delete');
 
             //mass destroy
             Route::post('reviews/massdestroy', 'Webkul\Product\Http\Controllers\ReviewController@massDestroy')->defaults('_config', [
-                'redirect' => 'admin.customer.review.index'
+                'redirect' => 'admin.customer.review.index',
             ])->name('admin.customer.review.massdelete');
 
             //mass update
             Route::post('reviews/massupdate', 'Webkul\Product\Http\Controllers\ReviewController@massUpdate')->defaults('_config', [
-                'redirect' => 'admin.customer.review.index'
+                'redirect' => 'admin.customer.review.index',
             ])->name('admin.customer.review.massupdate');
 
             // Customer Groups Routes
-            Route::get('groups', 'Webkul\Admin\Http\Controllers\Customer\CustomerGroupController@index')->defaults('_config',[
-                'view' => 'admin::customers.groups.index'
+            Route::get('groups', 'Webkul\Admin\Http\Controllers\Customer\CustomerGroupController@index')->defaults('_config', [
+                'view' => 'admin::customers.groups.index',
             ])->name('admin.groups.index');
 
-            Route::get('groups/create', 'Webkul\Admin\Http\Controllers\Customer\CustomerGroupController@create')->defaults('_config',[
-                'view' => 'admin::customers.groups.create'
+            Route::get('groups/create', 'Webkul\Admin\Http\Controllers\Customer\CustomerGroupController@create')->defaults('_config', [
+                'view' => 'admin::customers.groups.create',
             ])->name('admin.groups.create');
 
-            Route::post('groups/create', 'Webkul\Admin\Http\Controllers\Customer\CustomerGroupController@store')->defaults('_config',[
-                'redirect' => 'admin.groups.index'
+            Route::post('groups/create', 'Webkul\Admin\Http\Controllers\Customer\CustomerGroupController@store')->defaults('_config', [
+                'redirect' => 'admin.groups.index',
             ])->name('admin.groups.store');
 
-            Route::get('groups/edit/{id}', 'Webkul\Admin\Http\Controllers\Customer\CustomerGroupController@edit')->defaults('_config',[
-                'view' => 'admin::customers.groups.edit'
+            Route::get('groups/edit/{id}', 'Webkul\Admin\Http\Controllers\Customer\CustomerGroupController@edit')->defaults('_config', [
+                'view' => 'admin::customers.groups.edit',
             ])->name('admin.groups.edit');
 
-            Route::put('groups/edit/{id}', 'Webkul\Admin\Http\Controllers\Customer\CustomerGroupController@update')->defaults('_config',[
-                'redirect' => 'admin.groups.index'
+            Route::put('groups/edit/{id}', 'Webkul\Admin\Http\Controllers\Customer\CustomerGroupController@update')->defaults('_config', [
+                'redirect' => 'admin.groups.index',
             ])->name('admin.groups.update');
 
             Route::post('groups/delete/{id}', 'Webkul\Admin\Http\Controllers\Customer\CustomerGroupController@destroy')->name('admin.groups.delete');
@@ -176,15 +176,15 @@ Route::group(['middleware' => ['web']], function () {
             Route::prefix('sales')->group(function () {
                 // Sales Order Routes
                 Route::get('/orders', 'Webkul\Admin\Http\Controllers\Sales\OrderController@index')->defaults('_config', [
-                    'view' => 'admin::sales.orders.index'
+                    'view' => 'admin::sales.orders.index',
                 ])->name('admin.sales.orders.index');
 
                 Route::get('/orders/view/{id}', 'Webkul\Admin\Http\Controllers\Sales\OrderController@view')->defaults('_config', [
-                    'view' => 'admin::sales.orders.view'
+                    'view' => 'admin::sales.orders.view',
                 ])->name('admin.sales.orders.view');
 
                 Route::get('/orders/cancel/{id}', 'Webkul\Admin\Http\Controllers\Sales\OrderController@cancel')->defaults('_config', [
-                    'view' => 'admin::sales.orders.cancel'
+                    'view' => 'admin::sales.orders.cancel',
                 ])->name('admin.sales.orders.cancel');
 
                 Route::post('/orders/create/{order_id}', 'Webkul\Admin\Http\Controllers\Sales\OrderController@comment')->name('admin.sales.orders.comment');
@@ -192,63 +192,63 @@ Route::group(['middleware' => ['web']], function () {
 
                 // Sales Invoices Routes
                 Route::get('/invoices', 'Webkul\Admin\Http\Controllers\Sales\InvoiceController@index')->defaults('_config', [
-                    'view' => 'admin::sales.invoices.index'
+                    'view' => 'admin::sales.invoices.index',
                 ])->name('admin.sales.invoices.index');
 
                 Route::get('/invoices/create/{order_id}', 'Webkul\Admin\Http\Controllers\Sales\InvoiceController@create')->defaults('_config', [
-                    'view' => 'admin::sales.invoices.create'
+                    'view' => 'admin::sales.invoices.create',
                 ])->name('admin.sales.invoices.create');
 
                 Route::post('/invoices/create/{order_id}', 'Webkul\Admin\Http\Controllers\Sales\InvoiceController@store')->defaults('_config', [
-                    'redirect' => 'admin.sales.orders.view'
+                    'redirect' => 'admin.sales.orders.view',
                 ])->name('admin.sales.invoices.store');
 
                 Route::get('/invoices/view/{id}', 'Webkul\Admin\Http\Controllers\Sales\InvoiceController@view')->defaults('_config', [
-                    'view' => 'admin::sales.invoices.view'
+                    'view' => 'admin::sales.invoices.view',
                 ])->name('admin.sales.invoices.view');
 
                 Route::get('/invoices/print/{id}', 'Webkul\Admin\Http\Controllers\Sales\InvoiceController@print')->defaults('_config', [
-                    'view' => 'admin::sales.invoices.print'
+                    'view' => 'admin::sales.invoices.print',
                 ])->name('admin.sales.invoices.print');
 
 
                 // Sales Shipments Routes
                 Route::get('/shipments', 'Webkul\Admin\Http\Controllers\Sales\ShipmentController@index')->defaults('_config', [
-                    'view' => 'admin::sales.shipments.index'
+                    'view' => 'admin::sales.shipments.index',
                 ])->name('admin.sales.shipments.index');
 
                 Route::get('/shipments/create/{order_id}', 'Webkul\Admin\Http\Controllers\Sales\ShipmentController@create')->defaults('_config', [
-                    'view' => 'admin::sales.shipments.create'
+                    'view' => 'admin::sales.shipments.create',
                 ])->name('admin.sales.shipments.create');
 
                 Route::post('/shipments/create/{order_id}', 'Webkul\Admin\Http\Controllers\Sales\ShipmentController@store')->defaults('_config', [
-                    'redirect' => 'admin.sales.orders.view'
+                    'redirect' => 'admin.sales.orders.view',
                 ])->name('admin.sales.shipments.store');
 
                 Route::get('/shipments/view/{id}', 'Webkul\Admin\Http\Controllers\Sales\ShipmentController@view')->defaults('_config', [
-                    'view' => 'admin::sales.shipments.view'
+                    'view' => 'admin::sales.shipments.view',
                 ])->name('admin.sales.shipments.view');
 
 
                 // Sales Redunds Routes
                 Route::get('/refunds', 'Webkul\Admin\Http\Controllers\Sales\RefundController@index')->defaults('_config', [
-                    'view' => 'admin::sales.refunds.index'
+                    'view' => 'admin::sales.refunds.index',
                 ])->name('admin.sales.refunds.index');
 
                 Route::get('/refunds/create/{order_id}', 'Webkul\Admin\Http\Controllers\Sales\RefundController@create')->defaults('_config', [
-                    'view' => 'admin::sales.refunds.create'
+                    'view' => 'admin::sales.refunds.create',
                 ])->name('admin.sales.refunds.create');
 
                 Route::post('/refunds/create/{order_id}', 'Webkul\Admin\Http\Controllers\Sales\RefundController@store')->defaults('_config', [
-                    'redirect' => 'admin.sales.orders.view'
+                    'redirect' => 'admin.sales.orders.view',
                 ])->name('admin.sales.refunds.store');
 
                 Route::post('/refunds/update-qty/{order_id}', 'Webkul\Admin\Http\Controllers\Sales\RefundController@updateQty')->defaults('_config', [
-                    'redirect' => 'admin.sales.orders.view'
+                    'redirect' => 'admin.sales.orders.view',
                 ])->name('admin.sales.refunds.update_qty');
 
                 Route::get('/refunds/view/{id}', 'Webkul\Admin\Http\Controllers\Sales\RefundController@view')->defaults('_config', [
-                    'view' => 'admin::sales.refunds.view'
+                    'view' => 'admin::sales.refunds.view',
                 ])->name('admin.sales.refunds.view');
             });
 
@@ -258,23 +258,23 @@ Route::group(['middleware' => ['web']], function () {
 
                 // Catalog Product Routes
                 Route::get('/products', 'Webkul\Product\Http\Controllers\ProductController@index')->defaults('_config', [
-                    'view' => 'admin::catalog.products.index'
+                    'view' => 'admin::catalog.products.index',
                 ])->name('admin.catalog.products.index');
 
                 Route::get('/products/create', 'Webkul\Product\Http\Controllers\ProductController@create')->defaults('_config', [
-                    'view' => 'admin::catalog.products.create'
+                    'view' => 'admin::catalog.products.create',
                 ])->name('admin.catalog.products.create');
 
                 Route::post('/products/create', 'Webkul\Product\Http\Controllers\ProductController@store')->defaults('_config', [
-                    'redirect' => 'admin.catalog.products.edit'
+                    'redirect' => 'admin.catalog.products.edit',
                 ])->name('admin.catalog.products.store');
 
                 Route::get('/products/edit/{id}', 'Webkul\Product\Http\Controllers\ProductController@edit')->defaults('_config', [
-                    'view' => 'admin::catalog.products.edit'
+                    'view' => 'admin::catalog.products.edit',
                 ])->name('admin.catalog.products.edit');
 
                 Route::put('/products/edit/{id}', 'Webkul\Product\Http\Controllers\ProductController@update')->defaults('_config', [
-                    'redirect' => 'admin.catalog.products.index'
+                    'redirect' => 'admin.catalog.products.index',
                 ])->name('admin.catalog.products.update');
 
                 Route::post('/products/upload-file/{id}', 'Webkul\Product\Http\Controllers\ProductController@uploadLink')->name('admin.catalog.products.upload_link');
@@ -289,44 +289,44 @@ Route::group(['middleware' => ['web']], function () {
 
                 //product massdelete
                 Route::post('products/massdelete', 'Webkul\Product\Http\Controllers\ProductController@massDestroy')->defaults('_config', [
-                    'redirect' => 'admin.catalog.products.index'
+                    'redirect' => 'admin.catalog.products.index',
                 ])->name('admin.catalog.products.massdelete');
 
                 //product massupdate
                 Route::post('products/massupdate', 'Webkul\Product\Http\Controllers\ProductController@massUpdate')->defaults('_config', [
-                    'redirect' => 'admin.catalog.products.index'
+                    'redirect' => 'admin.catalog.products.index',
                 ])->name('admin.catalog.products.massupdate');
 
                 //product search for linked products
                 Route::get('products/search', 'Webkul\Product\Http\Controllers\ProductController@productLinkSearch')->defaults('_config', [
-                    'view' => 'admin::catalog.products.edit'
+                    'view' => 'admin::catalog.products.edit',
                 ])->name('admin.catalog.products.productlinksearch');
 
                 Route::get('products/search-simple-products', 'Webkul\Product\Http\Controllers\ProductController@searchSimpleProducts')->name('admin.catalog.products.search_simple_product');
 
                 Route::get('/products/{id}/{attribute_id}', 'Webkul\Product\Http\Controllers\ProductController@download')->defaults('_config', [
-                    'view' => 'admin.catalog.products.edit'
+                    'view' => 'admin.catalog.products.edit',
                 ])->name('admin.catalog.products.file.download');
 
                 // Catalog Category Routes
                 Route::get('/categories', 'Webkul\Category\Http\Controllers\CategoryController@index')->defaults('_config', [
-                    'view' => 'admin::catalog.categories.index'
+                    'view' => 'admin::catalog.categories.index',
                 ])->name('admin.catalog.categories.index');
 
                 Route::get('/categories/create', 'Webkul\Category\Http\Controllers\CategoryController@create')->defaults('_config', [
-                    'view' => 'admin::catalog.categories.create'
+                    'view' => 'admin::catalog.categories.create',
                 ])->name('admin.catalog.categories.create');
 
                 Route::post('/categories/create', 'Webkul\Category\Http\Controllers\CategoryController@store')->defaults('_config', [
-                    'redirect' => 'admin.catalog.categories.index'
+                    'redirect' => 'admin.catalog.categories.index',
                 ])->name('admin.catalog.categories.store');
 
                 Route::get('/categories/edit/{id}', 'Webkul\Category\Http\Controllers\CategoryController@edit')->defaults('_config', [
-                    'view' => 'admin::catalog.categories.edit'
+                    'view' => 'admin::catalog.categories.edit',
                 ])->name('admin.catalog.categories.edit');
 
                 Route::put('/categories/edit/{id}', 'Webkul\Category\Http\Controllers\CategoryController@update')->defaults('_config', [
-                    'redirect' => 'admin.catalog.categories.index'
+                    'redirect' => 'admin.catalog.categories.index',
                 ])->name('admin.catalog.categories.update');
 
                 Route::post('/categories/delete/{id}', 'Webkul\Category\Http\Controllers\CategoryController@destroy')->name('admin.catalog.categories.delete');
@@ -334,23 +334,23 @@ Route::group(['middleware' => ['web']], function () {
 
                 // Catalog Attribute Routes
                 Route::get('/attributes', 'Webkul\Attribute\Http\Controllers\AttributeController@index')->defaults('_config', [
-                    'view' => 'admin::catalog.attributes.index'
+                    'view' => 'admin::catalog.attributes.index',
                 ])->name('admin.catalog.attributes.index');
 
                 Route::get('/attributes/create', 'Webkul\Attribute\Http\Controllers\AttributeController@create')->defaults('_config', [
-                    'view' => 'admin::catalog.attributes.create'
+                    'view' => 'admin::catalog.attributes.create',
                 ])->name('admin.catalog.attributes.create');
 
                 Route::post('/attributes/create', 'Webkul\Attribute\Http\Controllers\AttributeController@store')->defaults('_config', [
-                    'redirect' => 'admin.catalog.attributes.index'
+                    'redirect' => 'admin.catalog.attributes.index',
                 ])->name('admin.catalog.attributes.store');
 
                 Route::get('/attributes/edit/{id}', 'Webkul\Attribute\Http\Controllers\AttributeController@edit')->defaults('_config', [
-                    'view' => 'admin::catalog.attributes.edit'
+                    'view' => 'admin::catalog.attributes.edit',
                 ])->name('admin.catalog.attributes.edit');
 
                 Route::put('/attributes/edit/{id}', 'Webkul\Attribute\Http\Controllers\AttributeController@update')->defaults('_config', [
-                    'redirect' => 'admin.catalog.attributes.index'
+                    'redirect' => 'admin.catalog.attributes.index',
                 ])->name('admin.catalog.attributes.update');
 
                 Route::post('/attributes/delete/{id}', 'Webkul\Attribute\Http\Controllers\AttributeController@destroy')->name('admin.catalog.attributes.delete');
@@ -359,23 +359,23 @@ Route::group(['middleware' => ['web']], function () {
 
                 // Catalog Family Routes
                 Route::get('/families', 'Webkul\Attribute\Http\Controllers\AttributeFamilyController@index')->defaults('_config', [
-                    'view' => 'admin::catalog.families.index'
+                    'view' => 'admin::catalog.families.index',
                 ])->name('admin.catalog.families.index');
 
                 Route::get('/families/create', 'Webkul\Attribute\Http\Controllers\AttributeFamilyController@create')->defaults('_config', [
-                    'view' => 'admin::catalog.families.create'
+                    'view' => 'admin::catalog.families.create',
                 ])->name('admin.catalog.families.create');
 
                 Route::post('/families/create', 'Webkul\Attribute\Http\Controllers\AttributeFamilyController@store')->defaults('_config', [
-                    'redirect' => 'admin.catalog.families.index'
+                    'redirect' => 'admin.catalog.families.index',
                 ])->name('admin.catalog.families.store');
 
                 Route::get('/families/edit/{id}', 'Webkul\Attribute\Http\Controllers\AttributeFamilyController@edit')->defaults('_config', [
-                    'view' => 'admin::catalog.families.edit'
+                    'view' => 'admin::catalog.families.edit',
                 ])->name('admin.catalog.families.edit');
 
                 Route::put('/families/edit/{id}', 'Webkul\Attribute\Http\Controllers\AttributeFamilyController@update')->defaults('_config', [
-                    'redirect' => 'admin.catalog.families.index'
+                    'redirect' => 'admin.catalog.families.index',
                 ])->name('admin.catalog.families.update');
 
                 Route::post('/families/delete/{id}', 'Webkul\Attribute\Http\Controllers\AttributeFamilyController@destroy')->name('admin.catalog.families.delete');
@@ -384,59 +384,59 @@ Route::group(['middleware' => ['web']], function () {
             // User Routes
             //datagrid for backend users
             Route::get('/users', 'Webkul\User\Http\Controllers\UserController@index')->defaults('_config', [
-                'view' => 'admin::users.users.index'
+                'view' => 'admin::users.users.index',
             ])->name('admin.users.index');
 
             //create backend user get
             Route::get('/users/create', 'Webkul\User\Http\Controllers\UserController@create')->defaults('_config', [
-                'view' => 'admin::users.users.create'
+                'view' => 'admin::users.users.create',
             ])->name('admin.users.create');
 
             //create backend user post
             Route::post('/users/create', 'Webkul\User\Http\Controllers\UserController@store')->defaults('_config', [
-                'redirect' => 'admin.users.index'
+                'redirect' => 'admin.users.index',
             ])->name('admin.users.store');
 
             //delete backend user view
             Route::get('/users/edit/{id}', 'Webkul\User\Http\Controllers\UserController@edit')->defaults('_config', [
-                'view' => 'admin::users.users.edit'
+                'view' => 'admin::users.users.edit',
             ])->name('admin.users.edit');
 
             //edit backend user submit
             Route::put('/users/edit/{id}', 'Webkul\User\Http\Controllers\UserController@update')->defaults('_config', [
-                'redirect' => 'admin.users.index'
+                'redirect' => 'admin.users.index',
             ])->name('admin.users.update');
 
             //delete backend user
             Route::post('/users/delete/{id}', 'Webkul\User\Http\Controllers\UserController@destroy')->name('admin.users.delete');
 
             Route::get('/users/confirm/{id}', 'Webkul\User\Http\Controllers\UserController@confirm')->defaults('_config', [
-                'view' => 'admin::customers.confirm-password'
+                'view' => 'admin::customers.confirm-password',
             ])->name('super.users.confirm');
 
             Route::post('/users/confirm/{id}', 'Webkul\User\Http\Controllers\UserController@destroySelf')->defaults('_config', [
-                'redirect' => 'admin.users.index'
+                'redirect' => 'admin.users.index',
             ])->name('admin.users.destroy');
 
             // User Role Routes
             Route::get('/roles', 'Webkul\User\Http\Controllers\RoleController@index')->defaults('_config', [
-                'view' => 'admin::users.roles.index'
+                'view' => 'admin::users.roles.index',
             ])->name('admin.roles.index');
 
             Route::get('/roles/create', 'Webkul\User\Http\Controllers\RoleController@create')->defaults('_config', [
-                'view' => 'admin::users.roles.create'
+                'view' => 'admin::users.roles.create',
             ])->name('admin.roles.create');
 
             Route::post('/roles/create', 'Webkul\User\Http\Controllers\RoleController@store')->defaults('_config', [
-                'redirect' => 'admin.roles.index'
+                'redirect' => 'admin.roles.index',
             ])->name('admin.roles.store');
 
             Route::get('/roles/edit/{id}', 'Webkul\User\Http\Controllers\RoleController@edit')->defaults('_config', [
-                'view' => 'admin::users.roles.edit'
+                'view' => 'admin::users.roles.edit',
             ])->name('admin.roles.edit');
 
             Route::put('/roles/edit/{id}', 'Webkul\User\Http\Controllers\RoleController@update')->defaults('_config', [
-                'redirect' => 'admin.roles.index'
+                'redirect' => 'admin.roles.index',
             ])->name('admin.roles.update');
 
             Route::post('/roles/delete/{id}', 'Webkul\User\Http\Controllers\RoleController@destroy')->name('admin.roles.delete');
@@ -444,23 +444,23 @@ Route::group(['middleware' => ['web']], function () {
 
             // Locale Routes
             Route::get('/locales', 'Webkul\Core\Http\Controllers\LocaleController@index')->defaults('_config', [
-                'view' => 'admin::settings.locales.index'
+                'view' => 'admin::settings.locales.index',
             ])->name('admin.locales.index');
 
             Route::get('/locales/create', 'Webkul\Core\Http\Controllers\LocaleController@create')->defaults('_config', [
-                'view' => 'admin::settings.locales.create'
+                'view' => 'admin::settings.locales.create',
             ])->name('admin.locales.create');
 
             Route::post('/locales/create', 'Webkul\Core\Http\Controllers\LocaleController@store')->defaults('_config', [
-                'redirect' => 'admin.locales.index'
+                'redirect' => 'admin.locales.index',
             ])->name('admin.locales.store');
 
             Route::get('/locales/edit/{id}', 'Webkul\Core\Http\Controllers\LocaleController@edit')->defaults('_config', [
-                'view' => 'admin::settings.locales.edit'
+                'view' => 'admin::settings.locales.edit',
             ])->name('admin.locales.edit');
 
             Route::put('/locales/edit/{id}', 'Webkul\Core\Http\Controllers\LocaleController@update')->defaults('_config', [
-                'redirect' => 'admin.locales.index'
+                'redirect' => 'admin.locales.index',
             ])->name('admin.locales.update');
 
             Route::post('/locales/delete/{id}', 'Webkul\Core\Http\Controllers\LocaleController@destroy')->name('admin.locales.delete');
@@ -468,23 +468,23 @@ Route::group(['middleware' => ['web']], function () {
 
             // Currency Routes
             Route::get('/currencies', 'Webkul\Core\Http\Controllers\CurrencyController@index')->defaults('_config', [
-                'view' => 'admin::settings.currencies.index'
+                'view' => 'admin::settings.currencies.index',
             ])->name('admin.currencies.index');
 
             Route::get('/currencies/create', 'Webkul\Core\Http\Controllers\CurrencyController@create')->defaults('_config', [
-                'view' => 'admin::settings.currencies.create'
+                'view' => 'admin::settings.currencies.create',
             ])->name('admin.currencies.create');
 
             Route::post('/currencies/create', 'Webkul\Core\Http\Controllers\CurrencyController@store')->defaults('_config', [
-                'redirect' => 'admin.currencies.index'
+                'redirect' => 'admin.currencies.index',
             ])->name('admin.currencies.store');
 
             Route::get('/currencies/edit/{id}', 'Webkul\Core\Http\Controllers\CurrencyController@edit')->defaults('_config', [
-                'view' => 'admin::settings.currencies.edit'
+                'view' => 'admin::settings.currencies.edit',
             ])->name('admin.currencies.edit');
 
             Route::put('/currencies/edit/{id}', 'Webkul\Core\Http\Controllers\CurrencyController@update')->defaults('_config', [
-                'redirect' => 'admin.currencies.index'
+                'redirect' => 'admin.currencies.index',
             ])->name('admin.currencies.update');
 
             Route::post('/currencies/delete/{id}', 'Webkul\Core\Http\Controllers\CurrencyController@destroy')->name('admin.currencies.delete');
@@ -494,25 +494,25 @@ Route::group(['middleware' => ['web']], function () {
 
             // Exchange Rates Routes
             Route::get('/exchange_rates', 'Webkul\Core\Http\Controllers\ExchangeRateController@index')->defaults('_config', [
-                'view' => 'admin::settings.exchange_rates.index'
+                'view' => 'admin::settings.exchange_rates.index',
             ])->name('admin.exchange_rates.index');
 
             Route::get('/exchange_rates/create', 'Webkul\Core\Http\Controllers\ExchangeRateController@create')->defaults('_config', [
-                'view' => 'admin::settings.exchange_rates.create'
+                'view' => 'admin::settings.exchange_rates.create',
             ])->name('admin.exchange_rates.create');
 
             Route::post('/exchange_rates/create', 'Webkul\Core\Http\Controllers\ExchangeRateController@store')->defaults('_config', [
-                'redirect' => 'admin.exchange_rates.index'
+                'redirect' => 'admin.exchange_rates.index',
             ])->name('admin.exchange_rates.store');
 
             Route::get('/exchange_rates/edit/{id}', 'Webkul\Core\Http\Controllers\ExchangeRateController@edit')->defaults('_config', [
-                'view' => 'admin::settings.exchange_rates.edit'
+                'view' => 'admin::settings.exchange_rates.edit',
             ])->name('admin.exchange_rates.edit');
 
             Route::get('/exchange_rates/update-rates', 'Webkul\Core\Http\Controllers\ExchangeRateController@updateRates')->name('admin.exchange_rates.update_rates');
 
             Route::put('/exchange_rates/edit/{id}', 'Webkul\Core\Http\Controllers\ExchangeRateController@update')->defaults('_config', [
-                'redirect' => 'admin.exchange_rates.index'
+                'redirect' => 'admin.exchange_rates.index',
             ])->name('admin.exchange_rates.update');
 
             Route::post('/exchange_rates/delete/{id}', 'Webkul\Core\Http\Controllers\ExchangeRateController@destroy')->name('admin.exchange_rates.delete');
@@ -520,46 +520,46 @@ Route::group(['middleware' => ['web']], function () {
 
             // Inventory Source Routes
             Route::get('/inventory_sources', 'Webkul\Inventory\Http\Controllers\InventorySourceController@index')->defaults('_config', [
-                'view' => 'admin::settings.inventory_sources.index'
+                'view' => 'admin::settings.inventory_sources.index',
             ])->name('admin.inventory_sources.index');
 
             Route::get('/inventory_sources/create', 'Webkul\Inventory\Http\Controllers\InventorySourceController@create')->defaults('_config', [
-                'view' => 'admin::settings.inventory_sources.create'
+                'view' => 'admin::settings.inventory_sources.create',
             ])->name('admin.inventory_sources.create');
 
             Route::post('/inventory_sources/create', 'Webkul\Inventory\Http\Controllers\InventorySourceController@store')->defaults('_config', [
-                'redirect' => 'admin.inventory_sources.index'
+                'redirect' => 'admin.inventory_sources.index',
             ])->name('admin.inventory_sources.store');
 
             Route::get('/inventory_sources/edit/{id}', 'Webkul\Inventory\Http\Controllers\InventorySourceController@edit')->defaults('_config', [
-                'view' => 'admin::settings.inventory_sources.edit'
+                'view' => 'admin::settings.inventory_sources.edit',
             ])->name('admin.inventory_sources.edit');
 
             Route::put('/inventory_sources/edit/{id}', 'Webkul\Inventory\Http\Controllers\InventorySourceController@update')->defaults('_config', [
-                'redirect' => 'admin.inventory_sources.index'
+                'redirect' => 'admin.inventory_sources.index',
             ])->name('admin.inventory_sources.update');
 
             Route::post('/inventory_sources/delete/{id}', 'Webkul\Inventory\Http\Controllers\InventorySourceController@destroy')->name('admin.inventory_sources.delete');
 
             // Channel Routes
             Route::get('/channels', 'Webkul\Core\Http\Controllers\ChannelController@index')->defaults('_config', [
-                'view' => 'admin::settings.channels.index'
+                'view' => 'admin::settings.channels.index',
             ])->name('admin.channels.index');
 
             Route::get('/channels/create', 'Webkul\Core\Http\Controllers\ChannelController@create')->defaults('_config', [
-                'view' => 'admin::settings.channels.create'
+                'view' => 'admin::settings.channels.create',
             ])->name('admin.channels.create');
 
             Route::post('/channels/create', 'Webkul\Core\Http\Controllers\ChannelController@store')->defaults('_config', [
-                'redirect' => 'admin.channels.index'
+                'redirect' => 'admin.channels.index',
             ])->name('admin.channels.store');
 
             Route::get('/channels/edit/{id}', 'Webkul\Core\Http\Controllers\ChannelController@edit')->defaults('_config', [
-                'view' => 'admin::settings.channels.edit'
+                'view' => 'admin::settings.channels.edit',
             ])->name('admin.channels.edit');
 
             Route::put('/channels/edit/{id}', 'Webkul\Core\Http\Controllers\ChannelController@update')->defaults('_config', [
-                'redirect' => 'admin.channels.index'
+                'redirect' => 'admin.channels.index',
             ])->name('admin.channels.update');
 
             Route::post('/channels/delete/{id}', 'Webkul\Core\Http\Controllers\ChannelController@destroy')->name('admin.channels.delete');
@@ -567,51 +567,51 @@ Route::group(['middleware' => ['web']], function () {
 
             // Admin Profile route
             Route::get('/account', 'Webkul\User\Http\Controllers\AccountController@edit')->defaults('_config', [
-                'view' => 'admin::account.edit'
+                'view' => 'admin::account.edit',
             ])->name('admin.account.edit');
 
             Route::put('/account', 'Webkul\User\Http\Controllers\AccountController@update')->name('admin.account.update');
 
 
             // Admin Store Front Settings Route
-            Route::get('/subscribers','Webkul\Core\Http\Controllers\SubscriptionController@index')->defaults('_config',[
-                'view' => 'admin::customers.subscribers.index'
+            Route::get('/subscribers', 'Webkul\Core\Http\Controllers\SubscriptionController@index')->defaults('_config', [
+                'view' => 'admin::customers.subscribers.index',
             ])->name('admin.customers.subscribers.index');
 
             //destroy a newsletter subscription item
             Route::post('subscribers/delete/{id}', 'Webkul\Core\Http\Controllers\SubscriptionController@destroy')->name('admin.customers.subscribers.delete');
 
             Route::get('subscribers/edit/{id}', 'Webkul\Core\Http\Controllers\SubscriptionController@edit')->defaults('_config', [
-                'view' => 'admin::customers.subscribers.edit'
+                'view' => 'admin::customers.subscribers.edit',
             ])->name('admin.customers.subscribers.edit');
 
             Route::put('subscribers/update/{id}', 'Webkul\Core\Http\Controllers\SubscriptionController@update')->defaults('_config', [
-                'redirect' => 'admin.customers.subscribers.index'
+                'redirect' => 'admin.customers.subscribers.index',
             ])->name('admin.customers.subscribers.update');
 
             //slider index
-            Route::get('/slider','Webkul\Core\Http\Controllers\SliderController@index')->defaults('_config',[
-                'view' => 'admin::settings.sliders.index'
+            Route::get('/slider', 'Webkul\Core\Http\Controllers\SliderController@index')->defaults('_config', [
+                'view' => 'admin::settings.sliders.index',
             ])->name('admin.sliders.index');
 
             //slider create show
-            Route::get('slider/create','Webkul\Core\Http\Controllers\SliderController@create')->defaults('_config',[
-                'view' => 'admin::settings.sliders.create'
+            Route::get('slider/create', 'Webkul\Core\Http\Controllers\SliderController@create')->defaults('_config', [
+                'view' => 'admin::settings.sliders.create',
             ])->name('admin.sliders.create');
 
             //slider create show
-            Route::post('slider/create','Webkul\Core\Http\Controllers\SliderController@store')->defaults('_config',[
-                'redirect' => 'admin.sliders.index'
+            Route::post('slider/create', 'Webkul\Core\Http\Controllers\SliderController@store')->defaults('_config', [
+                'redirect' => 'admin.sliders.index',
             ])->name('admin.sliders.store');
 
             //slider edit show
-            Route::get('slider/edit/{id}','Webkul\Core\Http\Controllers\SliderController@edit')->defaults('_config',[
-                'view' => 'admin::settings.sliders.edit'
+            Route::get('slider/edit/{id}', 'Webkul\Core\Http\Controllers\SliderController@edit')->defaults('_config', [
+                'view' => 'admin::settings.sliders.edit',
             ])->name('admin.sliders.edit');
 
             //slider edit update
-            Route::post('slider/edit/{id}','Webkul\Core\Http\Controllers\SliderController@update')->defaults('_config',[
-                'redirect' => 'admin.sliders.index'
+            Route::post('slider/edit/{id}', 'Webkul\Core\Http\Controllers\SliderController@update')->defaults('_config', [
+                'redirect' => 'admin.sliders.index',
             ])->name('admin.sliders.update');
 
             //destroy a slider item
@@ -619,25 +619,25 @@ Route::group(['middleware' => ['web']], function () {
 
             //tax routes
             Route::get('/tax-categories', 'Webkul\Tax\Http\Controllers\TaxController@index')->defaults('_config', [
-                'view' => 'admin::tax.tax-categories.index'
+                'view' => 'admin::tax.tax-categories.index',
             ])->name('admin.tax-categories.index');
 
 
             // tax category routes
             Route::get('/tax-categories/create', 'Webkul\Tax\Http\Controllers\TaxCategoryController@show')->defaults('_config', [
-                'view' => 'admin::tax.tax-categories.create'
+                'view' => 'admin::tax.tax-categories.create',
             ])->name('admin.tax-categories.show');
 
             Route::post('/tax-categories/create', 'Webkul\Tax\Http\Controllers\TaxCategoryController@create')->defaults('_config', [
-                'redirect' => 'admin.tax-categories.index'
+                'redirect' => 'admin.tax-categories.index',
             ])->name('admin.tax-categories.create');
 
             Route::get('/tax-categories/edit/{id}', 'Webkul\Tax\Http\Controllers\TaxCategoryController@edit')->defaults('_config', [
-                'view' => 'admin::tax.tax-categories.edit'
+                'view' => 'admin::tax.tax-categories.edit',
             ])->name('admin.tax-categories.edit');
 
             Route::put('/tax-categories/edit/{id}', 'Webkul\Tax\Http\Controllers\TaxCategoryController@update')->defaults('_config', [
-                'redirect' => 'admin.tax-categories.index'
+                'redirect' => 'admin.tax-categories.index',
             ])->name('admin.tax-categories.update');
 
             Route::post('/tax-categories/delete/{id}', 'Webkul\Tax\Http\Controllers\TaxCategoryController@destroy')->name('admin.tax-categories.delete');
@@ -646,29 +646,29 @@ Route::group(['middleware' => ['web']], function () {
 
             //tax rate
             Route::get('tax-rates', 'Webkul\Tax\Http\Controllers\TaxRateController@index')->defaults('_config', [
-                'view' => 'admin::tax.tax-rates.index'
+                'view' => 'admin::tax.tax-rates.index',
             ])->name('admin.tax-rates.index');
 
             Route::get('tax-rates/create', 'Webkul\Tax\Http\Controllers\TaxRateController@show')->defaults('_config', [
-                'view' => 'admin::tax.tax-rates.create'
+                'view' => 'admin::tax.tax-rates.create',
             ])->name('admin.tax-rates.show');
 
             Route::post('tax-rates/create', 'Webkul\Tax\Http\Controllers\TaxRateController@create')->defaults('_config', [
-                'redirect' => 'admin.tax-rates.index'
+                'redirect' => 'admin.tax-rates.index',
             ])->name('admin.tax-rates.create');
 
             Route::get('tax-rates/edit/{id}', 'Webkul\Tax\Http\Controllers\TaxRateController@edit')->defaults('_config', [
-                'view' => 'admin::tax.tax-rates.edit'
+                'view' => 'admin::tax.tax-rates.edit',
             ])->name('admin.tax-rates.store');
 
             Route::put('tax-rates/update/{id}', 'Webkul\Tax\Http\Controllers\TaxRateController@update')->defaults('_config', [
-                'redirect' => 'admin.tax-rates.index'
+                'redirect' => 'admin.tax-rates.index',
             ])->name('admin.tax-rates.update');
 
             Route::post('/tax-rates/delete/{id}', 'Webkul\Tax\Http\Controllers\TaxRateController@destroy')->name('admin.tax-rates.delete');
 
             Route::post('/tax-rates/import', 'Webkul\Tax\Http\Controllers\TaxRateController@import')->defaults('_config', [
-                'redirect' => 'admin.tax-rates.index'
+                'redirect' => 'admin.tax-rates.index',
             ])->name('admin.tax-rates.import');
             //tax rate ends
 
@@ -677,23 +677,27 @@ Route::group(['middleware' => ['web']], function () {
 
             Route::prefix('promotions')->group(function () {
                 Route::get('cart-rules', 'Webkul\CartRule\Http\Controllers\CartRuleController@index')->defaults('_config', [
-                    'view' => 'admin::promotions.cart-rules.index'
+                    'view' => 'admin::promotions.cart-rules.index',
                 ])->name('admin.cart-rules.index');
 
                 Route::get('cart-rules/create', 'Webkul\CartRule\Http\Controllers\CartRuleController@create')->defaults('_config', [
-                    'view' => 'admin::promotions.cart-rules.create'
+                    'view' => 'admin::promotions.cart-rules.create',
                 ])->name('admin.cart-rules.create');
 
                 Route::post('cart-rules/create', 'Webkul\CartRule\Http\Controllers\CartRuleController@store')->defaults('_config', [
-                    'redirect' => 'admin.cart-rules.index'
+                    'redirect' => 'admin.cart-rules.index',
                 ])->name('admin.cart-rules.store');
 
+                Route::get('cart-rules/copy/{id}', 'Webkul\CartRule\Http\Controllers\CartRuleController@copy')->defaults('_config', [
+                    'view' => 'admin::promotions.cart-rules.edit',
+                ])->name('admin.cart-rules.copy');
+
                 Route::get('cart-rules/edit/{id}', 'Webkul\CartRule\Http\Controllers\CartRuleController@edit')->defaults('_config', [
-                    'view' => 'admin::promotions.cart-rules.edit'
+                    'view' => 'admin::promotions.cart-rules.edit',
                 ])->name('admin.cart-rules.edit');
 
                 Route::post('cart-rules/edit/{id}', 'Webkul\CartRule\Http\Controllers\CartRuleController@update')->defaults('_config', [
-                    'redirect' => 'admin.cart-rules.index'
+                    'redirect' => 'admin.cart-rules.index',
                 ])->name('admin.cart-rules.update');
 
                 Route::post('cart-rules/delete/{id}', 'Webkul\CartRule\Http\Controllers\CartRuleController@destroy')->name('admin.cart-rules.delete');
@@ -705,23 +709,23 @@ Route::group(['middleware' => ['web']], function () {
 
                 //Catalog rules
                 Route::get('catalog-rules', 'Webkul\CatalogRule\Http\Controllers\CatalogRuleController@index')->defaults('_config', [
-                    'view' => 'admin::promotions.catalog-rules.index'
+                    'view' => 'admin::promotions.catalog-rules.index',
                 ])->name('admin.catalog-rules.index');
 
                 Route::get('catalog-rules/create', 'Webkul\CatalogRule\Http\Controllers\CatalogRuleController@create')->defaults('_config', [
-                    'view' => 'admin::promotions.catalog-rules.create'
+                    'view' => 'admin::promotions.catalog-rules.create',
                 ])->name('admin.catalog-rules.create');
 
                 Route::post('catalog-rules/create', 'Webkul\CatalogRule\Http\Controllers\CatalogRuleController@store')->defaults('_config', [
-                    'redirect' => 'admin.catalog-rules.index'
+                    'redirect' => 'admin.catalog-rules.index',
                 ])->name('admin.catalog-rules.store');
 
                 Route::get('catalog-rules/edit/{id}', 'Webkul\CatalogRule\Http\Controllers\CatalogRuleController@edit')->defaults('_config', [
-                    'view' => 'admin::promotions.catalog-rules.edit'
+                    'view' => 'admin::promotions.catalog-rules.edit',
                 ])->name('admin.catalog-rules.edit');
 
                 Route::post('catalog-rules/edit/{id}', 'Webkul\CatalogRule\Http\Controllers\CatalogRuleController@update')->defaults('_config', [
-                    'redirect' => 'admin.catalog-rules.index'
+                    'redirect' => 'admin.catalog-rules.index',
                 ])->name('admin.catalog-rules.update');
 
                 Route::post('catalog-rules/delete/{id}', 'Webkul\CatalogRule\Http\Controllers\CatalogRuleController@destroy')->name('admin.catalog-rules.delete');
@@ -729,32 +733,32 @@ Route::group(['middleware' => ['web']], function () {
 
             Route::prefix('cms')->group(function () {
                 Route::get('/', 'Webkul\CMS\Http\Controllers\Admin\PageController@index')->defaults('_config', [
-                    'view' => 'admin::cms.index'
+                    'view' => 'admin::cms.index',
                 ])->name('admin.cms.index');
 
 
                 Route::get('create', 'Webkul\CMS\Http\Controllers\Admin\PageController@create')->defaults('_config', [
-                    'view' => 'admin::cms.create'
+                    'view' => 'admin::cms.create',
                 ])->name('admin.cms.create');
 
                 Route::post('create', 'Webkul\CMS\Http\Controllers\Admin\PageController@store')->defaults('_config', [
-                    'redirect' => 'admin.cms.index'
+                    'redirect' => 'admin.cms.index',
                 ])->name('admin.cms.store');
 
                 Route::get('edit/{id}', 'Webkul\CMS\Http\Controllers\Admin\PageController@edit')->defaults('_config', [
-                    'view' => 'admin::cms.edit'
+                    'view' => 'admin::cms.edit',
                 ])->name('admin.cms.edit');
 
                 Route::post('edit/{id}', 'Webkul\CMS\Http\Controllers\Admin\PageController@update')->defaults('_config', [
-                    'redirect' => 'admin.cms.index'
+                    'redirect' => 'admin.cms.index',
                 ])->name('admin.cms.update');
 
                 Route::post('/delete/{id}', 'Webkul\CMS\Http\Controllers\Admin\PageController@delete')->defaults('_config', [
-                    'redirect' => 'admin.cms.index'
+                    'redirect' => 'admin.cms.index',
                 ])->name('admin.cms.delete');
 
                 Route::post('/massdelete', 'Webkul\CMS\Http\Controllers\Admin\PageController@massDelete')->defaults('_config', [
-                    'redirect' => 'admin.cms.index'
+                    'redirect' => 'admin.cms.index',
                 ])->name('admin.cms.mass-delete');
 
                 // Route::post('/delete/{id}', 'Webkul\CMS\Http\Controllers\Admin\PageController@delete')->defaults('_config', [

--- a/packages/Webkul/Admin/src/Resources/lang/de/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/de/app.php
@@ -152,6 +152,7 @@ return array (
             'direction' => 'Richtung',
             'fullname' => 'Vollständiger Name',
             'type' => 'Typ',
+            'copy' => 'Kopieren',
             'required' => 'Erforderlich',
             'unique' => 'Einzigartig',
             'per-locale' => 'Sprach-basierend',

--- a/packages/Webkul/Admin/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en/app.php
@@ -151,6 +151,7 @@ return [
         'code' => 'Code',
         'admin-name' => 'Name',
         'name' => 'Name',
+        'copy' => 'Copy',
         'direction' => 'Direction',
         'fullname' => 'Full Name',
         'type' => 'Type',

--- a/packages/Webkul/Admin/src/Resources/views/promotions/cart-rules/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/promotions/cart-rules/edit.blade.php
@@ -1,3 +1,8 @@
+<?php
+/** @var array $selectedOptionIds */
+/** @var \Webkul\CartRule\Models\CartRule $cartRule */
+?>
+
 @extends('admin::layouts.content')
 
 @section('page_title')

--- a/tests/_support/FunctionalTester.php
+++ b/tests/_support/FunctionalTester.php
@@ -1,15 +1,11 @@
 <?php
 
-use Illuminate\Routing\RouteCollection;
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Route;
 use Webkul\User\Models\Admin;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Auth;
 use Webkul\Customer\Models\Customer;
-use Webkul\Customer\Models\CustomerAddress;
-use Webkul\Checkout\Models\Cart;
-use Webkul\Checkout\Models\CartItem;
-use Webkul\Checkout\Models\CartAddress;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Routing\RouteCollection;
 
 /**
  * Inherited Methods
@@ -90,10 +86,10 @@ class FunctionalTester extends \Codeception\Actor
     /**
      * @param string $name
      */
-    public function amOnAdminRoute(string $name)
+    public function amOnAdminRoute(string $name, array $params = [])
     {
         $I = $this;
-        $I->amOnRoute($name);
+        $I->amOnRoute($name, $params);
         $I->seeCurrentRouteIs($name);
 
         /** @var RouteCollection $routes */

--- a/tests/functional/CartRule/CartRuleCopyCest.php
+++ b/tests/functional/CartRule/CartRuleCopyCest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Functional\CartRule;
+
+use FunctionalTester;
+use Webkul\CartRule\Models\CartRule;
+
+class CartRuleCopyCest
+{
+
+    public function testCartRuleCopy(FunctionalTester $I)
+    {
+        $I->loginAsAdmin();
+
+        $original = $I->have(CartRule::class, [
+            'status' => 1,
+        ]);
+
+        $count = count(cartRule::all());
+
+        $I->amOnAdminRoute('admin.cart-rules.copy', ['id' => $original->id]);
+
+        $I->seeRecord(CartRule::class, [
+            'id'     => $original->id + 1,
+            'status' => 0,
+            'name'   => $original->name,
+        ]);
+
+        $I->assertCount($count + 1, CartRule::all());
+
+        $I->seeResponseCodeIsSuccessful();
+
+    }
+}

--- a/tests/functional/CartRule/CartRuleCreateCest.php
+++ b/tests/functional/CartRule/CartRuleCreateCest.php
@@ -2,13 +2,10 @@
 
 namespace Tests\Functional\CartRule;
 
-use Webkul\Product\Models\ProductAttributeValue;
-use Webkul\Product\Models\ProductFlat;
 use FunctionalTester;
-
 use Webkul\CartRule\Models\CartRule;
 
-class CartRuleCest
+class CartRuleCreateCest
 {
 
     public function testCartRuleCreation(FunctionalTester $I)


### PR DESCRIPTION
In our Marketplace we use a lot of cart rules and coupons. In order to make it easier for the administrators to manage them, we introduced a "copy cart rule" feature. One could think to adapt this for other models scattered thorough bagisto, this is just a start. What is your opinion?