### PR TITLE
fixed #4804

### DIFF
--- a/packages/Webkul/Shop/src/Resources/views/checkout/onepage/review.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/checkout/onepage/review.blade.php
@@ -19,8 +19,17 @@
                             <b>{{ $billingAddress->first_name }} {{ $billingAddress->last_name }}</b>
                         </li>
                         <li class="mb-10">
-                            {{ $billingAddress->address1 }},<br/> {{ $billingAddress->state }}
+                            {{ $billingAddress->address1 }},<br/>
                         </li>
+
+                        <li class="mb-10">
+                            {{ $billingAddress->postcode . " " . $billingAddress->city }}
+                        </li>
+
+                        <li class="mb-10">
+                            {{ $billingAddress->state }}
+                        </li>
+
                         <li class="mb-10">
                             {{ core()->country_name($billingAddress->country) }} {{ $billingAddress->postcode }}
                         </li>
@@ -50,10 +59,19 @@
                             <b>{{ $shippingAddress->first_name }} {{ $shippingAddress->last_name }}</b>
                         </li>
                         <li class="mb-10">
-                            {{ $shippingAddress->address1 }},<br/> {{ $shippingAddress->state }}
+                            {{ $shippingAddress->address1 }},<br/>
                         </li>
+
                         <li class="mb-10">
-                            {{ core()->country_name($shippingAddress->country) }} {{ $shippingAddress->postcode }}
+                            {{ $shippingAddress->postcode . " " . $shippingAddress->city }}
+                        </li>
+
+                        <li class="mb-10">
+                            {{ $shippingAddress->state }}
+                        </li>
+
+                        <li class="mb-10">
+                            {{ core()->country_name($shippingAddress->country) }}
                         </li>
 
                         <span class="horizontal-rule mb-15 mt-15"></span>

--- a/packages/Webkul/Shop/src/Resources/views/emails/sales/new-admin-order.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/emails/sales/new-admin-order.blade.php
@@ -52,7 +52,7 @@
                     </div>
 
                     <div>
-                        {{ $order->shipping_address->postcode ." " . $order->shipping_address->city }}
+                        {{ $order->shipping_address->postcode . " " . $order->shipping_address->city }}
                     </div>
 
                     <div>
@@ -97,7 +97,7 @@
                 </div>
 
                 <div>
-                    {{ $order->billing_address->postcode ." " . $order->billing_address->city }}
+                    {{ $order->billing_address->postcode . " " . $order->billing_address->city }}
                 </div>
 
                 <div>

--- a/packages/Webkul/Shop/src/Resources/views/emails/sales/new-admin-order.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/emails/sales/new-admin-order.blade.php
@@ -33,41 +33,51 @@
         </div>
 
         <div style="display: flex;flex-direction: row;margin-top: 20px;justify-content: space-between;margin-bottom: 40px;">
-            <div style="line-height: 25px;">
-                <div style="font-weight: bold;font-size: 16px;color: #242424;">
-                    {{ __('shop::app.mail.order.shipping-address') }}
-                </div>
+            @if ($order->shipping_address)
+                <div style="line-height: 25px;">
+                    <div style="font-weight: bold;font-size: 16px;color: #242424;">
+                        {{ __('shop::app.mail.order.shipping-address') }}
+                    </div>
 
-                <div>
-                    {{ $order->shipping_address->company_name ?? '' }}
-                </div>
+                    <div>
+                        {{ $order->shipping_address->company_name ?? '' }}
+                    </div>
 
-                <div>
-                    {{ $order->shipping_address->name }}
-                </div>
+                    <div>
+                        {{ $order->shipping_address->name }}
+                    </div>
 
-                <div>
-                    {{ $order->shipping_address->address1 }}, {{ $order->shipping_address->state }}
-                </div>
+                    <div>
+                        {{ $order->shipping_address->address1 }}
+                    </div>
 
-                <div>
-                    {{ core()->country_name($order->shipping_address->country) }} {{ $order->shipping_address->postcode }}
-                </div>
+                    <div>
+                        {{ $order->shipping_address->postcode ." " . $order->shipping_address->city }}
+                    </div>
 
-                <div>---</div>
+                    <div>
+                        {{ $order->shipping_address->state }}
+                    </div>
 
