### PR TITLE
Use the latest version of ar-php library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "intervention/image": "^2.4",
         "intervention/imagecache": "^2.3",
         "kalnoy/nestedset": "5.0.1",
-        "khaled.alshamaa/ar-php": "^5.5.2",
+        "khaled.alshamaa/ar-php": "^6.0.0",
         "konekt/concord": "^1.2",
         "laravel/framework": "^7.0",
         "laravel/scout": "^8.0",


### PR DESCRIPTION
Version 6.0.0 of the ar-php library fixed the issue of ignoring the punctuation marks when coming in the Arabic context for more robust segmentation using the "arIdentify" method. This will resolve the issue reported here by Fahad Khan:
https://github.com/bagisto/bagisto/pull/4462#issuecomment-765555768
