### PR TITLE
Fix download catalog/products

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/ExportController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/ExportController.php
@@ -32,7 +32,7 @@ class ExportController extends Controller
 
         $path = '\Webkul\Admin\DataGrids' . '\\' . last($gridName);
 
-        $gridInstance = new $path;
+        $gridInstance = App::make($path);
 
         $records = $gridInstance->export();
 


### PR DESCRIPTION
## Issue Reference
On the catalogue products page if you try to download the list of csv or xls an error is generated because no properties are declared in the constructor.
## Description
I fixed the problem by adding the solver App::make
