### PR TITLE
feature: expose downloadable links 

### DIFF
--- a/packages/Webkul/API/Http/Resources/Sales/Order.php
+++ b/packages/Webkul/API/Http/Resources/Sales/Order.php
@@ -100,10 +100,11 @@ class Order extends JsonResource
             'channel'                            => $this->when($this->channel_id, new ChannelResource($this->channel)),
             'shipping_address'                   => new OrderAddress($this->shipping_address),
             'billing_address'                    => new OrderAddress($this->billing_address),
-            'updated_at'                         => $this->updated_at,
             'items'                              => OrderItem::collection($this->items),
             'invoices'                           => Invoice::collection($this->invoices),
             'shipments'                          => Shipment::collection($this->shipments),
+            'downloadable_links'                 => $this->downloadable_link_purchased,
+            'updated_at'                         => $this->updated_at,
             'created_at'                         => $this->created_at,
         ];
     }

--- a/packages/Webkul/Sales/src/Models/OrderItem.php
+++ b/packages/Webkul/Sales/src/Models/OrderItem.php
@@ -213,6 +213,8 @@ class OrderItem extends Model implements OrderItemContract
 
         $array['qty_to_refund'] = $this->qty_to_refund;
 
+        $array['downloadable_links'] = $this->downloadable_link_purchased;
+
         return $array;
     }
 }


### PR DESCRIPTION
in API Resource\Sales\Order.php and src\Models\OrderItem.php

this is a suggestion to expose some data about downloadable links. We need this data for some custom adjustments to our shop system. Thanks a lot !