### PR TITLE
Added support for checking bundle inventory, and bundle product inventory.

### DIFF
--- a/packages/Webkul/Product/src/Helpers/BundleOption.php
+++ b/packages/Webkul/Product/src/Helpers/BundleOption.php
@@ -35,6 +35,9 @@ class BundleOption extends AbstractProduct
     {
         $options = [];
 
+        # eager load all inventories for bundle options
+        $this->product->bundle_options->load('bundle_option_products.product.inventories');
+
         foreach ($this->product->bundle_options as $option) {
             $options[$option->id] = $this->getOptionItemData($option);
         }
@@ -87,6 +90,8 @@ class BundleOption extends AbstractProduct
                 'product_id' => $bundleOptionProduct->product_id,
                 'is_default' => $bundleOptionProduct->is_default,
                 'sort_order' => $bundleOptionProduct->sort_order,
+                'in_stock'  => $bundleOptionProduct->product->inventories->sum('qty') >= $bundleOptionProduct->qty,
+                'inventory'  => $bundleOptionProduct->product->inventories->sum('qty'),
             ];
         }
 

--- a/packages/Webkul/Product/src/Type/Bundle.php
+++ b/packages/Webkul/Product/src/Type/Bundle.php
@@ -172,7 +172,7 @@ class Bundle extends AbstractType
             if (count($optionProductsPrices)) {
                 $selectionMinPrice = min($optionProductsPrices);
 
-                if($option->is_required) {
+                if ($option->is_required) {
                     $minPrice += $selectionMinPrice;
                 } elseif (! $haveRequiredOptions) {
                     $minPrices[] = $selectionMinPrice;
@@ -206,7 +206,7 @@ class Bundle extends AbstractType
             if (count($optionProductsPrices)) {
                 $selectionMinPrice = min($optionProductsPrices);
 
-                if($option->is_required) {
+                if ($option->is_required) {
                     $minPrice += $selectionMinPrice;
                 } elseif (! $haveRequiredOptions) {
                     $minPrices[] = $selectionMinPrice;
@@ -661,7 +661,7 @@ class Bundle extends AbstractType
     {
         # to consider a bundle in stock we need to check that at least one product from each required group is available for the given quantity
         foreach ($this->product->bundle_options as $option) {
-            if($option->is_required) {
+            if ($option->is_required) {
                 foreach ($option->bundle_option_products as $bundleOptionProduct) {
                     # as long as at least one product in the required group is available we can continue checking other groups
                     if($bundleOptionProduct->product->haveSufficientQuantity($bundleOptionProduct->qty * $qty)) {

--- a/packages/Webkul/Product/src/Type/Bundle.php
+++ b/packages/Webkul/Product/src/Type/Bundle.php
@@ -652,4 +652,27 @@ class Bundle extends AbstractType
 
         return $options;
     }
+
+    /**
+     * @param  int  $qty
+     * @return bool
+     */
+    public function haveSufficientQuantity($qty)
+    {
+        # to consider a bundle in stock we need to check that at least one product from each required group is available for the given quantity
+        foreach ($this->product->bundle_options as $option) {
+            if($option->is_required) {
+                foreach ($option->bundle_option_products as $bundleOptionProduct) {
+                    # as long as at least one product in the required group is available we can continue checking other groups
+                    if($bundleOptionProduct->product->haveSufficientQuantity($bundleOptionProduct->qty * $qty)) {
+                        continue 2;
+                    }
+                }
+                # if any required option does not have any in-stock product option we will get here.
+                return false;
+            }
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
**BUGS:**
Bundle inventory is never properly display in the front end. For either the bundle as a whole, or the individual bundle items.

**SOLUTIONS**:

1. Implemented haveSufficientQuantity() in the Type\Bundle class in order to determine if a bundle as a whole should be considered in stock.
2. Added in_stock and inventory properties to the bundle option product data so that inventory checks on individual products in the bundle can be performed on the front end. NOTE: I dod not have time to implement #2 into the front end, but at least the data is available now.