### PR TITLE
ProductDataGrid: Really show all products if it is wished

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/ProductDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/ProductDataGrid.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Admin\DataGrids;
 
+use Webkul\Core\Models\Locale;
 use Webkul\Ui\DataGrid\DataGrid;
 use Illuminate\Support\Facades\DB;
 use Webkul\Core\Models\Channel;
@@ -34,15 +35,27 @@ class ProductDataGrid extends DataGrid
         /* channel */
         $this->channel = request()->get('channel') ?? 'all';
 
-        /* finding channel name */
+        /* finding channel code */
         if ($this->channel !== 'all') {
-            $this->channel = Channel::find($this->channel);
+            $this->channel = Channel::query()->find($this->channel);
             $this->channel = $this->channel ? $this->channel->code : 'all';
         }
     }
 
     public function prepareQueryBuilder()
     {
+        if ($this->channel === 'all') {
+            $whereInChannels = Channel::query()->pluck('code')->toArray();
+        } else {
+            $whereInChannels = [$this->channel];
+        }
+
+        if ($this->locale === 'all') {
+            $whereInLocales = Locale::query()->pluck('code')->toArray();
+        } else {
+            $whereInLocales = [$this->locale];
+        }
+
         /* query builder */
         $queryBuilder = DB::table('product_flat')
             ->leftJoin('products', 'product_flat.product_id', '=', 'products.id')
@@ -62,12 +75,11 @@ class ProductDataGrid extends DataGrid
             );
 
         $queryBuilder->groupBy('product_flat.product_id', 'product_flat.locale', 'product_flat.channel');
-        $queryBuilder->where('locale', $this->locale !== 'all' ? $this->locale : 'en');
-       
-        if($this->channel !== 'all') {
-            $queryBuilder->where('channel', $this->channel );
-        }
-       
+
+        $queryBuilder->whereIn('product_flat.locale', $whereInLocales);
+        $queryBuilder->whereIn('product_flat.channel', $whereInChannels);
+        $queryBuilder->whereNotNull('product_flat.name');
+
         $this->addFilter('product_id', 'product_flat.product_id');
         $this->addFilter('product_name', 'product_flat.name');
         $this->addFilter('product_sku', 'products.sku');


### PR DESCRIPTION
I have fixed a small bug in the ProductDataGrid: If you have chosen no filter for channel and locale, the DataGrid did not show all products, but used fallbacks like "en" for the locale and "default" for the channel. 

You now should see all products for real in the DataGrid, as long as there is a name saved for the ProdutFlat for the specific locale/channel combination.