### PR TITLE
Removed the invoice button when the payment method is PayPal Standard #5088

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Sales/InvoiceController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Sales/InvoiceController.php
@@ -4,8 +4,8 @@ namespace Webkul\Admin\Http\Controllers\Sales;
 
 use PDF;
 use Webkul\Admin\Http\Controllers\Controller;
-use Webkul\Sales\Repositories\OrderRepository;
 use Webkul\Sales\Repositories\InvoiceRepository;
+use Webkul\Sales\Repositories\OrderRepository;
 
 class InvoiceController extends Controller
 {
@@ -17,14 +17,14 @@ class InvoiceController extends Controller
     protected $_config;
 
     /**
-     * OrderRepository object
+     * Order repository instance.
      *
      * @var \Webkul\Sales\Repositories\OrderRepository
      */
     protected $orderRepository;
 
     /**
-     * InvoiceRepository object
+     * Invoice repository instance.
      *
      * @var \Webkul\Sales\Repositories\InvoiceRepository
      */
@@ -40,8 +40,7 @@ class InvoiceController extends Controller
     public function __construct(
         OrderRepository $orderRepository,
         InvoiceRepository $invoiceRepository
-    )
-    {
+    ) {
         $this->middleware('admin');
 
         $this->_config = request('_config');
@@ -70,6 +69,10 @@ class InvoiceController extends Controller
     public function create($orderId)
     {
         $order = $this->orderRepository->findOrFail($orderId);
+
+        if ($order->payment->method === 'paypal_standard') {
+            abort(404);
+        }
 
         return view($this->_config['view'], compact('order'));
     }
@@ -160,9 +163,9 @@ class InvoiceController extends Controller
 
         $p = $arabic->arIdentify($html);
 
-        for ($i = count($p)-1; $i >= 0; $i -= 2) {
-            $utf8ar = $arabic->utf8Glyphs(substr($html, $p[$i-1], $p[$i] - $p[$i-1]));
-            $html   = substr_replace($html, $utf8ar, $p[$i-1], $p[$i] - $p[$i-1]);
+        for ($i = count($p) - 1; $i >= 0; $i -= 2) {
+            $utf8ar = $arabic->utf8Glyphs(substr($html, $p[$i - 1], $p[$i] - $p[$i - 1]));
+            $html   = substr_replace($html, $utf8ar, $p[$i - 1], $p[$i] - $p[$i - 1]);
         }
 
         return $html;

--- a/packages/Webkul/Admin/src/Resources/views/sales/orders/view.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/sales/orders/view.blade.php
@@ -31,7 +31,7 @@
                     </a>
                 @endif
 
-                @if ($order->canInvoice())
+                @if ($order->canInvoice() && $order->payment->method !== 'paypal_standard')
                     <a href="{{ route('admin.sales.invoices.create', $order->id) }}" class="btn btn-lg btn-primary">
                         {{ __('admin::app.sales.orders.invoice-btn-title') }}
                     </a>


### PR DESCRIPTION
## Issue Reference
Link: https://github.com/bagisto/bagisto/issues/5088

## Description
- Removed the invoice button when the payment method is PayPal Standard.

## For Developers
- Not added case in the `canInvoice` method because the request is also coming from the IPN also which will result in false.
- So added case in the view page and create method. If somehow it is forced from the Postman will result in 500 in production.

## How To Test This?
- Place an order from the PayPal standard option and check for the invoice button on the index page. It should not be available.
