### PR TITLE
FIX: currencies "value"s and "phone" fields formated for API

### DIFF
--- a/packages/Webkul/Paypal/src/Http/Controllers/SmartButtonController.php
+++ b/packages/Webkul/Paypal/src/Http/Controllers/SmartButtonController.php
@@ -115,7 +115,7 @@ class SmartButtonController extends Controller
                     'phone_type'   => 'MOBILE',
 
                     'phone_number' => [
-                        'national_number' => $cart->billing_address->phone,
+                        'national_number' => $this->smartButton->formatPhone($cart->billing_address->phone),
                     ],
                 ],
             ],
@@ -127,28 +127,28 @@ class SmartButtonController extends Controller
             'purchase_units' => [
                 [
                     'amount'   => [
-                        'value'         => (float) $cart->sub_total + $cart->tax_total + ($cart->selected_shipping_rate ? $cart->selected_shipping_rate->price : 0) - $cart->discount_amount,
+                        'value'         => $this->smartButton->formatCurrencyValue((float) $cart->sub_total + $cart->tax_total + ($cart->selected_shipping_rate ? $cart->selected_shipping_rate->price : 0) - $cart->discount_amount),
                         'currency_code' => $cart->cart_currency_code,
 
                         'breakdown'     => [
                             'item_total' => [
                                 'currency_code' => $cart->cart_currency_code,
-                                'value'         => (float) $cart->sub_total,
+                                'value'         => $this->smartButton->formatCurrencyValue((float) $cart->sub_total),
                             ],
 
                             'shipping'   => [
                                 'currency_code' => $cart->cart_currency_code,
-                                'value'         => (float) ($cart->selected_shipping_rate ? $cart->selected_shipping_rate->price : 0),
+                                'value'         => $this->smartButton->formatCurrencyValue((float) ($cart->selected_shipping_rate ? $cart->selected_shipping_rate->price : 0)),
                             ],
 
                             'tax_total'  => [
                                 'currency_code' => $cart->cart_currency_code,
-                                'value'         => (float) $cart->tax_total,
+                                'value'         => $this->smartButton->formatCurrencyValue((float) $cart->tax_total),
                             ],
 
                             'discount'   => [
                                 'currency_code' => $cart->cart_currency_code,
-                                'value'         => (float) $cart->discount_amount,
+                                'value'         => $this->smartButton->formatCurrencyValue( (float) $cart->discount_amount),
                             ],
                         ],
                     ],
@@ -190,7 +190,7 @@ class SmartButtonController extends Controller
             $lineItems[] = [
                 'unit_amount' => [
                     'currency_code' => $cart->cart_currency_code,
-                    'value'         => (float) $item->price,
+                    'value'         => $this->smartButton->formatCurrencyValue((float) $item->price),
                 ],
                 'quantity'    => $item->quantity,
                 'name'        => $item->name,

--- a/packages/Webkul/Paypal/src/Http/Controllers/SmartButtonController.php
+++ b/packages/Webkul/Paypal/src/Http/Controllers/SmartButtonController.php
@@ -148,7 +148,7 @@ class SmartButtonController extends Controller
 
                             'discount'   => [
                                 'currency_code' => $cart->cart_currency_code,
-                                'value'         => $this->smartButton->formatCurrencyValue( (float) $cart->discount_amount),
+                                'value'         => $this->smartButton->formatCurrencyValue((float) $cart->discount_amount),
                             ],
                         ],
                     ],

--- a/packages/Webkul/Paypal/src/Payment/Paypal.php
+++ b/packages/Webkul/Paypal/src/Payment/Paypal.php
@@ -75,4 +75,29 @@ abstract class Paypal extends Payment
     {
         return true;
     }
+
+    /**
+     * Format a currency value according to paypal's api constraints
+     * 
+     * @param float|int $long
+     * @return float
+     */
+    public function formatCurrencyValue($number): float
+    {
+        return round((float) $number, 2);
+    }
+
+    /**
+     * Format phone field according to paypal's api constraints
+     * 
+     * Strips non-numbers characters like '+' or ' ' in 
+     * inputs like "+54 11 3323 2323"
+     * 
+     * @param mixed $phone
+     * @return string
+     */
+    public function formatPhone($phone): string
+    {
+        return preg_replace('/[^0-9]/', '', (string) $phone);
+    }
 }


### PR DESCRIPTION
**BUGS:**

PayPal SmartButton don't work if the Billing Adress phone have a non-number character. Also if some "value" of type currency have more than two decimal places. Bagisto just shows "error: expected an order id to be passed" alert.
