### PR TITLE
Search API addition in webkul/API package to search a product

### DIFF
--- a/packages/Webkul/API/Http/Controllers/Shop/ProductController.php
+++ b/packages/Webkul/API/Http/Controllers/Shop/ProductController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Webkul\Product\Repositories\ProductRepository;
 use Webkul\API\Http\Resources\Catalog\Product as ProductResource;
+use Webkul\Velocity\Repositories\Product\ProductRepository as VelocityProductRepository;
 
 class ProductController extends Controller
 {
@@ -17,14 +18,23 @@ class ProductController extends Controller
     protected $productRepository;
 
     /**
+     * ProductRepository object
+     *
+     * @var \Webkul\Velocity\Repositories\Product\ProductRepository
+     */
+    protected $velocityProductRepository;
+
+    /**
      * Create a new controller instance.
      *
      * @param  \Webkul\Product\Repositories\ProductRepository $productRepository
+     * @param  \Webkul\Velocity\Repositories\Product\ProductRepository $velocityProductRepository
      * @return void
      */
-    public function __construct(ProductRepository $productRepository)
+    public function __construct(ProductRepository $productRepository, VelocityProductRepository $velocityProductRepository)
     {
         $this->productRepository = $productRepository;
+        $this->velocityProductRepository = $velocityProductRepository;
     }
 
     /**
@@ -73,6 +83,18 @@ class ProductController extends Controller
     {
         return response()->json([
             'data' => app('Webkul\Product\Helpers\ConfigurableOption')->getConfigurationConfig($this->productRepository->findOrFail($id)),
+        ]);
+    }
+
+    /**
+     * Returns product's Search.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function search()
+    {
+        return response()->json([
+            'data' => $this->velocityProductRepository->searchProductsFromCategory(request()->all()),
         ]);
     }
 }

--- a/packages/Webkul/API/Http/Resources/Catalog/Search.php
+++ b/packages/Webkul/API/Http/Resources/Catalog/Search.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Webkul\API\Http\Resources\Catalog;
+
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class Search extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'id'                 => $this->id,
+            'code'               => $this->code,
+            'name'               => $this->name,
+            'slug'               => $this->slug,
+            'display_mode'       => $this->display_mode,
+            'description'        => $this->description,
+            'meta_title'         => $this->meta_title,
+            'meta_description'   => $this->meta_description,
+            'meta_keywords'      => $this->meta_keywords,
+            'status'             => $this->status,
+            'image_url'          => $this->image_url,
+            'category_icon_path' => $this->category_icon_path
+                ? Storage::url($this->category_icon_path)
+                : null,
+            'additional'         => is_array($this->resource->additional)
+                ? $this->resource->additional
+                : json_decode($this->resource->additional, true),
+            'created_at'         => $this->created_at,
+            'updated_at'         => $this->updated_at,
+        ];
+    }
+}

--- a/packages/Webkul/API/Http/routes.php
+++ b/packages/Webkul/API/Http/routes.php
@@ -286,5 +286,12 @@ Route::group(['prefix' => 'api'], function ($router) {
 
             Route::post('save-order', 'CheckoutController@saveOrder');
         });
+
+        // Product Search
+        // GET <HOST>/api/search?category=2&term=iphone
+        Route::get('search', 'ProductController@search')->defaults('_config', [
+            'repository' => 'Webkul\Category\Repositories\SearchRepository',
+            'resource' => 'Webkul\API\Http\Resources\Catalog\Search'
+        ]);
     });
 });


### PR DESCRIPTION
## Issue Reference
The search API is missing in the Webkul/API package for a user to run a product search. 

## Description
The search API addition in the Webkul/API package to search product by category or by a search term. 

## How To Test This?
1) Open the Postman and run the below url to see search product result
2) <Host>/api/search?category={categoryId}&term={term}

## Documentation
- My API needs to add to the "https://devdocs.bagisto.com/1.x/api/" Bagisto Web API section. 