-                <div style="margin-bottom: 40px;">
-                    {{ __('shop::app.mail.order.contact') }} : {{ $order->shipping_address->phone }}
-                </div>
+                    <div>
+                        {{ core()->country_name($order->shipping_address->country) }}
+                    </div>
 
-                <div style="font-size: 16px;color: #242424; font-weight: bold">
-                    {{ __('shop::app.mail.order.shipping') }}
-                </div>
+                    <div>---</div>
 
-                <div style="font-size: 16px;color: #242424;">
-                    {{ $order->shipping_title }}
+                    <div style="margin-bottom: 40px;">
+                        {{ __('shop::app.mail.order.contact') }} : {{ $order->shipping_address->phone }}
+                    </div>
+
+                    <div style="font-size: 16px;color: #242424;">
+                        {{ __('shop::app.mail.order.shipping') }}
+                    </div>
+
+                    <div style="font-weight: bold;font-size: 16px;color: #242424;">
+                        {{ $order->shipping_title }}
+                    </div>
                 </div>
-            </div>
+            @endif
 
             <div style="line-height: 25px;">
                 <div style="font-weight: bold;font-size: 16px;color: #242424;">
@@ -83,11 +93,19 @@
                 </div>
 
                 <div>
-                    {{ $order->billing_address->address1 }}, {{ $order->billing_address->state }}
+                    {{ $order->billing_address->address1 }}
                 </div>
 
                 <div>
-                    {{ core()->country_name($order->billing_address->country) }} {{ $order->billing_address->postcode }}
+                    {{ $order->billing_address->postcode ." " . $order->billing_address->city }}
+                </div>
+
+                <div>
+                    {{ $order->billing_address->state }}
+                </div>
+
+                <div>
+                    {{ core()->country_name($order->billing_address->country) }}
                 </div>
 
                 <div>---</div>
@@ -96,11 +114,11 @@
                     {{ __('shop::app.mail.order.contact') }} : {{ $order->billing_address->phone }}
                 </div>
 
-                <div style="font-size: 16px; color: #242424; font-weight: bold">
+                <div style="font-size: 16px; color: #242424;">
                     {{ __('shop::app.mail.order.payment') }}
                 </div>
 
-                <div style="font-size: 16px; color: #242424;">
+                <div style="font-weight: bold; font-size: 16px; color: #242424; margin-bottom: 20px;">
                     {{ core()->getConfigData('sales.paymentmethods.' . $order->payment->method . '.title') }}
                 </div>
 

--- a/packages/Webkul/Shop/src/Resources/views/emails/sales/new-inventorysource-shipment.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/emails/sales/new-inventorysource-shipment.blade.php
@@ -48,11 +48,19 @@
                 </div>
 
                 <div>
-                    {{ $order->shipping_address->address1 }}, {{ $order->shipping_address->state }}
+                    {{ $order->shipping_address->address1 }}
                 </div>
-
+                    
                 <div>
-                    {{ core()->country_name($order->shipping_address->country) }} {{ $order->shipping_address->postcode }}
+                    {{ $order->shipping_address->postcode . " " . $order->shipping_address->city }}
+                </div>
+                    
+                <div>
+                    {{ $order->shipping_address->state }}
+                </div>
+                    
+                <div>
+                    {{ core()->country_name($order->shipping_address->country) }}
                 </div>
 
                 <div>---</div>
@@ -94,11 +102,19 @@
                 </div>
 
                 <div>
-                    {{ $order->billing_address->address1 }}, {{ $order->billing_address->state }}
+                    {{ $order->billing_address->address1 }}
                 </div>
-
+                    
                 <div>
-                    {{ core()->country_name($order->billing_address->country) }} {{ $order->billing_address->postcode }}
+                    {{ $order->billing_address->postcode . " " . $order->billing_address->city }}
+                </div>
+                    
+                <div>
+                    {{ $order->billing_address->state }}
+                </div>
+                    
+                <div>
+                    {{ core()->country_name($order->billing_address->country) }}
                 </div>
 
                 <div>---</div>

--- a/packages/Webkul/Shop/src/Resources/views/emails/sales/new-invoice.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/emails/sales/new-invoice.blade.php
@@ -47,11 +47,19 @@
                     </div>
 
                     <div>
