### PR TITLE
Add locale to Category datagrid

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/catalog/categories/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/categories/edit.blade.php
@@ -53,7 +53,9 @@
                             {!! view_render_event('bagisto.admin.catalog.category.edit_form_accordian.general.controls.before', ['category' => $category]) !!}
 
                             <div class="control-group" :class="[errors.has('{{$locale}}[name]') ? 'has-error' : '']">
-                                <label for="name" class="required">{{ __('admin::app.catalog.categories.name') }}</label>
+                                <label for="name" class="required">{{ __('admin::app.catalog.categories.name') }}
+                                    <span class="locale">[{{ $locale }}]</span>
+                                </label>
                                 <input type="text" v-validate="'required'" class="control" id="name" name="{{$locale}}[name]" value="{{ old($locale)['name'] ?? ($category->translate($locale)['name'] ?? '') }}" data-vv-as="&quot;{{ __('admin::app.catalog.categories.name') }}&quot;" v-slugify-target="'slug'"/>
                                 <span class="control-error" v-if="errors.has('{{$locale}}[name]')">@{{ errors.first('{!!$locale!!}[name]') }}</span>
                             </div>
@@ -181,23 +183,31 @@
                             {!! view_render_event('bagisto.admin.catalog.category.edit_form_accordian.seo.controls.before', ['category' => $category]) !!}
 
                             <div class="control-group">
-                                <label for="meta_title">{{ __('admin::app.catalog.categories.meta_title') }}</label>
+                                <label for="meta_title">{{ __('admin::app.catalog.categories.meta_title') }}
+                                    <span class="locale">[{{ $locale }}]</span>
+                                </label>
                                 <input type="text" class="control" id="meta_title" name="{{$locale}}[meta_title]" value="{{ old($locale)['meta_title'] ?? ($category->translate($locale)['meta_title'] ?? '') }}"/>
                             </div>
 
                             <div class="control-group" :class="[errors.has('{{$locale}}[slug]') ? 'has-error' : '']">
-                                <label for="slug" class="required">{{ __('admin::app.catalog.categories.slug') }}</label>
+                                <label for="slug" class="required">{{ __('admin::app.catalog.categories.slug') }}
+                                    <span class="locale">[{{ $locale }}]</span>
+                                </label>
                                 <input type="text" v-validate="'required'" class="control" id="slug" name="{{$locale}}[slug]" value="{{ old($locale)['slug'] ?? ($category->translate($locale)['slug'] ?? '') }}" data-vv-as="&quot;{{ __('admin::app.catalog.categories.slug') }}&quot;" v-slugify/>
                                 <span class="control-error" v-if="errors.has('{{$locale}}[slug]')">@{{ errors.first('{!!$locale!!}[slug]') }}</span>
                             </div>
 
                             <div class="control-group">
-                                <label for="meta_description">{{ __('admin::app.catalog.categories.meta_description') }}</label>
+                                <label for="meta_description">{{ __('admin::app.catalog.categories.meta_description') }}
+                                    <span class="locale">[{{ $locale }}]</span>
+                                </label>
                                 <textarea class="control" id="meta_description" name="{{$locale}}[meta_description]">{{ old($locale)['meta_description'] ?? ($category->translate($locale)['meta_description'] ?? '') }}</textarea>
                             </div>
 
                             <div class="control-group">
-                                <label for="meta_keywords">{{ __('admin::app.catalog.categories.meta_keywords') }}</label>
+                                <label for="meta_keywords">{{ __('admin::app.catalog.categories.meta_keywords') }}
+                                    <span class="locale">[{{ $locale }}]</span>
+                                </label>
                                 <textarea class="control" id="meta_keywords" name="{{$locale}}[meta_keywords]">{{ old($locale)['meta_keywords'] ?? ($category->translate($locale)['meta_keywords'] ?? '') }}</textarea>
                             </div>
 
@@ -221,7 +231,9 @@
     <script type="text/x-template" id="description-template">
 
         <div class="control-group" :class="[errors.has('{{$locale}}[description]') ? 'has-error' : '']">
-            <label for="description" :class="isRequired ? 'required' : ''">{{ __('admin::app.catalog.categories.description') }}</label>
+            <label for="description" :class="isRequired ? 'required' : ''">{{ __('admin::app.catalog.categories.description') }}
+                <span class="locale">[{{ $locale }}]</span>
+            </label>
             <textarea v-validate="isRequired ? 'required' : ''" class="control" id="description" name="{{$locale}}[description]" data-vv-as="&quot;{{ __('admin::app.catalog.categories.description') }}&quot;">{{ old($locale)['description'] ?? ($category->translate($locale)['description'] ?? '') }}</textarea>
             <span class="control-error" v-if="errors.has('{{$locale}}[description]')">@{{ errors.first('{!!$locale!!}[description]') }}</span>
         </div>

--- a/packages/Webkul/Admin/src/Resources/views/catalog/categories/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/categories/index.blade.php
@@ -21,7 +21,7 @@
         {!! view_render_event('bagisto.admin.catalog.categories.list.before') !!}
 
         <div class="page-content">
-            {!! app('Webkul\Admin\DataGrids\CategoryDataGrid')->render() !!}
+            <datagrid-plus src="{{ route('admin.catalog.categories.index') }}"></datagrid-plus>
         </div>
 
         {!! view_render_event('bagisto.admin.catalog.categories.list.after') !!}
@@ -47,7 +47,7 @@
 
                 var indexes = formData.indexes;
             }
-            
+
             if (indexes) {
                 $.ajax({
                     type : 'POST',

--- a/packages/Webkul/Category/src/Http/Controllers/CategoryController.php
+++ b/packages/Webkul/Category/src/Http/Controllers/CategoryController.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Category\Http\Controllers;
 
+use Webkul\Admin\DataGrids\CategoryDataGrid;
 use Webkul\Core\Models\Channel;
 use Illuminate\Support\Facades\Event;
 use Webkul\Category\Repositories\CategoryRepository;
@@ -56,6 +57,10 @@ class CategoryController extends Controller
      */
     public function index()
     {
+        if (request()->ajax()) {
+            return app(CategoryDataGrid::class)->toJson();
+        }
+
         return view($this->_config['view']);
     }
 


### PR DESCRIPTION
## Description
Link: #5069 

- Locale filter added to category datagrid
- Locale added to input labels in category edit page

## How to test this
Add a new locale to your channel then edit a category and change local, change some locale-based values and save, after getting back to datagrid you can filter locale and see your changes.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
