### PR TITLE
Addresses required bundle options being removed if all product option…

### DIFF
--- a/packages/Webkul/Product/src/Helpers/BundleOption.php
+++ b/packages/Webkul/Product/src/Helpers/BundleOption.php
@@ -38,7 +38,7 @@ class BundleOption extends AbstractProduct
         foreach ($this->product->bundle_options as $option) {
             $data = $this->getOptionItemData($option);
 
-            if (! count($data['products'])) {
+            if (! $option->is_required && ! count($data['products'])) {
                 continue;
             }
 


### PR DESCRIPTION
Addresses missing portion of #3160

If a required bundle option has all of its products disabled it should not be removed from the bundle, because it is required.
