### PR TITLE
Dynamic url for route checking added for datagrids

### DIFF
--- a/packages/Webkul/Ui/src/DataGrid/DataGrid.php
+++ b/packages/Webkul/Ui/src/DataGrid/DataGrid.php
@@ -818,8 +818,7 @@ abstract class DataGrid
     private function getRouteNameFromUrl($action, $method)
     {
         return app('router')->getRoutes()
-                            ->match(app('request')
-                            ->create(str_replace(config('app.url'), '', $action), $method))
+                            ->match(app('request')->create(str_replace(url('/'), '', $action), $method))
                             ->getName();
     }
 }


### PR DESCRIPTION
## Issue

- When you are working on the `localhost` in data grids, it might be working. But when you try to use via IP or some other host it won't work because of checking the URL from `.env`.
- If `.env` not updated, then an exception will be occurred on all data grids with `massdelete`, `massupdate`, `delete`, `edit`, etc. methods.

## Addition

- Added `url('\')` method for checking the case, so that it won't rely on `.env`.

## Earlier related PR
PR Link: https://github.com/bagisto/bagisto/pull/4464