### PR TITLE
Removed installer folder when GUI installation completed

### DIFF
--- a/packages/Webkul/Core/src/Console/Commands/Install.php
+++ b/packages/Webkul/Core/src/Console/Commands/Install.php
@@ -73,6 +73,11 @@ class Install extends Command
         $result = shell_exec('composer dump-autoload');
         $this->info($result);
 
+        // removing the installer directory
+        if (is_dir('public/installer')) {
+            shell_exec('rm -rf public/installer');
+        }
+
         // final information
         $this->info('-----------------------------');
         $this->info('Congratulations!');


### PR DESCRIPTION
## Description
- Removed installer folder when GUI installation completed.

## How to test this
- Just make a fresh install and check whether the installer directory was deleted or not.
