### PR TITLE
Fixed class name

### DIFF
--- a/packages/Webkul/Product/src/Models/ProductBundleOptionProduct.php
+++ b/packages/Webkul/Product/src/Models/ProductBundleOptionProduct.php
@@ -23,7 +23,7 @@ class ProductBundleOptionProduct extends Model implements ProductBundleOptionPro
      */
     public function bundle_option()
     {
-        return $this->belongsTo(ProductBundleProductProxy::modelClass());
+        return $this->belongsTo(ProductBundleOptionProxy::modelClass());
     }
 
     /**


### PR DESCRIPTION
Changed class name in bundle option relationship. Because There is no ProductBundleProductProxy class. It is related to ProductBundleOptionProxy class.

## Issue Reference
There is no issue open related to this at the time of pull request.

## Description
There was a mistake referencing class name in the relationship method of bundle_option.
