### PR TITLE
Removed Channel Relationship From The ProductAttributeValues Model #4985

### DIFF
--- a/packages/Webkul/Product/src/Models/ProductAttributeValue.php
+++ b/packages/Webkul/Product/src/Models/ProductAttributeValue.php
@@ -4,14 +4,20 @@ namespace Webkul\Product\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Webkul\Attribute\Models\AttributeProxy;
-use Webkul\Channel\Models\ChannelProxy;
 use Webkul\Product\Contracts\ProductAttributeValue as ProductAttributeValueContract;
 
 class ProductAttributeValue extends Model implements ProductAttributeValueContract
 {
+    /**
+     * Indicates if the model should be timestamped.
+     *
+     * @var bool
+     */
     public $timestamps = false;
 
     /**
+     * Attribute type fields.
+     *
      * @var array
      */
     public static $attributeTypeFields = [
@@ -28,10 +34,14 @@ class ProductAttributeValue extends Model implements ProductAttributeValueContra
         'checkbox'    => 'text_value',
     ];
 
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
     protected $fillable = [
         'product_id',
         'attribute_id',
-        'channel_id',
         'locale',
         'channel',
         'text_value',
@@ -57,13 +67,5 @@ class ProductAttributeValue extends Model implements ProductAttributeValueContra
     public function product()
     {
         return $this->belongsTo(ProductProxy::modelClass());
-    }
-
-    /**
-     * Get the channel that owns the attribute value.
-     */
-    public function channel()
-    {
-        return $this->belongsTo(ChannelProxy::modelClass());
     }
 }


### PR DESCRIPTION
## Description
Link: https://github.com/bagisto/bagisto/issues/4985

## Information
- When calling the relationship, this proxy class is not found in the model, which caused the error, which means it never used in a project.
https://github.com/bagisto/bagisto/blob/8858ed64ffdb07c70652549a8b467b57cf5757eb/packages/Webkul/Product/src/Models/ProductAttributeValue.php#L7

    ![Selection_001](https://user-images.githubusercontent.com/68321766/123912144-4aea6b80-d99a-11eb-8650-be7bff169a3f.png)

- So rather creating a migration, i choosed to remove the method.