### PR TITLE
Make VatIdRule accept empty strings as VAT id

### DIFF
--- a/packages/Webkul/Customer/src/Rules/VatIdRule.php
+++ b/packages/Webkul/Customer/src/Rules/VatIdRule.php
@@ -27,7 +27,7 @@ class VatIdRule implements Rule
     {
         $validator = new VatValidator();
 
-        return $validator->validate($value);
+        return empty($value) || $validator->validate($value);
     }
 
     /**


### PR DESCRIPTION
Currently when trying to save any european address with an empty VAT ID an exception is thrown because the VatValidator's [validate() method](https://github.com/bagisto/bagisto/blob/master/packages/Webkul/Customer/src/Rules/VatValidator.php#L53) requires a string argument, in the given case it is NULL though, leading to a php exception