### PR TITLE
introduce CachableInterface for some Repositories (prettus)

### DIFF
--- a/config/repository.php
+++ b/config/repository.php
@@ -52,7 +52,7 @@ return [
          | Enable or disable cache
          |
          */
-        'enabled'    => false,
+        'enabled'    => true,
 
         /*
          |--------------------------------------------------------------------------

--- a/config/repository.php
+++ b/config/repository.php
@@ -138,8 +138,8 @@ return [
        | 'except'  =>['find'],
        */
         'allowed'    => [
-            'only'   => null,
-            'except' => null
+            'only'   => [],
+            'except' => ['findWhere']
         ]
     ],
 

--- a/packages/Webkul/Core/src/Repositories/ChannelRepository.php
+++ b/packages/Webkul/Core/src/Repositories/ChannelRepository.php
@@ -4,9 +4,12 @@ namespace Webkul\Core\Repositories;
 
 use Webkul\Core\Eloquent\Repository;
 use Illuminate\Support\Facades\Storage;
+use Prettus\Repository\Traits\CacheableRepository;
 
 class ChannelRepository extends Repository
 {
+    use CacheableRepository;
+
     /**
      * Specify Model class name
      *

--- a/packages/Webkul/Core/src/Repositories/CoreConfigRepository.php
+++ b/packages/Webkul/Core/src/Repositories/CoreConfigRepository.php
@@ -4,9 +4,12 @@ namespace Webkul\Core\Repositories;
 
 use Webkul\Core\Eloquent\Repository;
 use Illuminate\Support\Facades\Storage;
+use Prettus\Repository\Traits\CacheableRepository;
 
 class CoreConfigRepository extends Repository
 {
+    use CacheableRepository;
+
     /**
      * Specify Model class name
      *
@@ -111,7 +114,7 @@ class CoreConfigRepository extends Repository
      */
     public function recuressiveArray(array $formData, $method) {
         static $data = [];
-        
+
         static $recuressiveArrayData = [];
 
         foreach ($formData as $form => $formValue) {
@@ -119,7 +122,7 @@ class CoreConfigRepository extends Repository
 
             if (is_array($formValue)) {
                 $dim = $this->countDim($formValue);
-                
+
                 if ($dim > 1) {
                     $this->recuressiveArray($formValue, $value);
                 } elseif ($dim == 1) {
@@ -145,7 +148,7 @@ class CoreConfigRepository extends Repository
 
     /**
      * Return dimension of array
-     * 
+     *
      * @param  array  $array
      * @return int
     */

--- a/packages/Webkul/Core/src/Repositories/CountryRepository.php
+++ b/packages/Webkul/Core/src/Repositories/CountryRepository.php
@@ -3,9 +3,12 @@
 namespace Webkul\Core\Repositories;
 
 use Webkul\Core\Eloquent\Repository;
+use Prettus\Repository\Traits\CacheableRepository;
 
 class CountryRepository extends Repository
 {
+    use CacheableRepository;
+
     /**
      * Specify Model class name
      *

--- a/packages/Webkul/Core/src/Repositories/CountryStateRepository.php
+++ b/packages/Webkul/Core/src/Repositories/CountryStateRepository.php
@@ -3,9 +3,12 @@
 namespace Webkul\Core\Repositories;
 
 use Webkul\Core\Eloquent\Repository;
+use Prettus\Repository\Traits\CacheableRepository;
 
 class CountryStateRepository extends Repository
 {
+    use CacheableRepository;
+
     /**
      * Specify Model class name
      *

--- a/packages/Webkul/Core/src/Repositories/CurrencyRepository.php
+++ b/packages/Webkul/Core/src/Repositories/CurrencyRepository.php
@@ -3,9 +3,12 @@
 namespace Webkul\Core\Repositories;
 
 use Webkul\Core\Eloquent\Repository;
+use Prettus\Repository\Traits\CacheableRepository;
 
 class CurrencyRepository extends Repository
 {
+    use CacheableRepository;
+
     /**
      * Specify Model class name
      *

--- a/packages/Webkul/Core/src/Repositories/ExchangeRateRepository.php
+++ b/packages/Webkul/Core/src/Repositories/ExchangeRateRepository.php
@@ -3,9 +3,12 @@
 namespace Webkul\Core\Repositories;
 
 use Webkul\Core\Eloquent\Repository;
+use Prettus\Repository\Traits\CacheableRepository;
 
 class ExchangeRateRepository extends Repository
 {
+    use CacheableRepository;
+
     /**
      * Specify Model class name
      *

--- a/packages/Webkul/Core/src/Repositories/LocaleRepository.php
+++ b/packages/Webkul/Core/src/Repositories/LocaleRepository.php
@@ -3,9 +3,12 @@
 namespace Webkul\Core\Repositories;
 
 use Webkul\Core\Eloquent\Repository;
+use Prettus\Repository\Traits\CacheableRepository;
 
 class LocaleRepository extends Repository
 {
+    use CacheableRepository;
+
     /**
      * Specify Model class name
      *

--- a/packages/Webkul/Core/src/Repositories/SliderRepository.php
+++ b/packages/Webkul/Core/src/Repositories/SliderRepository.php
@@ -3,14 +3,16 @@
 namespace Webkul\Core\Repositories;
 
 use Storage;
+use Illuminate\Support\Arr;
 use Webkul\Core\Eloquent\Repository;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Container\Container as App;
-use Webkul\Core\Repositories\ChannelRepository;
-use Illuminate\Support\Arr;
+use Prettus\Repository\Traits\CacheableRepository;
 
 class SliderRepository extends Repository
 {
+    use CacheableRepository;
+
     /**
      * ChannelRepository object
      *

--- a/packages/Webkul/Core/src/Repositories/SubscribersListRepository.php
+++ b/packages/Webkul/Core/src/Repositories/SubscribersListRepository.php
@@ -2,11 +2,13 @@
 
 namespace Webkul\Core\Repositories;
 
-use Illuminate\Container\Container as App;
 use Webkul\Core\Eloquent\Repository;
+use Prettus\Repository\Traits\CacheableRepository;
 
 class SubscribersListRepository extends Repository
 {
+    use CacheableRepository;
+
     /**
      * Specify Model class name
      *

--- a/packages/Webkul/Velocity/src/Repositories/CategoryRepository.php
+++ b/packages/Webkul/Velocity/src/Repositories/CategoryRepository.php
@@ -2,12 +2,14 @@
 
 namespace Webkul\Velocity\Repositories;
 
-use Illuminate\Container\Container as App;
 use Webkul\Core\Eloquent\Repository;
-use Webkul\Category\Repositories\CategoryRepository as Category;
+use Illuminate\Container\Container as App;
+use Prettus\Repository\Traits\CacheableRepository;
 
 class CategoryRepository extends Repository
-{   
+{
+    use CacheableRepository;
+
    /**
     * Category Repository object
     *
@@ -54,12 +56,12 @@ class CategoryRepository extends Repository
         $velocityCategories = $this->model->all(['category_id']);
 
         $categoryMenues = json_decode(json_encode($velocityCategories), true);
-        
+
         $categories = $this->categoryRepository->getVisibleCategoryTree(core()->getCurrentChannel()->root_category_id);
 
         if (isset($categories->first()->id)) {
             foreach ($categories as $category) {
-                
+
                 if (! empty($categoryMenues) && !in_array($category->id, array_column($categoryMenues, 'category_id'))) {
                     $results[] = [
                         'id'   => $category->id,

--- a/packages/Webkul/Velocity/src/Repositories/ContentRepository.php
+++ b/packages/Webkul/Velocity/src/Repositories/ContentRepository.php
@@ -2,13 +2,15 @@
 
 namespace Webkul\Velocity\Repositories;
 
-use Illuminate\Container\Container as App;
 use Webkul\Core\Eloquent\Repository;
-use Illuminate\Support\Facades\Event;
+use Illuminate\Container\Container as App;
 use Webkul\Product\Repositories\ProductRepository;
+use Prettus\Repository\Traits\CacheableRepository;
 
 class ContentRepository extends Repository
 {
+    use CacheableRepository;
+
    /**
     * Product Repository object
     *
@@ -149,7 +151,7 @@ class ContentRepository extends Repository
             ->get();
 
         $formattedContent = [];
-        
+
         foreach ($contentCollection as $content) {
             array_push($formattedContent, [
                 'title'        => $content->title,
@@ -158,7 +160,7 @@ class ContentRepository extends Repository
                 'content_type' => $content->content_type,
             ]);
         }
-        
+
         return $formattedContent;
     }
 }

--- a/packages/Webkul/Velocity/src/Repositories/ContentTranslationRepository.php
+++ b/packages/Webkul/Velocity/src/Repositories/ContentTranslationRepository.php
@@ -3,9 +3,12 @@
 namespace Webkul\Velocity\Repositories;
 
 use Webkul\Core\Eloquent\Repository;
+use Prettus\Repository\Traits\CacheableRepository;
 
 class ContentTranslationRepository extends Repository
 {
+    use CacheableRepository;
+
     /**
      * Specify Model class name
      *

--- a/packages/Webkul/Velocity/src/Repositories/OrderBrandsRepository.php
+++ b/packages/Webkul/Velocity/src/Repositories/OrderBrandsRepository.php
@@ -3,14 +3,17 @@
 namespace Webkul\Velocity\Repositories;
 
 use Webkul\Core\Eloquent\Repository;
+use Prettus\Repository\Traits\CacheableRepository;
 
 /**
- * OrderBrands Reposotory
+ * OrderBrands Repository
  *
  * @copyright 2019 Webkul Software Pvt Ltd (http://www.webkul.com)
  */
 class OrderBrandsRepository extends Repository
-{   
+{
+    use CacheableRepository;
+
     /**
      * Specify Model class name
      *
@@ -20,5 +23,5 @@ class OrderBrandsRepository extends Repository
     {
         return 'Webkul\Velocity\Contracts\OrderBrand';
     }
-    
+
 }

--- a/packages/Webkul/Velocity/src/Repositories/Product/ProductRepository.php
+++ b/packages/Webkul/Velocity/src/Repositories/Product/ProductRepository.php
@@ -5,11 +5,14 @@ namespace Webkul\Velocity\Repositories\Product;
 use Webkul\Core\Eloquent\Repository;
 use Illuminate\Container\Container as App;
 use Webkul\Product\Models\ProductAttributeValue;
+use Prettus\Repository\Traits\CacheableRepository;
 use Webkul\Product\Repositories\ProductFlatRepository;
 use Webkul\Attribute\Repositories\AttributeRepository;
 
 class ProductRepository extends Repository
 {
+    use CacheableRepository;
+
      /**
      * AttributeRepository object
      *

--- a/packages/Webkul/Velocity/src/Repositories/ReviewRepository.php
+++ b/packages/Webkul/Velocity/src/Repositories/ReviewRepository.php
@@ -3,14 +3,17 @@
 namespace Webkul\Velocity\Repositories;
 
 use Webkul\Core\Eloquent\Repository;
+use Prettus\Repository\Traits\CacheableRepository;
 
 /**
- * Review Reposotory
+ * Review Repository
  *
  * @copyright 2019 Webkul Software Pvt Ltd (http://www.webkul.com)
  */
 class ReviewRepository extends Repository
 {
+    use CacheableRepository;
+
     /**
      * Specify Model class name
      *
@@ -22,10 +25,10 @@ class ReviewRepository extends Repository
     }
 
 
-    function getAll() 
+    function getAll()
     {
         $reviews = $this->model->get();
-        
+
         return $reviews;
     }
 }


### PR DESCRIPTION
For some requests in Bagisto there are a lot of SQL queries being sent to the attached SQL server multiple times. 
Luckily, the prettus Repository Pattern that is being used in Bagisto thorough almost the whole application is being able to add a simple cache to leverage this problem. This PR adds the `CacheableInterface` to some of the major Repositories that Bagisto have implemented in order to reduce the amount of duplicated SQL queries sent to the server.