### PR TITLE
Resources Path Removed From Marketing Provider

### DIFF
--- a/packages/Webkul/Marketing/src/Providers/MarketingServiceProvider.php
+++ b/packages/Webkul/Marketing/src/Providers/MarketingServiceProvider.php
@@ -3,7 +3,6 @@
 namespace Webkul\Marketing\Providers;
 
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Support\Facades\Event;
 use Webkul\Marketing\Console\Commands\EmailsCommand;
 
 class MarketingServiceProvider extends ServiceProvider
@@ -27,7 +26,6 @@ class MarketingServiceProvider extends ServiceProvider
      */
     public function register()
     {
-
         if ($this->app->runningInConsole()) {
             $this->commands([EmailsCommand::class]);
         }

--- a/packages/Webkul/Marketing/src/Providers/MarketingServiceProvider.php
+++ b/packages/Webkul/Marketing/src/Providers/MarketingServiceProvider.php
@@ -18,10 +18,6 @@ class MarketingServiceProvider extends ServiceProvider
         $this->loadMigrationsFrom(__DIR__ . '/../Database/Migrations');
 
         $this->loadRoutesFrom(__DIR__ . '/../Http/routes.php');
-
-        $this->loadTranslationsFrom(__DIR__ . '/../Resources/lang', 'marketing');
-
-        $this->loadViewsFrom(__DIR__ . '/../Resources/views', 'marketing');
     }
 
     /**
@@ -31,7 +27,7 @@ class MarketingServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        
+
         if ($this->app->runningInConsole()) {
             $this->commands([EmailsCommand::class]);
         }


### PR DESCRIPTION
Removed resources path from the marketing service provider because there is no resources path. Due to which `php artisan view:cache` won't work.