### PR TITLE
bugfix: add default value for search term

### DIFF
--- a/packages/Webkul/Product/src/Repositories/SearchRepository.php
+++ b/packages/Webkul/Product/src/Repositories/SearchRepository.php
@@ -18,14 +18,15 @@ class SearchRepository extends Repository
     /**
      * Create a new repository instance.
      *
-     * @param  Webkul\Product\Repositories\ProductRepository $productRepository
+     * @param \Webkul\Product\Repositories\ProductRepository $productRepository
+     * @param \Illuminate\Container\Container                $app
+     *
      * @return void
      */
     public function __construct(
         ProductRepository $productRepository,
         App $app
-    )
-    {
+    ) {
         parent::__construct($app);
 
         $this->productRepository = $productRepository;
@@ -38,8 +39,6 @@ class SearchRepository extends Repository
 
     public function search($data)
     {
-        $products = $this->productRepository->searchProductByAttribute($data['term']);
-
-        return $products;
+        return $this->productRepository->searchProductByAttribute($data['term'] ?? '');
     }
 }

--- a/packages/Webkul/Velocity/src/Repositories/Product/ProductRepository.php
+++ b/packages/Webkul/Velocity/src/Repositories/Product/ProductRepository.php
@@ -105,7 +105,7 @@ class ProductRepository extends Repository
      */
     public function searchProductsFromCategory($params)
     {
-        $term = $params['term'];
+        $term = $params['term'] ?? '';
         $categoryId = $params['category'];
 
         $results = app(ProductFlatRepository::class)->scopeQuery(function($query) use($term, $categoryId, $params) {


### PR DESCRIPTION
In some cases, our customers call the search without any query parameter (even without `?term=`). This heads into an exception since `term` is required for search. 

This fix adds the empty string as the default value so if the search is called without `?term=` is handled like `?term=` is given.
