### PR TITLE
Fixed cart items which get increased when navigating away from the buy now functionality #5179

### DIFF
--- a/packages/Webkul/Checkout/src/Http/Middleware/CartMerger.php
+++ b/packages/Webkul/Checkout/src/Http/Middleware/CartMerger.php
@@ -15,7 +15,11 @@ class CartMerger
      */
     public function handle($request, Closure $next)
     {
-        \Cart::mergeDeactivatedCart();
+        /**
+         * Currently removing the buy now cart only because in live
+         * instance merging not happen properly need to check this.
+         */
+        \Cart::activateCartIfSessionHasDeactivatedCartId();
 
         return $next($request);
     }


### PR DESCRIPTION
## Issue Reference
Link: https://github.com/bagisto/bagisto/issues/5179

## Description
- Currently, instead of merging I just removed the current buy now cart because on merging some issues happen on the live instances. Need to check this.

## How To Test This?
- Add two-three items to the cart.
- Then buy now any product.
- Then navigate away from the checkout.
- Old cart items should be there.