-                        {{ $order->shipping_address->address1 }}, {{ $order->shipping_address->state }}
+                        {{ $order->shipping_address->address1 }}
                     </div>
-
+                    
                     <div>
-                        {{ core()->country_name($order->shipping_address->country) }} {{ $order->shipping_address->postcode }}
+                        {{ $order->shipping_address->postcode . " " . $order->shipping_address->city }}
+                    </div>
+                    
+                    <div>
+                        {{ $order->shipping_address->state }}
+                    </div>
+                    
+                    <div>
+                        {{ core()->country_name($order->shipping_address->country) }}
                     </div>
 
                     <div>---</div>
@@ -84,11 +92,19 @@
                 </div>
 
                 <div>
-                    {{ $order->billing_address->address1 }}, {{ $order->billing_address->state }}
+                    {{ $order->billing_address->address1 }}
                 </div>
-
+                    
                 <div>
-                    {{ core()->country_name($order->billing_address->country) }} {{ $order->billing_address->postcode }}
+                    {{ $order->billing_address->postcode . " " . $order->billing_address->city }}
+                </div>
+                    
+                <div>
+                    {{ $order->billing_address->state }}
+                </div>
+                    
+                <div>
+                    {{ core()->country_name($order->billing_address->country) }}
                 </div>
 
                 <div>---</div>

--- a/packages/Webkul/Shop/src/Resources/views/emails/sales/new-order.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/emails/sales/new-order.blade.php
@@ -44,11 +44,19 @@
                     </div>
 
                     <div>
-                        {{ $order->shipping_address->address1 }}, {{ $order->shipping_address->state }}
+                        {{ $order->shipping_address->address1 }}
                     </div>
 
                     <div>
-                        {{ core()->country_name($order->shipping_address->country) }} {{ $order->shipping_address->postcode }}
+                        {{ $order->shipping_address->postcode ." " . $order->shipping_address->city }}
+                    </div>
+
+                    <div>
+                        {{ $order->shipping_address->state }}
+                    </div>
+
+                    <div>
+                        {{ core()->country_name($order->shipping_address->country) }}
                     </div>
 
                     <div>---</div>
@@ -81,11 +89,19 @@
                 </div>
 
                 <div>
-                    {{ $order->billing_address->address1 }}, {{ $order->billing_address->state }}
+                    {{ $order->billing_address->address1 }}
                 </div>
 
                 <div>
-                    {{ core()->country_name($order->billing_address->country) }} {{ $order->billing_address->postcode }}
+                    {{ $order->billing_address->postcode ." " . $order->billing_address->city }}
+                </div>
+
+                <div>
+                    {{ $order->billing_address->state }}
+                </div>
+
+                <div>
+                    {{ core()->country_name($order->billing_address->country) }}
                 </div>
 
                 <div>---</div>

--- a/packages/Webkul/Shop/src/Resources/views/emails/sales/new-order.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/emails/sales/new-order.blade.php
@@ -48,7 +48,7 @@
                     </div>
 
                     <div>
-                        {{ $order->shipping_address->postcode ." " . $order->shipping_address->city }}
+                        {{ $order->shipping_address->postcode . " " . $order->shipping_address->city }}
                     </div>
 
                     <div>

--- a/packages/Webkul/Shop/src/Resources/views/emails/sales/new-refund.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/emails/sales/new-refund.blade.php
@@ -46,11 +46,19 @@
                     </div>
 
                     <div>
-                        {{ $order->shipping_address->address1 }}, {{ $order->shipping_address->state }}
+                        {{ $order->shipping_address->address1 }}
                     </div>
 
                     <div>
-                        {{ core()->country_name($order->shipping_address->country) }} {{ $order->shipping_address->postcode }}
+                        {{ $order->shipping_address->postcode . " " . $order->shipping_address->city }}
+                    </div>
+
+                    <div>
+                        {{ $order->shipping_address->state }}
+                    </div>
+
+                    <div>
+                        {{ core()->country_name($order->shipping_address->country) }}
                     </div>
 
                     <div>---</div>
@@ -83,11 +91,19 @@
                 </div>
 
                 <div>
-                    {{ $order->billing_address->address1 }}, {{ $order->billing_address->state }}
+                    {{ $order->billing_address->address1 }}
                 </div>
 
                 <div>
