### PR TITLE
add title to data grid actions

### DIFF
--- a/packages/Webkul/Shop/src/DataGrids/OrderDataGrid.php
+++ b/packages/Webkul/Shop/src/DataGrids/OrderDataGrid.php
@@ -83,6 +83,7 @@ class OrderDataGrid extends DataGrid
     public function prepareActions()
     {
         $this->addAction([
+            'title'  => trans('ui::app.datagrid.view'),
             'type'   => 'View',
             'method' => 'GET',
             'route'  => 'customer.orders.view',

--- a/packages/Webkul/Ui/src/Resources/lang/ar/app.php
+++ b/packages/Webkul/Ui/src/Resources/lang/ar/app.php
@@ -41,6 +41,9 @@ return [
         'items-per-page' => 'مواد لكل صفحة',
         'value-here' => 'القيمة هنا',
         'numeric-value-here' => 'القيمة العددية هنا',
-        'submit' => 'إرسال'
+        'submit' => 'إرسال',
+        'edit' => 'تعديل',
+        'delete' => 'حذف',
+        'view' => 'رأي',
     ]
 ];

--- a/packages/Webkul/Ui/src/Resources/lang/de/app.php
+++ b/packages/Webkul/Ui/src/Resources/lang/de/app.php
@@ -41,6 +41,9 @@ return [
         'items-per-page' => 'Einträge pro Seite',
         'value-here' => 'Wert hier',
         'numeric-value-here' => 'Numerischer Wert hier',
-        'submit' => 'Bestätigen'
+        'submit' => 'Bestätigen',
+        'view' => 'View',
+        'edit' => 'Bearbeiten',
+        'delete' => 'Löschen',
     ]
 ];

--- a/packages/Webkul/Ui/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Ui/src/Resources/lang/en/app.php
@@ -41,6 +41,9 @@ return [
         'items-per-page' => 'Items Per Page',
         'value-here' => 'Value here',
         'numeric-value-here' => 'Numeric Value here',
-        'submit' => 'Submit'
+        'submit' => 'Submit',
+        'edit' => 'Edit',
+        'delete' => 'Delete',
+        'view' => 'View',
     ]
 ];

--- a/packages/Webkul/Ui/src/Resources/lang/es/app.php
+++ b/packages/Webkul/Ui/src/Resources/lang/es/app.php
@@ -41,6 +41,9 @@ return [
         'items-per-page' => 'Artículos por página',
         'value-here' => 'Valor aquí',
         'numeric-value-here' => 'Valor numérico aquí',
-        'submit' => 'Enviar'
+        'submit' => 'Enviar',
+        'edit' => 'Editar',
+        'delete' => 'Borrar',
+        'view' => 'Ver',
     ]
 ];

--- a/packages/Webkul/Ui/src/Resources/lang/fa/app.php
+++ b/packages/Webkul/Ui/src/Resources/lang/fa/app.php
@@ -41,6 +41,9 @@ return [
         'items-per-page' => 'موارد در هر صفحه',
         'value-here' => 'ارزش در اینجا',
         'numeric-value-here' => 'ارزش عددی در اینجا',
-        'submit' => 'ارسال'
+        'submit' => 'ارسال',
+        'edit' => 'ویرایش کنید',
+        'delete' => 'حذف',
+        'view' => 'چشم انداز',
     ]
 ];

--- a/packages/Webkul/Ui/src/Resources/lang/it/app.php
+++ b/packages/Webkul/Ui/src/Resources/lang/it/app.php
@@ -41,6 +41,9 @@ return [
         'items-per-page' => 'Risultati per pagina',
         'value-here' => 'Valore qui',
         'numeric-value-here' => 'Valore numerico qui',
-        'submit' => 'Invia'
+        'submit' => 'Invia',
+        'edit' => 'Modifica',
+        'delete' => 'Elimina',
+        'view' => 'Vedi',
     ]
 ];

