### PR TITLE
Add logging to exception thrown in cart

### DIFF
--- a/packages/Webkul/API/Http/Controllers/Shop/CartController.php
+++ b/packages/Webkul/API/Http/Controllers/Shop/CartController.php
@@ -72,7 +72,7 @@ class CartController extends Controller
     /**
      * Get customer cart
      *
-     * @return JsonResponse
+     * @return \Illuminate\Http\JsonResponse
      */
     public function get()
     {
@@ -126,7 +126,7 @@ class CartController extends Controller
             ]);
         } catch (Exception $e) {
             Log::error('API CartController: ' . $e->getMessage(),
-                ['productID' => $id, 'cartID' => cart()->getCart() ?? 0]);
+                ['product_id' => $id, 'cart_id' => cart()->getCart() ?? 0]);
 
             return response()->json([
                 'error' => [
@@ -140,7 +140,7 @@ class CartController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @return JsonResponse
+     * @return \Illuminate\Http\JsonResponse
      */
     public function update()
     {
@@ -175,7 +175,7 @@ class CartController extends Controller
     /**
      * Remove the specified resource from storage.
      *
-     * @return JsonResponse
+     * @return \Illuminate\Http\JsonResponse
      */
     public function destroy()
     {
@@ -198,7 +198,7 @@ class CartController extends Controller
      *
      * @param int $id
      *
-     * @return JsonResponse
+     * @return \Illuminate\Http\JsonResponse
      */
     public function destroyItem($id)
     {
@@ -223,7 +223,7 @@ class CartController extends Controller
      *
      * @param \Webkul\Checkout\Repositories\CartItemRepository $id
      *
-     * @return JsonResponse
+     * @return \Illuminate\Http\JsonResponse
      */
     public function moveToWishlist($id)
     {

--- a/packages/Webkul/Checkout/src/Cart.php
+++ b/packages/Webkul/Checkout/src/Cart.php
@@ -223,7 +223,7 @@ class Cart
         $cart = $this->cartRepository->create($cartData);
 
         if (! $cart) {
-            session()->flash('error', trans('shop::app.checkout.cart.create-error'));
+            session()->flash('error', __('shop::app.checkout.cart.create-error'));
 
             return;
         }
@@ -252,13 +252,13 @@ class Cart
             if ($quantity <= 0) {
                 $this->removeItem($itemId);
 
-                throw new Exception(trans('shop::app.checkout.cart.quantity.illegal'));
+                throw new Exception(__('shop::app.checkout.cart.quantity.illegal'));
             }
 
             $item->quantity = $quantity;
 
             if (! $this->isItemHaveQuantity($item)) {
-                throw new Exception(trans('shop::app.checkout.cart.quantity.inventory_warning'));
+                throw new Exception(__('shop::app.checkout.cart.quantity.inventory_warning'));
             }
 
             Event::dispatch('checkout.cart.update.before', $item);

--- a/packages/Webkul/Checkout/src/Cart.php
+++ b/packages/Webkul/Checkout/src/Cart.php
@@ -2,6 +2,8 @@
 
 namespace Webkul\Checkout;
 
+use Exception;
+use Illuminate\Support\Facades\Log;
 use Webkul\Checkout\Models\Cart as CartModel;
 use Webkul\Checkout\Models\CartAddress;
 use Webkul\Checkout\Repositories\CartRepository;
@@ -122,9 +124,11 @@ class Cart
     /**
      * Add Items in a cart with some cart and item details.
      *
-     * @param  int  $productId
-     * @param  array  $data
-     * @return \Webkul\Checkout\Contracts\Cart|\Exception|array
+     * @param int   $productId
+     * @param array $data
+     *
+     * @return \Webkul\Checkout\Contracts\Cart|string|array
+     * @throws Exception
      */
     public function addProduct($productId, $data)
     {
@@ -147,7 +151,8 @@ class Cart
                 session()->forget('cart');
             }
 
-            throw new \Exception($cartProducts);
+            Log::error($cartProducts, ['product' => $product, 'cartData' => $data]);
+            throw new Exception($cartProducts);
         } else {
             $parentCartItem = null;
 
@@ -161,7 +166,7 @@ class Cart
                 if (! $cartItem) {
                     $cartItem = $this->cartItemRepository->create(array_merge($cartProduct, ['cart_id' => $cart->id]));
                 } else {
-                    if (isset($cartProduct['parent_id']) && $cartItem->parent_id != $parentCartItem->id) {
+                    if (isset($cartProduct['parent_id']) && $cartItem->parent_id !== $parentCartItem->id) {
                         $cartItem = $this->cartItemRepository->create(array_merge($cartProduct, [
                             'cart_id' => $cart->id
                         ]));
@@ -232,7 +237,8 @@ class Cart
      * Update cart items information
      *
      * @param  array  $data
-     * @return bool|void|\Exception
+     *
+     * @return bool|void|Exception
      */
     public function updateItems($data)
     {
@@ -246,13 +252,13 @@ class Cart
             if ($quantity <= 0) {
                 $this->removeItem($itemId);
 
-                throw new \Exception(trans('shop::app.checkout.cart.quantity.illegal'));
+                throw new Exception(trans('shop::app.checkout.cart.quantity.illegal'));
             }
 
             $item->quantity = $quantity;
 
             if (! $this->isItemHaveQuantity($item)) {
-                throw new \Exception(trans('shop::app.checkout.cart.quantity.inventory_warning'));
+                throw new Exception(trans('shop::app.checkout.cart.quantity.inventory_warning'));
             }
 
             Event::dispatch('checkout.cart.update.before', $item);
@@ -499,7 +505,7 @@ class Cart
         $this->saveAddressesWhenRequested($data, $billingAddressData, $shippingAddressData);
 
         $this->linkAddresses($cart, $billingAddressData, $shippingAddressData);
-        
+
         $this->assignCustomerFields($cart);
 
         $cart->save();

--- a/packages/Webkul/Checkout/src/Cart.php
+++ b/packages/Webkul/Checkout/src/Cart.php
@@ -151,7 +151,6 @@ class Cart
                 session()->forget('cart');
             }
 
-            Log::error($cartProducts, ['product' => $product, 'cartData' => $data]);
             throw new Exception($cartProducts);
         } else {
             $parentCartItem = null;

--- a/packages/Webkul/Shop/src/Http/Controllers/CartController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/CartController.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Shop\Http\Controllers;
 
+use Illuminate\Support\Facades\Log;
 use Webkul\Customer\Repositories\WishlistRepository;
 use Webkul\Product\Repositories\ProductRepository;
 use Webkul\Checkout\Contracts\Cart as CartModel;
@@ -75,7 +76,7 @@ class CartController extends Controller
             }
 
             if ($result instanceof CartModel) {
-                session()->flash('success', trans('shop::app.checkout.cart.item.success'));
+                session()->flash('success', __('shop::app.checkout.cart.item.success'));
 
                 if ($customer = auth()->guard('customer')->user()) {
                     $this->wishlistRepository->deleteWhere(['product_id' => $id, 'customer_id' => $customer->id]);
@@ -88,9 +89,11 @@ class CartController extends Controller
                 }
             }
         } catch(\Exception $e) {
-            session()->flash('error', trans($e->getMessage()));
+            session()->flash('error', __($e->getMessage()));
 
             $product = $this->productRepository->find($id);
+
+            Log::error('Shop CartController: ' . $e->getMessage(), ['productID' => $id, 'cartID' => cart()->getCart() ?? 0]);
 
             return redirect()->route('shop.productOrCategory.index', $product->url_key);
         }

--- a/packages/Webkul/Shop/src/Http/Controllers/CartController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/CartController.php
@@ -93,7 +93,8 @@ class CartController extends Controller
 
             $product = $this->productRepository->find($id);
 
-            Log::error('Shop CartController: ' . $e->getMessage(), ['productID' => $id, 'cartID' => cart()->getCart() ?? 0]);
+            Log::error('Shop CartController: ' . $e->getMessage(),
+                ['product_id' => $id, 'cart_id' => cart()->getCart() ?? 0]);
 
             return redirect()->route('shop.productOrCategory.index', $product->url_key);
         }

--- a/packages/Webkul/Velocity/src/Http/Controllers/Shop/CartController.php
+++ b/packages/Webkul/Velocity/src/Http/Controllers/Shop/CartController.php
@@ -94,7 +94,8 @@ class CartController extends Controller
         } catch(\Exception $exception) {
             $product = $this->productRepository->find($id);
 
-            Log::error('Velocity CartController: ' . $exception->getMessage(), ['productID' => $id, 'cartID' => cart()->getCart() ?? 0]);
+            Log::error('Velocity CartController: ' . $exception->getMessage(),
+                ['product_id' => $id, 'cart_id' => cart()->getCart() ?? 0]);
 
             $response = [
                 'status'           => 'danger',

--- a/packages/Webkul/Velocity/src/Http/Controllers/Shop/CartController.php
+++ b/packages/Webkul/Velocity/src/Http/Controllers/Shop/CartController.php
@@ -3,6 +3,7 @@
 namespace Webkul\Velocity\Http\Controllers\Shop;
 
 use Cart;
+use Illuminate\Support\Facades\Log;
 use Webkul\Velocity\Helpers\Helper;
 use Webkul\Checkout\Contracts\Cart as CartModel;
 use Webkul\Product\Repositories\ProductRepository;
@@ -93,16 +94,18 @@ class CartController extends Controller
         } catch(\Exception $exception) {
             $product = $this->productRepository->find($id);
 
+            Log::error('Velocity CartController: ' . $exception->getMessage(), ['productID' => $id, 'cartID' => cart()->getCart() ?? 0]);
+
             $response = [
                 'status'           => 'danger',
-                'message'          => trans($exception->getMessage()),
+                'message'          => __($exception->getMessage()),
                 'redirectionRoute' => route('shop.productOrCategory.index', $product->url_key),
             ];
         }
 
         return $response ?? [
             'status'  => 'danger',
-            'message' => trans('velocity::app.error.something_went_wrong'),
+            'message' => __('velocity::app.error.something_went_wrong'),
         ];
     }
 


### PR DESCRIPTION
Whenever a product cannot be added to cart, an exception is thrown. 
This PR offers logging with context, when that exception occurs, making it possible to retrieve and repair the faulty product.

Provoking an exception is not that easy at that point. In order to test my changes, you could 

- create a new downloadable product
- in Product/Type/Downloadable.php, copy line 165 and paste it two lines above, i.e. to the very beginning of function `prepareForCart()`
- try to add the Downloadable to cart
- wait for the message: "Downloadable links are missing for this product."
- browse storage/logs/laravel.log, at the end of the file there should be the same message again, along with the product and cart data

```
[2020-06-09 11:40:36] local.ERROR: Downloadable links are missing for this product.
 {"product":{"Webkul\\Product\\Models\\Product":{"id":1,"sku":"1","type":"downloadable",
"created_at":"2020-06-09 11:36:01","updated_at":"2020-06-09 11:36:01",
"parent_id":null,"attribute_family_id":1,"short_description":"<p>Download 1</p>","description":"
<p>Download 1</p>","name":"Download 1","url_key":"download-1",
"tax_category_id":0,"new":0,"featured":1,"visible_individually":1,"status":1,"color":1,"size":6,
"brand":null,"guest_checkout":0,"meta_title":"","meta_keywords":"","meta_description":"",
"price":"10.0000","cost":null,"special_price":null,"special_price_from":null,
"special_price_to":null,"width":null,"height":null,"depth":null,"weight":null,
"attribute_family":{"id":1,"code":"default","name":"Default","status":0,"is_user_defined":1}}},
"cartData":{"is_buy_now":"0","_token":"scvjMwMDiOdkRebCeILKjslPHMVOX4tbXuNYwykL",
"product_id":"1","quantity":"1","links":["1"]}} 
```
