### PR TITLE
allow to get linked products by number of $limit

### DIFF
--- a/packages/Webkul/Product/src/Models/Product.php
+++ b/packages/Webkul/Product/src/Models/Product.php
@@ -182,26 +182,29 @@ class Product extends Model implements ProductContract
 
     /**
      * The related products that belong to the product.
+     * @var int $limit set number of products to get, -1 to get all
      */
-    public function related_products()
+    public function related_products(int $limit = 4)
     {
-        return $this->belongsToMany(static::class, 'product_relations', 'parent_id', 'child_id')->limit(4);
+        return $this->belongsToMany(static::class, 'product_relations', 'parent_id', 'child_id')->limit($limit);
     }
 
     /**
      * The up sells that belong to the product.
+     * @var int $limit set number of products to get, -1 to get all
      */
-    public function up_sells()
+    public function up_sells(int $limit = 4)
     {
-        return $this->belongsToMany(static::class, 'product_up_sells', 'parent_id', 'child_id')->limit(4);
+        return $this->belongsToMany(static::class, 'product_up_sells', 'parent_id', 'child_id')->limit($limit);
     }
 
     /**
      * The cross sells that belong to the product.
+     * @var int $limit set number of products to get, -1 to get all
      */
-    public function cross_sells()
+    public function cross_sells(int $limit = 4)
     {
-        return $this->belongsToMany(static::class, 'product_cross_sells', 'parent_id', 'child_id')->limit(4);
+        return $this->belongsToMany(static::class, 'product_cross_sells', 'parent_id', 'child_id')->limit($limit);
     }
 
     /**
@@ -338,9 +341,10 @@ class Product extends Model implements ProductContract
      */
     public function getAttribute($key)
     {
-        if (! method_exists(static::class, $key)
-            && ! in_array($key, ['pivot', 'parent_id', 'attribute_family_id'])
-            && ! isset($this->attributes[$key])
+        if (
+            !method_exists(static::class, $key)
+            && !in_array($key, ['pivot', 'parent_id', 'attribute_family_id'])
+            && !isset($this->attributes[$key])
         ) {
             if (isset($this->id)) {
                 $this->attributes[$key] = '';
@@ -405,7 +409,7 @@ class Product extends Model implements ProductContract
      */
     public function getCustomAttributeValue($attribute)
     {
-        if (! $attribute) {
+        if (!$attribute) {
             return;
         }
 


### PR DESCRIPTION
## Description
<!--- Please mention issue #id and use comma if your PR solves multiple issues -->
Add $limit agreement in 3 methods to get linked products so people can get number of products they want, not limited to 4.
If you want to get all, set $limit to -1

## How to test this
When call model Product's methods related_products(), up_sells(), cross_sells() you can input number of products to get or use -1 to get all

## Documentation
- [ ] My pull request requires a update on the documentation repository.
<!--- Please describe in detail what needs to be changed --->
