### PR TITLE
Some Exception Handled On Dashboard Page

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/dashboard/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/dashboard/index.blade.php
@@ -208,7 +208,7 @@
                                         <div class="product image">
                                             <?php $productBaseImage = productimage()->getProductBaseImage($item->product); ?>
 
-                                            <img class="item-image" src="{{ $productBaseImage['small_image_url'] }}" />
+                                            <img class="item-image" src="{{ $productBaseImage['small_image_url'] ?? asset('vendor/webkul/ui/assets/images/product/small-product-placeholder.webp') }}" />
                                         </div>
 
                                         <div class="description do-not-cross-arrow">


### PR DESCRIPTION
## Info
In the dashboard, top-selling products are shown from the order item's table. But when a product is deleted then this will cause an exception as no image is found on the associated product because the product instance is not available.

## Code additions
Added static no image placeholder.