### PR TITLE
While creating/updating Channel, make logo an favicon nullable

### DIFF
--- a/packages/Webkul/Core/src/Http/Controllers/ChannelController.php
+++ b/packages/Webkul/Core/src/Http/Controllers/ChannelController.php
@@ -69,8 +69,8 @@ class ChannelController extends Controller
             'currencies'        => 'required|array|min:1',
             'base_currency_id'  => 'required|in_array:currencies.*',
             'root_category_id'  => 'required',
-            'logo.*'            => 'mimes:bmp,jpeg,jpg,png,webp',
-            'favicon.*'         => 'mimes:bmp,jpeg,jpg,png,webp',
+            'logo.*'            => 'nullable|mimes:bmp,jpeg,jpg,png,webp',
+            'favicon.*'         => 'nullable|mimes:bmp,jpeg,jpg,png,webp',
             'seo_title'         => 'required|string',
             'seo_description'   => 'required|string',
             'seo_keywords'      => 'required|string',
@@ -132,8 +132,8 @@ class ChannelController extends Controller
             'currencies'        => 'required|array|min:1',
             'base_currency_id'  => 'required|in_array:currencies.*',
             'root_category_id'  => 'required',
-            'logo.*'            => 'mimes:bmp,jpeg,jpg,png,webp',
-            'favicon.*'         => 'mimes:bmp,jpeg,jpg,png,webp',
+            'logo.*'            => 'nullable|mimes:bmp,jpeg,jpg,png,webp',
+            'favicon.*'         => 'nullable|mimes:bmp,jpeg,jpg,png,webp',
             'hostname'          => 'unique:channels,hostname,' . $id,
         ]);
 


### PR DESCRIPTION
When creating or updating channel in administration, validation will silently fail if you don't select Logo and Favicon image.
Both fields should have **nullable** validation rule too!