### PR TITLE
add function to remove inactive products from cart

### DIFF
--- a/packages/Webkul/Checkout/src/Listeners/CustomerEventsHandler.php
+++ b/packages/Webkul/Checkout/src/Listeners/CustomerEventsHandler.php
@@ -20,6 +20,14 @@ class CustomerEventsHandler {
     }
 
     /**
+     * Handle cart changes
+     */
+    public function onCartChanged()
+    {
+        Cart::removeInactiveItems();
+    }
+
+    /**
      * Register the listeners for the subscriber.
      *
      * @param  \Illuminate\Events\Dispatcher  $events
@@ -28,5 +36,11 @@ class CustomerEventsHandler {
     public function subscribe($events)
     {
         $events->listen('customer.after.login', 'Webkul\Checkout\Listeners\CustomerEventsHandler@onCustomerLogin');
+
+        $events->listen('checkout.cart.add.before', 'Webkul\Checkout\Listeners\CustomerEventsHandler@onCartChanged');
+        $events->listen('checkout.cart.item.add.before', 'Webkul\Checkout\Listeners\CustomerEventsHandler@onCartChanged');
+
+        $events->listen('checkout.cart.update.before', 'Webkul\Checkout\Listeners\CustomerEventsHandler@onCartChanged');
+        $events->listen('checkout.cart.item.update.before', 'Webkul\Checkout\Listeners\CustomerEventsHandler@onCartChanged');
     }
 }

--- a/tests/unit/Checkout/Cart/CartCest.php
+++ b/tests/unit/Checkout/Cart/CartCest.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Tests\Unit\Checkout\Cart;
+
+use Faker\Factory;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+use UnitTester;
+use Webkul\Core\Helpers\Laravel5Helper;
+
+class CartCest
+{
+    private $faker;
+    private $simpleProduct1;
+    private $simpleProduct2;
+    private $virtualProduct1;
+    private $virtualProduct2;
+    private $downloadableProduct1;
+    private $downloadableProduct2;
+
+    public function _before(UnitTester $I)
+    {
+        $this->faker = Factory::create();
+
+        $this->sessionToken = $this->faker->uuid;
+        session(['_token' => $this->sessionToken]);
+
+        $this->simpleProduct1 = $I->haveProduct(Laravel5Helper::SIMPLE_PRODUCT);
+        cart()->addProduct($this->simpleProduct1->id, [
+            '_token'     => session('_token'),
+            'product_id' => $this->simpleProduct1->id,
+            'quantity'   => 1,
+        ]);
+
+        $this->simpleProduct2 = $I->haveProduct(Laravel5Helper::SIMPLE_PRODUCT);
+        cart()->addProduct($this->simpleProduct2->id, [
+            '_token'     => session('_token'),
+            'product_id' => $this->simpleProduct2->id,
+            'quantity'   => 1,
+        ]);
+
+        $this->virtualProduct1 = $I->haveProduct(Laravel5Helper::VIRTUAL_PRODUCT);
+        cart()->addProduct($this->virtualProduct1->id, [
+            '_token'     => session('_token'),
+            'product_id' => $this->virtualProduct1->id,
+            'quantity'   => 1,
+        ]);
+
+        $this->virtualProduct2 = $I->haveProduct(Laravel5Helper::VIRTUAL_PRODUCT);
+        cart()->addProduct($this->virtualProduct2->id, [
+            '_token'     => session('_token'),
+            'product_id' => $this->virtualProduct2->id,
+            'quantity'   => 1,
+        ]);
+
+        $this->downloadableProduct1 = $I->haveProduct(Laravel5Helper::DOWNLOADABLE_PRODUCT);
+
+        $this->downloadableProduct2 = $I->haveProduct(Laravel5Helper::DOWNLOADABLE_PRODUCT);
+    }
+
+    public function testCartWithInactiveProducts(UnitTester $I)
+    {
+        $I->comment('sP1, sP2, vP1 and vP2 in cart');
+        $I->assertEquals(4, count(cart()->getCart()->items));
+
+        $I->comment('deactivate sP2');
+        DB::table('product_attribute_values')
+            ->where([
+                'product_id'   => $this->simpleProduct2->id,
+                'attribute_id' => 8 // status
+            ])
+            ->update(['boolean_value' => 0]);
+
+        Event::dispatch('catalog.product.update.after', $this->simpleProduct2->refresh());
+
+        $I->assertFalse(cart()->hasError());
+        $I->comment('sP2 is inactive');
+        $I->assertEquals(3, count(cart()->getCart()->items));
+
+        $I->comment('add dP2 to cart');
+        cart()->addProduct($this->downloadableProduct2->id, [
+            '_token'     => session('_token'),
+            'product_id' => $this->downloadableProduct2->id,
+            'quantity'   => 1,
+            'links'      => $this->downloadableProduct2->downloadable_links->pluck('id')->all(),
+        ]);
+
+        $I->assertFalse(cart()->hasError());
+        $I->assertEquals(4, count(cart()->getCart()->items));
+
+        $I->comment('deactivate dP2');
+        DB::table('product_attribute_values')
+            ->where([
+                'product_id'   => $this->downloadableProduct2->id,
+                'attribute_id' => 8 // status
+            ])
+            ->update(['boolean_value' => 0]);
+
+        Event::dispatch('catalog.product.update.after', $this->downloadableProduct2->refresh());
+
+        $I->comment('we still have 4 products in cart as we didn`t changed cart itself');
+        $I->assertEquals(4, count(cart()->getCart()->items));
+
+        $I->comment('add dP1 to cart, dP2 should be removed now');
+        cart()->addProduct($this->downloadableProduct1->id, [
+            '_token'     => session('_token'),
+            'product_id' => $this->downloadableProduct1->id,
+            'quantity'   => 1,
+            'links'      => $this->downloadableProduct1->downloadable_links->pluck('id')->all(),
+        ]);
+
+        $I->assertEquals(4, count(cart()->getCart()->items));
+
+        $I->comment('deactivate vP2');
+        DB::table('product_attribute_values')
+            ->where([
+                'product_id'   => $this->virtualProduct2->id,
+                'attribute_id' => 8 // status
+            ])
+            ->update(['boolean_value' => 0]);
+
+        Event::dispatch('catalog.product.update.after', $this->virtualProduct2->refresh());
+
+        $I->comment('change quantity of vP1, vP2 should be removed now');
+        $cartItemId = $this->getCartItemIdFromProduct($this->virtualProduct1->id);
+        cart()->updateItems([
+            'qty' => [
+                $cartItemId => 5
+            ],
+        ]);
+        $I->assertEquals(3, count(cart()->getCart()->items));
+
+        $I->assertEquals(5, cart()->getCart()->items()->find($cartItemId)->quantity);
+    }
+
+    /**
+     * @param int $productId
+     *
+     * @return int|null
+     */
+    private function getCartItemIdFromProduct(int $productId): ?int
+    {
+        foreach(cart()->getCart()->items as $item) {
+            if ($item->product_id === $productId) {
+                return $item->id;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
**BUG:**
Let's suppose a customer has a product in cart, but doesn't checkout immediatly.

In the meanwhile the admin deactivates this product.

Now our customer goes to checkout and can buy this product successfully.

**Expected:**
The customer is not able to buy this product as it's deactivated.

**Solution:**
This PR introduces the functionality to check the cart for inactive products, every time a product is added or updated. This check also happens in function hasError() of Cart.php