### PR TITLE
Correct use of Order number length setting.

### DIFF
--- a/packages/Webkul/Sales/src/Generators/Sequencer.php
+++ b/packages/Webkul/Sales/src/Generators/Sequencer.php
@@ -113,8 +113,8 @@ class Sequencer implements SequencerContract
         if ($this->length && ($this->prefix || $this->suffix)) {
             $number = ($this->prefix) . sprintf(
                 "%0{$this->length}d",
-                0
-            ) . ($this->lastId + 1) . ($this->suffix);
+                ($this->lastId + 1)
+            ) . ($this->suffix);
         } else {
             $number = $this->lastId + 1;
         }


### PR DESCRIPTION
## Description
It was adding the 0s till the order_number_length and adding the (lastId+1). For example if order_number_length is set to 5 and my last id it 101, then next order increment id will be "00000102".
I have done the fix to generate order increment id like "00102".

## How To Test This?
By setting the order number length in config and then placing any order. After that see the order_increment_id.
