### PR TITLE
Test Case Update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
       - name: Composer install
         run: |
           set -e
-          composer global require hirak/prestissimo
           composer install --no-interaction --ansi --no-progress --no-suggest --optimize-autoloader
 
       - name: Migrate database


### PR DESCRIPTION
Composer 2.0 has parallel downloads, so this package i.e. `hirak/prestissimo` not needed anymore.