-                    {{ core()->country_name($order->billing_address->country) }} {{ $order->billing_address->postcode }}
+                    {{ $order->billing_address->postcode . " " . $order->billing_address->city }}
+                </div>
+                
+                <div>
+                    {{ $order->billing_address->state }}
+                </div>
+
+                <div>
+                    {{ core()->country_name($order->billing_address->country) }}
                 </div>
 
                 <div>---</div>

--- a/packages/Webkul/Shop/src/Resources/views/emails/sales/new-shipment.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/emails/sales/new-shipment.blade.php
@@ -45,11 +45,19 @@
                 </div>
 
                 <div>
-                    {{ $order->shipping_address->address1 }}, {{ $order->shipping_address->state }}
+                    {{ $order->shipping_address->address1 }}
                 </div>
 
                 <div>
-                    {{ core()->country_name($order->shipping_address->country) }} {{ $order->shipping_address->postcode }}
+                    {{ $order->shipping_address->postcode . " " . $order->shipping_address->city }}
+                </div>
+
+                <div>
+                    {{ $order->shipping_address->state }}
+                </div>
+
+                <div>
+                    {{ core()->country_name($order->shipping_address->country) }}
                 </div>
 
                 <div>---</div>
@@ -91,11 +99,19 @@
                 </div>
 
                 <div>
-                    {{ $order->billing_address->address1 }}, {{ $order->billing_address->state }}
+                    {{ $order->billing_address->address1 }}
                 </div>
 
                 <div>
-                    {{ core()->country_name($order->billing_address->country) }} {{ $order->billing_address->postcode }}
+                    {{ $order->billing_address->postcode . " " . $order->billing_address->city }}
+                </div>
+                
+                <div>
+                    {{ $order->billing_address->state }}
+                </div>
+
+                <div>
+                    {{ core()->country_name($order->billing_address->country) }}
                 </div>
 
                 <div>---</div>

--- a/packages/Webkul/Shop/src/Resources/views/emails/sales/order-cancel-admin.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/emails/sales/order-cancel-admin.blade.php
@@ -47,11 +47,19 @@
                 </div>
 
                 <div>
-                    {{ $order->shipping_address->address1 }}, {{ $order->shipping_address->state }}
+                    {{ $order->shipping_address->address1 }}
                 </div>
 
                 <div>
-                    {{ core()->country_name($order->shipping_address->country) }} {{ $order->shipping_address->postcode }}
+                    {{ $order->shipping_address->postcode . " " . $order->shipping_address->city }}
+                </div>
+
+                <div>
+                    {{ $order->shipping_address->state }}
+                </div>
+
+                <div>
+                    {{ core()->country_name($order->shipping_address->country) }}
                 </div>
 
                 <div>---</div>
@@ -83,11 +91,19 @@
                 </div>
 
                 <div>
-                    {{ $order->billing_address->address1 }}, {{ $order->billing_address->state }}
+                    {{ $order->billing_address->address1 }}
                 </div>
 
                 <div>
-                    {{ core()->country_name($order->billing_address->country) }} {{ $order->billing_address->postcode }}
+                    {{ $order->billing_address->postcode . " " .  $order->billing_address->city }}
+                </div>
+
+                <div>
+                    {{ $order->billing_address->state }}
+                </div>
+
+                <div>
+                    {{ core()->country_name($order->billing_address->country) }}
                 </div>
 
                 <div>---</div>

--- a/packages/Webkul/Shop/src/Resources/views/emails/sales/order-cancel.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/emails/sales/order-cancel.blade.php
@@ -43,11 +43,19 @@
                 </div>
 
                 <div>
-                    {{ $order->shipping_address->address1 }}, {{ $order->shipping_address->state }}
+                    {{ $order->shipping_address->address1 }}
                 </div>
 
                 <div>
-                    {{ core()->country_name($order->shipping_address->country) }} {{ $order->shipping_address->postcode }}
+                    {{ $order->shipping_address->postcode . " " . $order->shipping_address->city }}
+                </div>
+
+                <div>
+                    {{ $order->shipping_address->state }}
+                </div>
+
+                <div>
+                    {{ core()->country_name($order->shipping_address->country) }}
                 </div>
 
                 <div>---</div>
@@ -75,15 +83,19 @@
                 </div>
 
                 <div>
