### PR TITLE
Fixed add a product to wishlist twice issue #4597

### DIFF
--- a/packages/Webkul/API/Http/Resources/Catalog/Product.php
+++ b/packages/Webkul/API/Http/Resources/Catalog/Product.php
@@ -61,7 +61,7 @@ class Product extends JsonResource
             /* product's checks */
             'in_stock'               => $product->haveSufficientQuantity(1),
             'is_saved'               => false,
-            'is_wishlisted'          => $this->wishlistHelper->getWishlistProduct($product),
+            'is_wishlisted'          => $this->wishlistHelper->getWishlistProduct($product) ? true : false,
             'is_item_in_cart'        => \Cart::hasProduct($product),
             'show_quantity_changer'  => $this->when(
                 $product->type !== 'grouped',

--- a/packages/Webkul/Customer/src/Helpers/Wishlist.php
+++ b/packages/Webkul/Customer/src/Helpers/Wishlist.php
@@ -43,9 +43,9 @@ class Wishlist
         }
 
         if ($wishlist) {
-            return true;
+            return $wishlist;
         }
 
-        return false;
+        return null;
     }
 }

--- a/packages/Webkul/Shop/src/Resources/views/products/view/gallery.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/products/view/gallery.blade.php
@@ -194,7 +194,7 @@
                 $('img#pro-img').data('zoom-image', $('img#pro-img').data('image')).ezPlus();
             }
 
-            var wishlist = " <?php echo $wishListHelper->getWishlistProduct($product);  ?> ";
+            var wishlist = "{{ $wishListHelper->getWishlistProduct($product) ? 'true' : 'false' }}";
 
             $(document).mousemove(function(event) {
                 if ($('.add-to-wishlist').length || wishlist != 0) {

--- a/packages/Webkul/Velocity/src/Resources/views/shop/products/wishlist.blade.php
+++ b/packages/Webkul/Velocity/src/Resources/views/shop/products/wishlist.blade.php
@@ -4,22 +4,22 @@
 
     @auth('customer')
         @php
-            $isWished = $wishListHelper->getWishlistProduct($product);
+            /* search wishlist on the basis of product's id so that wishlist id can be catched */
+            $wishlist = $wishListHelper->getWishlistProduct($product);
+
+            /* link making */
+            $href = isset($route) ? $route : ($wishlist ? route('customer.wishlist.remove', $wishlist->id) : route('customer.wishlist.add', $product->product_id));
+
+            /* title */
+            $title = $wishlist ? __('velocity::app.shop.wishlist.remove-wishlist-text') : __('velocity::app.shop.wishlist.add-wishlist-text');
         @endphp
 
         <a
             class="unset wishlist-icon {{ $addWishlistClass ?? '' }} text-right"
-            @if(isset($route))
-                href="{{ $route }}"
-            @elseif (! $isWished)
-                href="{{ route('customer.wishlist.add', $product->product_id) }}"
-                title="{{ __('velocity::app.shop.wishlist.add-wishlist-text') }}"
-            @elseif (isset($itemId) && $itemId)
-                href="{{ route('customer.wishlist.remove', $itemId) }}"
-                title="{{ __('velocity::app.shop.wishlist.remove-wishlist-text') }}"
-            @endif>
+            href="{{ $href }}"
+            title="{{ $title }}">
 
-            <wishlist-component active="{{ ! $isWished }}"></wishlist-component>
+            <wishlist-component active="{{ $wishlist ? false : true }}"></wishlist-component>
 
             @if (isset($text))
                 {!! $text !!}


### PR DESCRIPTION
## Bugs
Link: https://github.com/bagisto/bagisto/issues/4597

## Code Addition
As for the wishlist, `product_id` is needed while adding but for removing the `wishlist_id` is needed. So just enhanced the method as well. Which will give the wishlist object which can be used further for removing.