### PR TITLE
bug fix - after removing customer address in admin panel page does not reload

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Customer/AddressController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Customer/AddressController.php
@@ -174,7 +174,7 @@ class AddressController extends Controller
 
         session()->flash('success', trans('admin::app.customers.addresses.success-delete'));
 
-        return redirect()->route($this->_config['redirect']);
+        return response('success', 204);
     }
 
     /**

--- a/packages/Webkul/Admin/src/Http/routes.php
+++ b/packages/Webkul/Admin/src/Http/routes.php
@@ -103,9 +103,7 @@ Route::group(['middleware' => ['web', 'admin_locale']], function () {
                 'redirect' => 'admin.customer.addresses.index',
             ])->name('admin.customer.addresses.update');
 
-            Route::post('customers/addresses/delete/{id}', 'Webkul\Admin\Http\Controllers\Customer\AddressController@destroy')->defaults('_config', [
-                'redirect' => 'admin.customer.addresses.index',
-            ])->name('admin.customer.addresses.delete');
+            Route::post('customers/addresses/delete/{id}', 'Webkul\Admin\Http\Controllers\Customer\AddressController@destroy')->name('admin.customer.addresses.delete');
 
             //mass destroy
             Route::post('customers/{id}/addresses', 'Webkul\Admin\Http\Controllers\Customer\AddressController@massDestroy')->defaults('_config', [


### PR DESCRIPTION
## Issue Reference
Link: #5098 

## Description
Hi, I used no content response because in datagrid-plus in do action method in axios success response it will reload the page and will flash the message, but if we use redirect back or redirect to a route because there's two URL loading flash message will be destroyed in first redirect call.
I also removed the config from the route but I think I did it wrong, but for this solution, it's useless, maybe in the future, we need that.

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->
