### PR TITLE
Fix reading typeInstance from the product instead of the orderITem

### DIFF
--- a/packages/Webkul/Sales/src/Models/OrderItem.php
+++ b/packages/Webkul/Sales/src/Models/OrderItem.php
@@ -33,7 +33,7 @@ class OrderItem extends Model implements OrderItemContract
             return $this->typeInstance;
         }
 
-        $this->typeInstance = app(config('product_types.' . $this->type . '.class'));
+        $this->typeInstance = app(config('product_types.' . ($this->product()->first())->type . '.class'));
 
         if ($this->product) {
             $this->typeInstance->setProduct($this);


### PR DESCRIPTION
An OrderItem has no 'type' attribute. Thus, this information needs to be read from the associated product, else the admin dashboard will fail when there is an order in the system.