--- a/packages/Webkul/Ui/src/Resources/lang/nl/app.php
+++ b/packages/Webkul/Ui/src/Resources/lang/nl/app.php
@@ -41,6 +41,9 @@ return [
         'items-per-page' => 'Items per pagina',
         'value-here' => 'Waarde hier',
         'numeric-value-here' => 'Numerieke waarde hier',
-        'submit' => 'Submit'
+        'submit' => 'Submit',
+        'edit' => 'Edit',
+        'delete' => 'Delete',
+        'view' => 'View',
     ]
 ];

--- a/packages/Webkul/Ui/src/Resources/lang/pl/app.php
+++ b/packages/Webkul/Ui/src/Resources/lang/pl/app.php
@@ -41,6 +41,9 @@ return [
         'items-per-page' => 'Przedmioty na stronę',
         'value-here' => 'Wartość tutaj',
         'numeric-value-here' => 'wartość liczbowa tutaj',
-        'submit' => 'Prześlij'
+        'submit' => 'Prześlij',
+        'edit' => 'Edit',
+        'delete' => 'Usuń',
+        'view' => 'Widok',
     ]
 ];

--- a/packages/Webkul/Ui/src/Resources/lang/pt_BR/app.php
+++ b/packages/Webkul/Ui/src/Resources/lang/pt_BR/app.php
@@ -41,6 +41,9 @@ return [
         'items-per-page' => 'Itens por página',
         'value-here' => 'Valor aqui',
         'numeric-value-here' => 'Valor numérico aqui',
-        'submit' => 'Enviar'
+        'submit' => 'Enviar',
+        'edit' => 'Editar',
+        'delete' => 'Excluir',
+        'view' => 'Visão',
     ]
 ];

--- a/packages/Webkul/Ui/src/Resources/lang/tr/app.php
+++ b/packages/Webkul/Ui/src/Resources/lang/tr/app.php
@@ -41,6 +41,9 @@ return [
         'items-per-page' => 'Sayfa Başına Kayıt',
         'value-here' => 'Değeri girin',
         'numeric-value-here' => 'Satusal değeri girin',
-        'submit' => 'Kaydet'
+        'submit' => 'Kaydet',
+        'edit' => 'Düzenle',
+        'delete' => 'Sil',
+        'view' => 'Görüntüle',
     ]
 ];

--- a/packages/Webkul/Velocity/src/DataGrids/CategoryDataGrid.php
+++ b/packages/Webkul/Velocity/src/DataGrids/CategoryDataGrid.php
@@ -83,6 +83,7 @@ class CategoryDataGrid extends DataGrid
 
     public function prepareActions() {
         $this->addAction([
+            'title'  => trans('ui::app.datagrid.edit'),
             'type'   => 'Edit',
             'method' => 'GET',
             'route'  => 'velocity.admin.category.edit',
@@ -90,6 +91,7 @@ class CategoryDataGrid extends DataGrid
         ]);
 
         $this->addAction([
+            'title'        => trans('ui::app.datagrid.delete'),
             'type'         => 'Delete',
             'method'       => 'POST',
             'route'        => 'velocity.admin.category.delete',

--- a/packages/Webkul/Velocity/src/DataGrids/ContentDataGrid.php
+++ b/packages/Webkul/Velocity/src/DataGrids/ContentDataGrid.php
@@ -95,6 +95,7 @@ class ContentDataGrid extends DataGrid
 
     public function prepareActions() {
         $this->addAction([
+            'title'  => trans('ui::app.datagrid.edit'),
             'type'   => 'Edit',
             'method' => 'GET',
             'route'  => 'velocity.admin.content.edit',
@@ -102,6 +103,7 @@ class ContentDataGrid extends DataGrid
         ]);
 
         $this->addAction([
+            'title'        => trans('ui::app.datagrid.delete'),
             'type'         => 'Delete',
             'method'       => 'POST',
             'route'        => 'velocity.admin.content.delete',


### PR DESCRIPTION
## Description
#4860

In the previous PR, I used the title for the key and the admin section had no problem
But the front part of the customer section did not have a title, giving an error
That's why I came to add a title to actions


![image](https://user-images.githubusercontent.com/32425175/117706879-16043880-b1e3-11eb-8a05-eb48ddf01b52.png)

