### PR TITLE
add a 'clear' button beneath date and datetime pickers

### DIFF
--- a/packages/Webkul/Ui/src/Resources/assets/js/components/date.vue
+++ b/packages/Webkul/Ui/src/Resources/assets/js/components/date.vue
@@ -1,15 +1,20 @@
 <template>
-	<span>
+	<span style="display: flex;align-items: center;">
 		<slot>
 			<input type="text" :name="name" class="control" :value="value" data-input>
 		</slot>
+        <button
+            class="btn"
+            style="height:100%;margin-left: 8px; margin-top: 5px;"
+            @click.prevent="clear"
+        > <span class="icon trash-icon"></span> </button>
 	</span>
 </template>
 
 <script>
-	import Flatpickr from 'flatpickr';
+import Flatpickr from 'flatpickr';
 
-	export default {
+export default {
 		props: {
 			name: String,
 			value: String,
@@ -27,12 +32,19 @@
 			var element = this.$el.getElementsByTagName('input')[0];
 			this.datepicker = new Flatpickr(
 				element, {
+                    allowInput: true,
 					altFormat: 'Y-m-d',
 					dateFormat: 'Y-m-d',
+                    weekNumbers: true,
 					onChange: function(selectedDates, dateStr, instance) {
 						this_this.$emit('onChange', dateStr)
 					},
 				});
-		}
+		},
+        methods: {
+            clear() {
+                this.datepicker.clear();
+            }
+        }
 	};
 </script>

--- a/packages/Webkul/Ui/src/Resources/assets/js/components/datetime.vue
+++ b/packages/Webkul/Ui/src/Resources/assets/js/components/datetime.vue
@@ -1,15 +1,20 @@
 <template>
-	<span>
+	<span style="display: flex;align-items: center;">
 		<slot>
 			<input type="text" :name="name" class="control" :value="value" data-input>
 		</slot>
+        <button
+            class="btn"
+            style="height:100%;margin-left: 8px; margin-top: 5px;"
+            @click.prevent="clear"
+        > <span class="icon trash-icon"></span> </button>
 	</span>
 </template>
 
 <script>
-    import Flatpickr from "flatpickr";
+import Flatpickr from "flatpickr";
 
-    export default {
+export default {
         props: {
             name: String,
             value: String
@@ -35,10 +40,17 @@
                 dateFormat: "Y-m-d H:i:S",
                 enableTime: true,
                 time_24hr: true,
+                weekNumbers: true,
                 onChange: function (selectedDates, dateStr, instance) {
                     this_this.$emit('onChange', dateStr)
                 },
             });
+        },
+
+        methods: {
+           clear() {
+               this.datepicker.clear();
+           }
         }
     };
 </script>


### PR DESCRIPTION
Bagisto is using https://flatpickr.js.org as date and datetime picker. Unfortunately this (wonderful!) plugin still has this bug:

https://github.com/flatpickr/flatpickr/pull/2092

which is not merged there yet and which makes it therefore unable to clear already typed datetime fields. This PR adds a small trash icon right to the pickers to make it able to clear the value inside like this:

![grafik](https://user-images.githubusercontent.com/654271/84245933-18a76b00-ab06-11ea-8170-9c5b252977af.png)