-                    {{ $order->billing_address->name }}
+                    {{ $order->billing_address->address1 }}
                 </div>
 
                 <div>
-                    {{ $order->billing_address->address1 }}, {{ $order->billing_address->state }}
+                    {{ $order->billing_address->postcode . " " . $order->billing_address->city }}
+                </div>
+                
+                <div>
+                    {{ $order->billing_address->state }}
                 </div>
 
                 <div>
-                    {{ core()->country_name($order->billing_address->country) }} {{ $order->billing_address->postcode }}
+                    {{ core()->country_name($order->billing_address->country) }}
                 </div>
 
                 <div>---</div>

--- a/packages/Webkul/Velocity/src/Resources/views/shop/checkout/onepage/review.blade.php
+++ b/packages/Webkul/Velocity/src/Resources/views/shop/checkout/onepage/review.blade.php
@@ -62,7 +62,7 @@
                                     {{ $shippingAddress->name }}
                                 </li><br/>
                                 <li>
-                                    {{ $shippingAddress->address1 }},<br/> {{ $shippingAddress->state }}
+                                    {{ $shippingAddress->address1 }},<br/>
                                 </li><br/>
 
                                 <li>

--- a/packages/Webkul/Velocity/src/Resources/views/shop/checkout/onepage/review.blade.php
+++ b/packages/Webkul/Velocity/src/Resources/views/shop/checkout/onepage/review.blade.php
@@ -24,10 +24,19 @@
                                     {{ $billingAddress->name }}
                                 </li><br />
                                 <li>
-                                    {{ $billingAddress->address1 }}, <br />{{ $billingAddress->state }}
+                                    {{ $billingAddress->address1 }}, <br />
                                 </li><br />
+
                                 <li>
-                                    {{ core()->country_name($billingAddress->country) }} {{ $billingAddress->postcode }}
+                                    {{ $billingAddress->postcode ." " . $billingAddress->city }}
+                                </li><br />
+
+                                <li>
+                                    {{ $billingAddress->state }}
+                                </li><br />
+
+                                <li>
+                                    {{ core()->country_name($billingAddress->country) }}
                                 </li><br />
 
                                 <li>
@@ -55,9 +64,18 @@
                                 <li>
                                     {{ $shippingAddress->address1 }},<br/> {{ $shippingAddress->state }}
                                 </li><br/>
+
                                 <li>
-                                    {{ core()->country_name($shippingAddress->country) }} {{ $shippingAddress->postcode }}
-                                </li><br/>
+                                    {{ $shippingAddress->postcode ." " . $shippingAddress->city }}
+                                </li><br />
+
+                                <li>
+                                    {{ $shippingAddress->state }}
+                                </li><br />
+
+                                <li>
+                                    {{ core()->country_name($shippingAddress->country) }}
+                                </li><br />
 
                                 <li>
                                     {{ __('shop::app.checkout.onepage.contact') }} : {{ $shippingAddress->phone }}

--- a/packages/Webkul/Velocity/src/Resources/views/shop/checkout/onepage/review.blade.php
+++ b/packages/Webkul/Velocity/src/Resources/views/shop/checkout/onepage/review.blade.php
@@ -28,7 +28,7 @@
                                 </li><br />
 
                                 <li>
-                                    {{ $billingAddress->postcode ." " . $billingAddress->city }}
+                                    {{ $billingAddress->postcode . " " . $billingAddress->city }}
                                 </li><br />
 
                                 <li>
@@ -66,7 +66,7 @@
                                 </li><br/>
 
                                 <li>
-                                    {{ $shippingAddress->postcode ." " . $shippingAddress->city }}
+                                    {{ $shippingAddress->postcode . " " . $shippingAddress->city }}
                                 </li><br />
 
                                 <li>


### PR DESCRIPTION
## Description
<!--- Please mention issue #id and use comma if your PR solves multiple issues -->
<!--- Please describe your changes in detail -->
This pull requests fixes #4804 

- Added missing city field to order templates.
- Added missing city field to **Velocity** checkout order summary.
- Added missing city field to **Shop** checkout order summary.

## How to test this
- Create a new order
- Verify that your city is being displayed in the order summary.
- Verify that your city is being displayed in the order confirmation mail.

## Documentation
- [ ] My pull request requires a update on the documentation repository.
<!--- Please describe in detail what needs to be changed --->
