### PR TITLE
Cancel order API for customer implemented #5178

### DIFF
--- a/packages/Webkul/API/Http/Controllers/Shop/OrderController.php
+++ b/packages/Webkul/API/Http/Controllers/Shop/OrderController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Webkul\API\Http\Controllers\Shop;
+
+class OrderController extends Controller
+{
+    /**
+     * Contains current guard.
+     *
+     * @var array
+     */
+    protected $guard;
+
+    /**
+     * Contains route related configuration.
+     *
+     * @var array
+     */
+    protected $_config;
+
+    /**
+     * Repository instance.
+     *
+     * @var \Webkul\Core\Eloquent\Repository
+     */
+    protected $repository;
+
+    /**
+     * Create a new controller instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->guard = request()->has('token') ? 'api' : 'customer';
+
+        $this->_config = request('_config');
+
+        if (isset($this->_config['authorization_required']) && $this->_config['authorization_required']) {
+            auth()->setDefaultDriver($this->guard);
+
+            $this->middleware('auth:' . $this->guard);
+        }
+
+        if ($this->_config) {
+            $this->repository = app($this->_config['repository']);
+        }
+    }
+
+    /**
+     * Cancel customer's order.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function cancel($id)
+    {
+        $order = auth()->guard($this->guard)->user()->all_orders()->find($id);
+
+        if ($order && $this->repository->cancel($order)) {
+            return response()->json([
+                'status'  => true,
+                'message' => __('admin::app.response.cancel-success', [
+                    'name' => 'Order'
+                ]),
+            ]);
+        }
+
+        return response()->json([
+            'status'  => false,
+            'message' => __('shop::app.common.error'),
+        ]);
+    }
+}

--- a/packages/Webkul/API/Http/routes.php
+++ b/packages/Webkul/API/Http/routes.php
@@ -200,6 +200,11 @@ Route::group(['prefix' => 'api'], function ($router) {
             'authorization_required' => true
         ]);
 
+        Route::post('orders/{id}/cancel', 'OrderController@cancel')->defaults('_config', [
+            'repository' => 'Webkul\Sales\Repositories\OrderRepository',
+            'resource' => 'Webkul\API\Http\Resources\Sales\Order',
+            'authorization_required' => true
+        ]);
 
         //Invoice routes
         Route::get('invoices', 'InvoiceController@index')->defaults('_config', [

--- a/packages/Webkul/Shop/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Shop/src/Resources/lang/en/app.php
@@ -289,7 +289,7 @@ return [
                     'closed' => 'Closed',
                     'pending' => 'Pending',
                     'pending-payment' => 'Pending Payment',
-                    'fraud' => 'Fraud',
+                    'fraud' => 'Fraud'
                 ],
 
                 'view' => [

--- a/packages/Webkul/Shop/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Shop/src/Resources/lang/en/app.php
@@ -289,7 +289,7 @@ return [
                     'closed' => 'Closed',
                     'pending' => 'Pending',
                     'pending-payment' => 'Pending Payment',
-                    'fraud' => 'Fraud'
+                    'fraud' => 'Fraud',
                 ],
 
                 'view' => [


### PR DESCRIPTION
## Issue Reference
Link: https://github.com/bagisto/bagisto/issues/5178

## Description
- Added API for a customer.

## How To Test This?
- Hit this `POST api/order/{id}/cancel?token=true`.

## Documentation
- [x] My pull request requires an update on the documentation repository.
