### PR TITLE
No regular and final price in the product resource to compare between them on the frontend

### DIFF
--- a/packages/Webkul/API/Http/Resources/Catalog/Product.php
+++ b/packages/Webkul/API/Http/Resources/Catalog/Product.php
@@ -30,6 +30,8 @@ class Product extends JsonResource
     public function toArray($request)
     {
         $product = $this->product ? $this->product : $this;
+        
+        $prices = $product->getTypeInstance()->getProductPrices();
 
         return [
             'id'                     => $product->id,
@@ -56,7 +58,8 @@ class Product extends JsonResource
                     $product->getTypeInstance()->haveSpecialPrice(),
                     core()->currency($product->getTypeInstance()->getSpecialPrice())
                 ),
-            'prices'                 => $product->getTypeInstance()->getProductPrices(),
+            'regular_price'           => data_get($prices, 'regular_price.price'),
+            'formatted_regular_price' => data_get($prices, 'regular_price.formated_price'),
             'reviews'                => [
                 'total'          => $total = $this->productReviewHelper->getTotalReviews($product),
                 'total_rating'   => $total ? $this->productReviewHelper->getTotalRating($product) : 0,

--- a/packages/Webkul/API/Http/Resources/Catalog/Product.php
+++ b/packages/Webkul/API/Http/Resources/Catalog/Product.php
@@ -59,7 +59,7 @@ class Product extends JsonResource
                     core()->currency($product->getTypeInstance()->getSpecialPrice())
                 ),
             'regular_price'           => data_get($prices, 'regular_price.price'),
-            'formatted_regular_price' => data_get($prices, 'regular_price.formated_price'),
+            'formated_regular_price' => data_get($prices, 'regular_price.formated_price'),
             'reviews'                => [
                 'total'          => $total = $this->productReviewHelper->getTotalReviews($product),
                 'total_rating'   => $total ? $this->productReviewHelper->getTotalRating($product) : 0,

--- a/packages/Webkul/API/Http/Resources/Catalog/Product.php
+++ b/packages/Webkul/API/Http/Resources/Catalog/Product.php
@@ -56,7 +56,7 @@ class Product extends JsonResource
                     $product->getTypeInstance()->haveSpecialPrice(),
                     core()->currency($product->getTypeInstance()->getSpecialPrice())
                 ),
-            $product->getTypeInstance()->getProductPrices(),
+            'prices'                 => $product->getTypeInstance()->getProductPrices(),
             'reviews'                => [
                 'total'          => $total = $this->productReviewHelper->getTotalReviews($product),
                 'total_rating'   => $total ? $this->productReviewHelper->getTotalRating($product) : 0,

--- a/packages/Webkul/API/Http/Resources/Catalog/Product.php
+++ b/packages/Webkul/API/Http/Resources/Catalog/Product.php
@@ -56,6 +56,7 @@ class Product extends JsonResource
                     $product->getTypeInstance()->haveSpecialPrice(),
                     core()->currency($product->getTypeInstance()->getSpecialPrice())
                 ),
+            $product->getTypeInstance()->getProductPrices(),
             'reviews'                => [
                 'total'          => $total = $this->productReviewHelper->getTotalReviews($product),
                 'total_rating'   => $total ? $this->productReviewHelper->getTotalRating($product) : 0,

--- a/packages/Webkul/API/Http/Resources/Catalog/Product.php
+++ b/packages/Webkul/API/Http/Resources/Catalog/Product.php
@@ -58,7 +58,7 @@ class Product extends JsonResource
                     $product->getTypeInstance()->haveSpecialPrice(),
                     core()->currency($product->getTypeInstance()->getSpecialPrice())
                 ),
-            'regular_price'           => data_get($prices, 'regular_price.price'),
+            'regular_price'          => data_get($prices, 'regular_price.price'),
             'formated_regular_price' => data_get($prices, 'regular_price.formated_price'),
             'reviews'                => [
                 'total'          => $total = $this->productReviewHelper->getTotalReviews($product),


### PR DESCRIPTION
Added regular and final price to the product resource so that it is much easier to compare between them on the frontend

**BUGS:**

>The product resource did not include the original price if there was a special price for the product. The PR adds both the original price and the final price to the resource so that it is easier to compare both in the frontend