### PR TITLE
typo fixed

### DIFF
--- a/packages/Webkul/Shipping/src/Carriers/AbstractShipping.php
+++ b/packages/Webkul/Shipping/src/Carriers/AbstractShipping.php
@@ -2,8 +2,6 @@
 
 namespace Webkul\Shipping\Carriers;
 
-use Illuminate\Support\Facades\Config;
-
 abstract class AbstractShipping
 {
     abstract public function calculate();

--- a/packages/Webkul/Shipping/src/Carriers/AbstractShipping.php
+++ b/packages/Webkul/Shipping/src/Carriers/AbstractShipping.php
@@ -49,7 +49,7 @@ abstract class AbstractShipping
      */
     public function getDescription()
     {
-        return $this->getConfigData('decription');
+        return $this->getConfigData('description');
     }
 
     /**


### PR DESCRIPTION
Hi, config key of description in abstract shipping method has a typo so when you want to get description with getter method, it returns null.
