### PR TITLE
DB Prefix Issue Fix #3562

### DIFF
--- a/packages/Webkul/Product/src/Repositories/ProductRepository.php
+++ b/packages/Webkul/Product/src/Repositories/ProductRepository.php
@@ -125,7 +125,7 @@ class ProductRepository extends Repository
 
             $qb = $query->distinct()
                 ->select('product_flat.*')
-                ->join('product_flat as variants', 'product_flat.id', '=', DB::raw('COALESCE(variants.parent_id, variants.id)'))
+                ->join('product_flat as variants', 'product_flat.id', '=', DB::raw('COALESCE('.env('DB_PREFIX').'variants.parent_id, '.env('DB_PREFIX').'variants.id)'))
                 ->leftJoin('product_categories', 'product_categories.product_id', '=', 'product_flat.product_id')
                 ->leftJoin('product_attribute_values', 'product_attribute_values.product_id', '=', 'variants.product_id')
                 ->where('product_flat.channel', $channel)

--- a/packages/Webkul/Product/src/Repositories/ProductRepository.php
+++ b/packages/Webkul/Product/src/Repositories/ProductRepository.php
@@ -125,7 +125,7 @@ class ProductRepository extends Repository
 
             $qb = $query->distinct()
                 ->select('product_flat.*')
-                ->join('product_flat as variants', 'product_flat.id', '=', DB::raw('COALESCE('.env('DB_PREFIX').'variants.parent_id, '.env('DB_PREFIX').'variants.id)'))
+                ->join('product_flat as variants', 'product_flat.id', '=', DB::raw('COALESCE('.DB::getTablePrefix().'variants.parent_id, '.DB::getTablePrefix().'variants.id)'))
                 ->leftJoin('product_categories', 'product_categories.product_id', '=', 'product_flat.product_id')
                 ->leftJoin('product_attribute_values', 'product_attribute_values.product_id', '=', 'variants.product_id')
                 ->where('product_flat.channel', $channel)


### PR DESCRIPTION
**BUGS:**
Issue: https://github.com/bagisto/bagisto/issues/3562

On adding DB Prefixes, the error will be shown. This is because when we use raw queries Laravel will not detect DB prefixes. So need to concatenate with environment variable i.e. '**env()**' or '**DB::getTablePrefix()**'.