### PR TITLE
Added Missing Public Folder

### DIFF
--- a/storage/app/public/.gitignore
+++ b/storage/app/public/.gitignore
@@ -1,0 +1,3 @@
+*
+!public/
+!.gitignore


### PR DESCRIPTION
## Info
Just notices that the public folder is missing which creating the problem with storage linking. Because the linking path is not proper.