### PR TITLE
Fixed products per page configuration is not working properly #3533

### DIFF
--- a/packages/Webkul/Product/src/Repositories/ProductRepository.php
+++ b/packages/Webkul/Product/src/Repositories/ProductRepository.php
@@ -111,7 +111,7 @@ class ProductRepository extends Repository
         if (core()->getConfigData('catalog.products.storefront.products_per_page')) {
             $pages = explode(',', core()->getConfigData('catalog.products.storefront.products_per_page'));
 
-            $perPage = isset($params['limit']) ? $params['limit'] : current($pages);
+            $perPage = isset($params['limit']) ? (!empty($params['limit']) ? $params['limit'] : 9) : current($pages);
         } else {
             $perPage = isset($params['limit']) && !empty($params['limit']) ? $params['limit'] : 9;
         }


### PR DESCRIPTION
**BUGS:**
Link: https://github.com/bagisto/bagisto/issues/3533

If limit is set to 0 then the default value will set i.e. **9**.

If options are **0,5,10,15,0** then on zero it will show products according to default limit.