### PR TITLE
Fixed a typo in checkForEnvFile()

### DIFF
--- a/packages/Webkul/Core/src/Console/Commands/Install.php
+++ b/packages/Webkul/Core/src/Console/Commands/Install.php
@@ -81,7 +81,7 @@ class Install extends Command
             $this->info('Creating the environment configuration file.');
             $this->createEnvFile();
         } else {
-            $this->info('Great! your environment configuration file aready exists.');
+            $this->info('Great! your environment configuration file already exists.');
         }
     }
 


### PR DESCRIPTION
Fixed a typo in functions => checkForEnvFile() : changed "aready" to "already".