### PR TITLE
Fix security risk for null emails

### DIFF
--- a/packages/Webkul/SocialLogin/src/Repositories/CustomerSocialAccountRepository.php
+++ b/packages/Webkul/SocialLogin/src/Repositories/CustomerSocialAccountRepository.php
@@ -71,7 +71,7 @@ class CustomerSocialAccountRepository extends Repository
         if ($account) {
             return $account->customer;
         } else {
-            $customer = $this->customerRepository->findOneByField('email', $providerUser->getEmail());
+            $customer = $providerUser->getEmail()?$this->customerRepository->findOneByField('email', $providerUser->getEmail()):null;
  
             if (! $customer) {
                 $names = $this->getFirstLastName($providerUser->getName());

--- a/packages/Webkul/SocialLogin/src/Repositories/CustomerSocialAccountRepository.php
+++ b/packages/Webkul/SocialLogin/src/Repositories/CustomerSocialAccountRepository.php
@@ -71,7 +71,7 @@ class CustomerSocialAccountRepository extends Repository
         if ($account) {
             return $account->customer;
         } else {
-            $customer = $providerUser->getEmail()?$this->customerRepository->findOneByField('email', $providerUser->getEmail()):null;
+            $customer = $providerUser->getEmail() ? $this->customerRepository->findOneByField('email', $providerUser->getEmail()) : null;
  
             if (! $customer) {
                 $names = $this->getFirstLastName($providerUser->getName());


### PR DESCRIPTION
**BUGS:**
The returned email from Facebook is sometimes `null`. Bagisto tries to match the returned email from Facebook against the database, which would allow logins to accounts that have a `null` email which may not belong to the Facebook user trying to login, and therefore such user accounts might be breached.

This commit checks for `null` emails first, and returns a `null` customer instead of the first customer with a `null` email.


