### PR TITLE
Fixed back icon which is not working properly at admin end #4615

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/catalog/attributes/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/attributes/create.blade.php
@@ -11,7 +11,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.catalog.attributes.index') }}'"></i>
 
                         {{ __('admin::app.catalog.attributes.add-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/catalog/attributes/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/attributes/edit.blade.php
@@ -11,7 +11,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.catalog.attributes.index') }}'"></i>
 
                         {{ __('admin::app.catalog.attributes.edit-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/catalog/categories/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/categories/create.blade.php
@@ -12,7 +12,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.catalog.categories.index') }}'"></i>
 
                         {{ __('admin::app.catalog.categories.add-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/catalog/categories/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/categories/edit.blade.php
@@ -13,7 +13,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.catalog.categories.index') }}'"></i>
 
                         {{ __('admin::app.catalog.categories.edit-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/catalog/families/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/families/create.blade.php
@@ -11,7 +11,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.catalog.families.index') }}'"></i>
 
                         {{ __('admin::app.catalog.families.add-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/catalog/families/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/families/edit.blade.php
@@ -11,7 +11,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.catalog.families.index') }}'"></i>
 
                         {{ __('admin::app.catalog.families.edit-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/catalog/products/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/products/create.blade.php
@@ -26,7 +26,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.catalog.products.index') }}'"></i>
 
                         {{ __('admin::app.catalog.products.add-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/catalog/products/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/products/edit.blade.php
@@ -26,7 +26,7 @@
                 <div class="page-title">
                     <h1>
                         <i class="icon angle-left-icon back-link"
-                           onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                           onclick="window.location = '{{ route('admin.catalog.products.index') }}'"></i>
 
                         {{ __('admin::app.catalog.products.edit-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/cms/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/cms/create.blade.php
@@ -11,7 +11,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.cms.index') }}'"></i>
 
                         {{ __('admin::app.cms.pages.add-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/cms/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/cms/edit.blade.php
@@ -13,7 +13,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.cms.index') }}'"></i>
 
                         {{ __('admin::app.cms.pages.edit-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/customers/addresses/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/customers/addresses/create.blade.php
@@ -14,7 +14,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.customer.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.customer.addresses.index', ['id' => $customer->id]) }}'"></i>
 
                         {{ __('admin::app.customers.addresses.create-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/customers/addresses/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/customers/addresses/create.blade.php
@@ -14,7 +14,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.customer.index') }}'"></i>
 
                         {{ __('admin::app.customers.addresses.create-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/customers/addresses/orders/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/customers/addresses/orders/index.blade.php
@@ -10,7 +10,7 @@
         <div class="page-header">
             <div class="page-title">
                 <h1>
-                    <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                    <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.customer.index') }}'"></i>
 
                     {{ __('address::app.admin.addresses.title-orders', ['customer_name' => $customer->first_name . ' ' . $customer->last_name]) }}
                 </h1>

--- a/packages/Webkul/Admin/src/Resources/views/customers/confirm-password.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/customers/confirm-password.blade.php
@@ -9,7 +9,7 @@
         <div class="page-header">
             <div class="page-title">
                 <h1>
-                    <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                    <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.customer.index') }}'"></i>
                     {{ __('admin::app.users.users.confirm-delete-title') }}
                 </h1>
             </div>

--- a/packages/Webkul/Admin/src/Resources/views/customers/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/customers/create.blade.php
@@ -11,7 +11,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.customer.index') }}'"></i>
 
                         {{ __('admin::app.customers.customers.title') }}
 

--- a/packages/Webkul/Admin/src/Resources/views/customers/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/customers/edit.blade.php
@@ -9,7 +9,7 @@
         <div class="page-header">
             <div class="page-title">
                 <h1>
-                    <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                    <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.customer.index') }}'"></i>
                     {{ $customer->first_name . " " . $customer->last_name }}
                 </h1>
             </div>

--- a/packages/Webkul/Admin/src/Resources/views/customers/groups/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/customers/groups/create.blade.php
@@ -11,7 +11,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.groups.index') }}'"></i>
 
                         {{ __('admin::app.customers.groups.add-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/customers/groups/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/customers/groups/edit.blade.php
@@ -11,7 +11,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.groups.index') }}'"></i>
 
                         {{ __('admin::app.customers.groups.edit-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/customers/note.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/customers/note.blade.php
@@ -10,7 +10,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.customer.index') }}'"></i>
 
                         {{ __('admin::app.customers.note.title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/customers/reviews/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/customers/reviews/edit.blade.php
@@ -11,7 +11,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.customer.review.index') }}'"></i>
 
                         {{ __('admin::app.customers.reviews.edit-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/marketing/email-marketing/campaigns/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/marketing/email-marketing/campaigns/create.blade.php
@@ -11,7 +11,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.customer.review.index') }}'"></i>
 
                         {{ __('admin::app.marketing.campaigns.add-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/marketing/email-marketing/campaigns/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/marketing/email-marketing/campaigns/edit.blade.php
@@ -11,7 +11,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.campaigns.index') }}'"></i>
 
                         {{ __('admin::app.marketing.campaigns.edit-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/marketing/email-marketing/events/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/marketing/email-marketing/events/create.blade.php
@@ -11,7 +11,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.events.index') }}'"></i>
 
                         {{ __('admin::app.marketing.events.add-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/marketing/email-marketing/events/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/marketing/email-marketing/events/edit.blade.php
@@ -11,7 +11,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.events.index') }}'"></i>
 
                         {{ __('admin::app.marketing.events.edit-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/marketing/email-marketing/subscribers/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/marketing/email-marketing/subscribers/edit.blade.php
@@ -11,7 +11,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.customers.subscribers.index') }}'"></i>
 
                         {{ __('admin::app.customers.subscribers.title-edit') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/marketing/email-marketing/templates/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/marketing/email-marketing/templates/create.blade.php
@@ -11,7 +11,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.email-templates.index') }}'"></i>
 
                         {{ __('admin::app.marketing.templates.add-title') }}
                     </h1>
@@ -61,7 +61,7 @@
                             </div>
                         </div>
                     </accordian>
-                            
+
                     {!! view_render_event('bagisto.admin.marketing.templates.create.after') !!}
 
                 </div>

--- a/packages/Webkul/Admin/src/Resources/views/marketing/email-marketing/templates/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/marketing/email-marketing/templates/edit.blade.php
@@ -11,7 +11,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.email-templates.index') }}'"></i>
 
                         {{ __('admin::app.marketing.templates.edit-title') }}
                     </h1>
@@ -62,7 +62,7 @@
                             </div>
                         </div>
                     </accordian>
-                            
+
                     {!! view_render_event('bagisto.admin.marketing.templates.create.after') !!}
 
                 </div>

--- a/packages/Webkul/Admin/src/Resources/views/marketing/promotions/cart-rules/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/marketing/promotions/cart-rules/create.blade.php
@@ -22,7 +22,7 @@
                     <div class="page-title">
                         <h1>
                             <i class="icon angle-left-icon back-link"
-                            onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                            onclick="window.location = '{{ route('admin.cart-rules.index') }}'"></i>
 
                             {{ __('admin::app.promotions.cart-rules.add-title') }}
                         </h1>

--- a/packages/Webkul/Admin/src/Resources/views/marketing/promotions/cart-rules/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/marketing/promotions/cart-rules/edit.blade.php
@@ -27,7 +27,7 @@
                     <div class="page-title">
                         <h1>
                             <i class="icon angle-left-icon back-link"
-                            onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                            onclick="window.location = '{{ route('admin.cart-rules.index') }}'"></i>
 
                             {{ __('admin::app.promotions.cart-rules.edit-title') }}
                         </h1>

--- a/packages/Webkul/Admin/src/Resources/views/marketing/promotions/catalog-rules/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/marketing/promotions/catalog-rules/create.blade.php
@@ -22,7 +22,7 @@
                     <div class="page-title">
                         <h1>
                         <i class="icon angle-left-icon back-link"
-                            onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                            onclick="window.location = '{{ route('admin.catalog-rules.index') }}'"></i>
 
                             {{ __('admin::app.promotions.catalog-rules.add-title') }}
                         </h1>

--- a/packages/Webkul/Admin/src/Resources/views/marketing/promotions/catalog-rules/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/marketing/promotions/catalog-rules/edit.blade.php
@@ -22,7 +22,7 @@
                     <div class="page-title">
                         <h1>
                         <i class="icon angle-left-icon back-link"
-                            onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                            onclick="window.location = '{{ route('admin.catalog-rules.index') }}'"></i>
 
                             {{ __('admin::app.promotions.catalog-rules.edit-title') }}
                         </h1>

--- a/packages/Webkul/Admin/src/Resources/views/sales/invoices/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/sales/invoices/create.blade.php
@@ -12,7 +12,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.sales.invoices.index') }}'"></i>
 
                         {{ __('admin::app.sales.invoices.add-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/sales/invoices/view.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/sales/invoices/view.blade.php
@@ -14,7 +14,7 @@
                 <h1>
                     {!! view_render_event('sales.invoice.title.before', ['order' => $order]) !!}
 
-                    <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                    <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.sales.invoices.index') }}'"></i>
 
                     {{ __('admin::app.sales.invoices.view-title', ['invoice_id' => $invoice->id]) }}
 

--- a/packages/Webkul/Admin/src/Resources/views/sales/orders/view.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/sales/orders/view.blade.php
@@ -14,7 +14,7 @@
                 <h1>
                     {!! view_render_event('sales.order.title.before', ['order' => $order]) !!}
 
-                    <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                    <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.sales.orders.index') }}'"></i>
 
                     {{ __('admin::app.sales.orders.view-title', ['order_id' => $order->increment_id]) }}
 

--- a/packages/Webkul/Admin/src/Resources/views/sales/refunds/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/sales/refunds/create.blade.php
@@ -12,7 +12,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.sales.refunds.index') }}'"></i>
 
                         {{ __('admin::app.sales.refunds.add-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/sales/refunds/view.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/sales/refunds/view.blade.php
@@ -12,7 +12,7 @@
         <div class="page-header">
             <div class="page-title">
                 <h1>
-                    <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                    <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.sales.refunds.index') }}'"></i>
 
                     {{ __('admin::app.sales.refunds.view-title', ['refund_id' => $refund->id]) }}
                 </h1>

--- a/packages/Webkul/Admin/src/Resources/views/sales/shipments/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/sales/shipments/create.blade.php
@@ -12,7 +12,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.sales.shipments.index') }}'"></i>
 
                         {{ __('admin::app.sales.shipments.add-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/sales/shipments/view.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/sales/shipments/view.blade.php
@@ -11,7 +11,7 @@
         <div class="page-header">
             <div class="page-title">
                 <h1>
-                    <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                    <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.sales.shipments.index') }}'"></i>
 
                     {{ __('admin::app.sales.shipments.view-title', ['shipment_id' => $shipment->id]) }}
                 </h1>

--- a/packages/Webkul/Admin/src/Resources/views/settings/channels/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/channels/create.blade.php
@@ -11,7 +11,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.channels.index') }}'"></i>
 
                         {{ __('admin::app.settings.channels.add-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/settings/channels/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/channels/edit.blade.php
@@ -12,7 +12,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.channels.index') }}'"></i>
 
                         {{ __('admin::app.settings.channels.edit-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/settings/currencies/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/currencies/create.blade.php
@@ -11,7 +11,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.currencies.index') }}'"></i>
 
                         {{ __('admin::app.settings.currencies.add-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/settings/currencies/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/currencies/edit.blade.php
@@ -11,7 +11,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.currencies.index') }}'"></i>
 
                         {{ __('admin::app.settings.currencies.edit-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/settings/exchange_rates/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/exchange_rates/create.blade.php
@@ -11,7 +11,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.exchange_rates.index') }}'"></i>
 
                         {{ __('admin::app.settings.exchange_rates.add-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/settings/exchange_rates/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/exchange_rates/edit.blade.php
@@ -11,7 +11,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.exchange_rates.index') }}'"></i>
 
                         {{ __('admin::app.settings.exchange_rates.edit-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/settings/inventory_sources/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/inventory_sources/create.blade.php
@@ -11,7 +11,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.inventory_sources.index') }}'"></i>
 
                         {{ __('admin::app.settings.inventory_sources.add-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/settings/inventory_sources/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/inventory_sources/edit.blade.php
@@ -11,7 +11,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.inventory_sources.index') }}'"></i>
 
                         {{ __('admin::app.settings.inventory_sources.edit-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/settings/locales/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/locales/create.blade.php
@@ -11,7 +11,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.locales.index') }}'"></i>
 
                         {{ __('admin::app.settings.locales.add-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/settings/locales/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/locales/edit.blade.php
@@ -11,7 +11,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.locales.index') }}'"></i>
 
                         {{ __('admin::app.settings.locales.edit-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/settings/sliders/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/sliders/create.blade.php
@@ -15,7 +15,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.sliders.index') }}'"></i>
 
                         {{ __('admin::app.settings.sliders.add-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/settings/sliders/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/sliders/edit.blade.php
@@ -12,7 +12,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.sliders.index') }}'"></i>
 
                         {{ __('admin::app.settings.sliders.edit-title') }}
 

--- a/packages/Webkul/Admin/src/Resources/views/tax/tax-categories/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/tax/tax-categories/create.blade.php
@@ -10,7 +10,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.tax-categories.index') }}'"></i>
 
                         {{ __('admin::app.settings.tax-categories.add-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/tax/tax-categories/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/tax/tax-categories/edit.blade.php
@@ -10,7 +10,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.tax-categories.index') }}'"></i>
 
                         {{ __('admin::app.settings.tax-categories.edit.title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/tax/tax-rates/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/tax/tax-rates/create.blade.php
@@ -10,7 +10,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.tax-rates.index') }}'"></i>
 
                         {{ __('admin::app.settings.tax-rates.add-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/tax/tax-rates/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/tax/tax-rates/edit.blade.php
@@ -10,7 +10,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.tax-rates.index') }}'"></i>
 
                         {{ __('admin::app.settings.tax-rates.edit.title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/users/roles/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/users/roles/create.blade.php
@@ -11,7 +11,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.roles.index') }}'"></i>
 
                         {{ __('admin::app.users.roles.add-role-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/users/roles/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/users/roles/edit.blade.php
@@ -11,7 +11,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.roles.index') }}'"></i>
 
                         {{ __('admin::app.users.roles.edit-role-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/users/users/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/users/users/create.blade.php
@@ -10,7 +10,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.users.index') }}'"></i>
 
                         {{ __('admin::app.users.users.add-user-title') }}
                     </h1>

--- a/packages/Webkul/Admin/src/Resources/views/users/users/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/users/users/edit.blade.php
@@ -10,7 +10,7 @@
             <div class="page-header">
                 <div class="page-title">
                     <h1>
-                        <i class="icon angle-left-icon back-link" onclick="window.location = history.length > 1 ? document.referrer : '{{ route('admin.dashboard.index') }}'"></i>
+                        <i class="icon angle-left-icon back-link" onclick="window.location = '{{ route('admin.users.index') }}'"></i>
 
                         {{ __('admin::app.users.users.edit-user-title') }}
                     </h1>


### PR DESCRIPTION
## Bug
Link: https://github.com/bagisto/bagisto/issues/4615

## Info
- Back button relies on the history. When add or edit link is clicked then the last history is been tracked as the current page.

- Added exact route for each back button so that it will be going to a specific route at any cost.