### PR TITLE
fixed issue #3311 in default theme

### DIFF
--- a/packages/Webkul/Shop/src/Resources/views/products/index.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/products/index.blade.php
@@ -46,9 +46,9 @@
                 @if (in_array($category->display_mode, [null, 'products_only', 'products_and_description']))
                     <?php $products = $productRepository->getAll($category->id); ?>
 
-                    @if ($products->count())
+                    @include ('shop::products.list.toolbar')
 
-                        @include ('shop::products.list.toolbar')
+                    @if ($products->count())
 
                         @inject ('toolbarHelper', 'Webkul\Product\Helpers\Toolbar')
 


### PR DESCRIPTION
 When filtering on mobile, if you choose a filter combination that does not match any products the filters completely disappear, forcing you to use the back button to correct it.

fixed issue #3311 in default theme 

