### PR TITLE
Removed non-compliant condition in orders initialization

### DIFF
--- a/packages/Webkul/Ui/src/Resources/assets/js/components/datagrid/datagrid-plus.vue
+++ b/packages/Webkul/Ui/src/Resources/assets/js/components/datagrid/datagrid-plus.vue
@@ -774,8 +774,7 @@
                     .get(this.url)
                     .then(function(response) {
                         if (
-                            response.status === 200 &&
-                            response.statusText === "OK"
+                            response.status === 200
                         ) {
                             let results = response.data;
 


### PR DESCRIPTION
## Issue Reference
#5123, #5118

## Description
Removed non-compliant condition in orders initialization because that property is not in the order response

## How To Test This?
Just enter the orders section in the administrative panel.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->
