### PR TITLE
fixed issue #3381 and #3311 

### DIFF
--- a/packages/Webkul/Shop/src/Resources/views/customers/account/address/edit.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/customers/account/address/edit.blade.php
@@ -86,7 +86,7 @@
 
                     <div class="control-group" :class="[errors.has('city') ? 'has-error' : '']">
                         <label for="city" class="required">{{ __('shop::app.customer.account.address.create.city') }}</label>
-                        <input type="text" class="control" name="city" v-validate="'required|alpha_spaces'" value="{{ old('city') ?: $address->city }}" data-vv-as="&quot;{{ __('shop::app.customer.account.address.create.city') }}&quot;">
+                        <input type="text" class="control" name="city" v-validate="'required|regex:^[a-zA-Z \-]*$'" value="{{ old('city') ?: $address->city }}" data-vv-as="&quot;{{ __('shop::app.customer.account.address.create.city') }}&quot;">
                         <span class="control-error" v-if="errors.has('city')">@{{ errors.first('city') }}</span>
                     </div>
 

--- a/packages/Webkul/Velocity/src/Resources/views/shop/customers/account/address/edit.blade.php
+++ b/packages/Webkul/Velocity/src/Resources/views/shop/customers/account/address/edit.blade.php
@@ -79,7 +79,7 @@
 
             <div class="control-group" :class="[errors.has('city') ? 'has-error' : '']">
                 <label for="city" class="mandatory">{{ __('shop::app.customer.account.address.create.city') }}</label>
-                <input type="text" class="control" name="city" value="{{ old('city') ?? $address->city }}" v-validate="'required|alpha_spaces'" data-vv-as="&quot;{{ __('shop::app.customer.account.address.create.city') }}&quot;">
+                <input type="text" class="control" name="city" value="{{ old('city') ?? $address->city }}" v-validate="'required|regex:^[a-zA-Z \-]*$'" data-vv-as="&quot;{{ __('shop::app.customer.account.address.create.city') }}&quot;">
                 <span class="control-error" v-if="errors.has('city')">@{{ errors.first('city') }}</span>
             </div>
 

--- a/packages/Webkul/Velocity/src/Resources/views/shop/products/index.blade.php
+++ b/packages/Webkul/Velocity/src/Resources/views/shop/products/index.blade.php
@@ -91,7 +91,7 @@
 
                 @if ($isProductsDisplayMode)
                     <div class="filters-container">
-                        <template v-if="products.length > 0">
+                        <template v-if="products.length >= 0">
                             @include ('shop::products.list.toolbar')
                         </template>
                     </div>


### PR DESCRIPTION

1. When filtering on mobile, if you choose a filter combination that does not match any products the filters completely disappear, forcing you to use the back button to correct it. issue #3311  solved

2. When adding a new address for the customer, the validation on the city field is not allowing a hyphen. issue #3381 solved