### PR TITLE
Two properties moved to abstract class

### DIFF
--- a/packages/Webkul/Product/src/Type/AbstractType.php
+++ b/packages/Webkul/Product/src/Type/AbstractType.php
@@ -134,6 +134,20 @@ abstract class AbstractType
     protected $productOptions = [];
 
     /**
+     * Skip attribute for simple product type.
+     *
+     * @var array
+     */
+    protected $skipAttributes = [];
+
+    /**
+     * These blade files will be included in product edit page.
+     *
+     * @var array
+     */
+    protected $additionalViews = [];
+
+    /**
      * Create a new product type instance.
      *
      * @param \Webkul\Attribute\Repositories\AttributeRepository           $attributeRepository

--- a/packages/Webkul/Product/src/Type/Simple.php
+++ b/packages/Webkul/Product/src/Type/Simple.php
@@ -5,13 +5,6 @@ namespace Webkul\Product\Type;
 class Simple extends AbstractType
 {
     /**
-     * Skip attribute for simple product type
-     *
-     * @var array
-     */
-    protected $skipAttributes = [];
-
-    /**
      * These blade files will be included in product edit page
      *
      * @var array


### PR DESCRIPTION
## Enhancement
When I tried to create a new product type then two properties i.e. `$skipAttributes` and `$additionalViews` also needed after extending with the `AbstractType` class which throws error.

## Additions
- When creating new product types just need to extend the class and everything will be working fine.