### PR TITLE
Fixed error `addToCartHtml` which is not defined on the compare page #4727

### DIFF
--- a/packages/Webkul/Shop/src/Resources/views/guest/compare/compare-products.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/guest/compare/compare-products.blade.php
@@ -68,7 +68,7 @@
 
                                     @case('addToCartHtml')
                                         <div class="action">
-                                            <div v-html="addToCartHtml"></div>
+                                            <div v-html="product.addToCartHtml"></div>
 
                                             <span class="icon white-cross-sm-icon remove-product" @click="removeProductCompare(product.id)"></span>
                                         </div>


### PR DESCRIPTION
## Bug
Link: https://github.com/bagisto/bagisto/issues/4727