### PR TITLE
update product_flat table with values when changing attribue->use_in_…

### DIFF
--- a/packages/Webkul/Product/src/Listeners/ProductFlat.php
+++ b/packages/Webkul/Product/src/Listeners/ProductFlat.php
@@ -137,7 +137,7 @@ class ProductFlat
                 }
             });
             
-            $this->productFlatRepository->updateAttributeColumn( $attribute );
+            $this->productFlatRepository->updateAttributeColumn( $attribute , $this );
             
         }
     }

--- a/packages/Webkul/Product/src/Listeners/ProductFlat.php
+++ b/packages/Webkul/Product/src/Listeners/ProductFlat.php
@@ -136,6 +136,10 @@ class ProductFlat
                     $table->dropColumn($attribute->code . '_label');
                 }
             });
+            
+            $query = "update product_flat f join product_attribute_values v on f.id = v.product_id and v.attribute_id = $attribute->id set f.$attribute->code = ". $attribute->type ."_value";
+            \DB::update($query);
+            
         }
     }
 

--- a/packages/Webkul/Product/src/Listeners/ProductFlat.php
+++ b/packages/Webkul/Product/src/Listeners/ProductFlat.php
@@ -137,8 +137,7 @@ class ProductFlat
                 }
             });
             
-            $query = "update product_flat f join product_attribute_values v on f.id = v.product_id and v.attribute_id = $attribute->id set f.$attribute->code = ". $attribute->type ."_value";
-            \DB::update($query);
+            $this->productFlatRepository->updateAttributeColumn( $attribute );
             
         }
     }

--- a/packages/Webkul/Product/src/Repositories/ProductFlatRepository.php
+++ b/packages/Webkul/Product/src/Repositories/ProductFlatRepository.php
@@ -92,13 +92,16 @@ class ProductFlatRepository extends Repository
      * update product_flat custom column
      * 
      * @param \Webkul\Attribute\Models\Attribute $attribute
+     * @param \Webkul\Product\Listeners\ProductFlat $listener
      */
-    public function updateAttributeColumn( \Webkul\Attribute\Models\Attribute $attribute ) {
+    public function updateAttributeColumn(
+        \Webkul\Attribute\Models\Attribute $attribute ,
+        \Webkul\Product\Listeners\ProductFlat $listener ) {
         return $this->model
             ->leftJoin('product_attribute_values as v', function($join) use ($attribute) {
                 $join->on('product_flat.id', '=', 'v.product_id')
                     ->on('v.attribute_id', '=', \DB::raw($attribute->id));
-            })->update(['product_flat.'.$attribute->code => \DB::raw($attribute->type .'_value')]);
+            })->update(['product_flat.'.$attribute->code => \DB::raw($listener->attributeTypeFields[$attribute->type] .'_value')]);
     }
 
 }

--- a/packages/Webkul/Product/src/Repositories/ProductFlatRepository.php
+++ b/packages/Webkul/Product/src/Repositories/ProductFlatRepository.php
@@ -86,4 +86,19 @@ class ProductFlatRepository extends Repository
 
         return $filterAttributes;
     }
+
+
+    /**
+     * update product_flat custom column
+     * 
+     * @param \Webkul\Attribute\Models\Attribute $attribute
+     */
+    public function updateAttributeColumn( \Webkul\Attribute\Models\Attribute $attribute ) {
+        return $this->model
+            ->leftJoin('product_attribute_values as v', function($join) use ($attribute) {
+                $join->on('product_flat.id', '=', 'v.product_id')
+                    ->on('v.attribute_id', '=', \DB::raw($attribute->id));
+            })->update(['product_flat.'.$attribute->code => \DB::raw($attribute->type .'_value')]);
+    }
+
 }


### PR DESCRIPTION

>Please describe the issue that you solved if its not filed.

When you update a product attribute to use_in_flat, the value within product_flat.attribute_name remains NULL if a product already exists.

This query that I added updates it to the values of the product.

closing this ticket: https://github.com/bagisto/bagisto/issues/3215

