### PR TITLE
Allow unchecking all checkboxes in an attribute

### DIFF
--- a/packages/Webkul/Product/src/Http/Controllers/ProductController.php
+++ b/packages/Webkul/Product/src/Http/Controllers/ProductController.php
@@ -227,7 +227,7 @@ class ProductController extends Controller
 
             if (count($customAttributes)) {
                 foreach ($customAttributes as $attribute) {
-                    if ($attribute->type == 'multiselect') {
+                    if ($attribute->type == 'multiselect' || $attribute->type == 'checkbox') {
                         array_push($multiselectAttributeCodes, $attribute->code);
                     }
                 }


### PR DESCRIPTION
## Issue Reference
Fixes #5191 

## Description

When a checkbox attribute is not required, all checkboxes can successfully be unchecked.

## Tests
Tested changes locally on my machine.

## Documentation
- [x] My pull request does NOT require an update to the documentation.
<!--- Please describe in detail what needs to be changed. --->
