### PR TITLE
Booking Product Bug: Additional data wont be saved

### DIFF
--- a/packages/Webkul/BookingProduct/src/Type/Booking.php
+++ b/packages/Webkul/BookingProduct/src/Type/Booking.php
@@ -186,13 +186,13 @@ class Booking extends Virtual
                     continue;
                 }
 
-                $cartProducts = parent::prepareForCart([
+                $cartProducts = parent::prepareForCart(array_merge($data, [
                     'product_id' => $data['product_id'],
                     'quantity'   => $qty,
                     'booking'    => [
                         'ticket_id' => $ticketId,
                     ],
-                ]);
+                ]));
 
                 if (is_string($cartProducts)) {
                     return $cartProducts;


### PR DESCRIPTION
If we pass additional data to a cart item, it's getting overwritten by this line. For example, if I want to use the API /api/checkout/cart/add/[some_product_id] and give it additional data it wont be saved. 

We have to array_merge the product_id, quantity and booking with the additional data that we passed to the item.