### PR TITLE
Allow to disable actions on a per-row (per-record) basis

### DIFF
--- a/packages/Webkul/Ui/src/Resources/views/datagrid/body.blade.php
+++ b/packages/Webkul/Ui/src/Resources/views/datagrid/body.blade.php
@@ -43,7 +43,7 @@
                         <div class="action">
                             @foreach ($actions as $action)
                                 @php
-                                    $toDisplay = (isset($action['condition']) && gettype($action['condition']) == 'object') ? $action['condition']() : true;
+                                    $toDisplay = (isset($action['condition']) && gettype($action['condition']) == 'object') ? $action['condition']($record) : true;
                                 @endphp
 
                                 @if ($toDisplay)


### PR DESCRIPTION
When adding actions to a dataGrid the `condition` key can be specified. It can hold a function which currently doesn't receive any parameters.

When we pass the record here we allow developers to decide whether or not to show a action on a per-row (per-record) basis, so showing an action for some items, hiding it for others.