### PR TITLE
Use generic Factory class on method return type

### DIFF
--- a/packages/Webkul/Attribute/src/Models/Attribute.php
+++ b/packages/Webkul/Attribute/src/Models/Attribute.php
@@ -3,6 +3,7 @@
 namespace Webkul\Attribute\Models;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Webkul\Core\Eloquent\TranslatableModel;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -61,9 +62,9 @@ class Attribute extends TranslatableModel implements AttributeContract
     /**
      * Create a new factory instance for the model
      *
-     * @return AttributeFactory
+     * @return Factory
      */
-    protected static function newFactory(): AttributeFactory
+    protected static function newFactory(): Factory
     {
         return AttributeFactory::new();
     }

--- a/packages/Webkul/Attribute/src/Models/AttributeFamily.php
+++ b/packages/Webkul/Attribute/src/Models/AttributeFamily.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Attribute\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Webkul\Product\Models\ProductProxy;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -82,7 +83,12 @@ class AttributeFamily extends Model implements AttributeFamilyContract
         return $this->hasMany(ProductProxy::modelClass());
     }
 
-    protected static function newFactory(): AttributeFamilyFactory
+    /**
+     * Create a new factory instance for the model
+     *
+     * @return Factory
+     */
+    protected static function newFactory(): Factory
     {
         return AttributeFamilyFactory::new();
     }

--- a/packages/Webkul/Attribute/src/Models/AttributeOption.php
+++ b/packages/Webkul/Attribute/src/Models/AttributeOption.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Attribute\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Webkul\Core\Eloquent\TranslatableModel;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -51,7 +52,12 @@ class AttributeOption extends TranslatableModel implements AttributeOptionContra
         return $this->swatch_value_url();
     }
 
-    protected static function newFactory(): AttributeOptionFactory
+    /**
+     * Create a new factory instance for the model
+     *
+     * @return Factory
+     */
+    protected static function newFactory(): Factory
     {
         return AttributeOptionFactory::new();
     }

--- a/packages/Webkul/BookingProduct/src/Models/BookingProduct.php
+++ b/packages/Webkul/BookingProduct/src/Models/BookingProduct.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\BookingProduct\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Webkul\Product\Models\ProductProxy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -79,9 +80,9 @@ class BookingProduct extends Model implements BookingProductContract
     /**
      * Create a new factory instance for the model.
      *
-     * @return BookingProductFactory
+     * @return Factory
      */
-    protected static function newFactory(): BookingProductFactory
+    protected static function newFactory(): Factory
     {
         return BookingProductFactory::new();
     }

--- a/packages/Webkul/BookingProduct/src/Models/BookingProductEventTicket.php
+++ b/packages/Webkul/BookingProduct/src/Models/BookingProductEventTicket.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\BookingProduct\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Webkul\Core\Eloquent\TranslatableModel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Webkul\BookingProduct\Database\Factories\BookingProductEventTicketFactory;
@@ -30,9 +31,9 @@ class BookingProductEventTicket extends TranslatableModel implements BookingProd
     /**
      * Create a new factory instance for the model.
      *
-     * @return BookingProductEventTicketFactory
+     * @return Factory
      */
-    protected static function newFactory(): BookingProductEventTicketFactory
+    protected static function newFactory(): Factory
     {
         return BookingProductEventTicketFactory::new();
     }

--- a/packages/Webkul/CartRule/src/Models/CartRule.php
+++ b/packages/Webkul/CartRule/src/Models/CartRule.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\CartRule\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Webkul\Core\Database\Factories\CartRuleFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -133,9 +134,9 @@ class CartRule extends Model implements CartRuleContract
     /**
      * Create a new factory instance for the model.
      *
-     * @return CartRuleFactory
+     * @return Factory
      */
-    protected static function newFactory(): CartRuleFactory
+    protected static function newFactory(): Factory
     {
         return CartRuleFactory::new();
     }

--- a/packages/Webkul/CartRule/src/Models/CartRuleCoupon.php
+++ b/packages/Webkul/CartRule/src/Models/CartRuleCoupon.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\CartRule\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -30,7 +31,7 @@ class CartRuleCoupon extends Model implements CartRuleCouponContract
     {
         return $this->belongsTo(CartRuleProxy::modelClass());
     }
-    
+
     /**
      * Get the cart rule that owns the cart rule coupon.
      */
@@ -42,9 +43,9 @@ class CartRuleCoupon extends Model implements CartRuleCouponContract
     /**
      * Create a new factory instance for the model
      *
-     * @return CartRuleCouponFactory
+     * @return Factory
      */
-    protected static function newFactory(): CartRuleCouponFactory
+    protected static function newFactory(): Factory
     {
         return CartRuleCouponFactory::new();
     }

--- a/packages/Webkul/Category/src/Models/Category.php
+++ b/packages/Webkul/Category/src/Models/Category.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Category\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Webkul\Core\Eloquent\TranslatableModel;
 use Kalnoy\Nestedset\NodeTrait;
 use Illuminate\Support\Facades\Storage;
@@ -164,9 +165,9 @@ class Category extends TranslatableModel implements CategoryContract
     /**
      * Create a new factory instance for the model.
      *
-     * @return CategoryFactory
+     * @return Factory
      */
-    protected static function newFactory(): CategoryFactory
+    protected static function newFactory(): Factory
     {
         return CategoryFactory::new();
     }

--- a/packages/Webkul/Checkout/src/Models/Cart.php
+++ b/packages/Webkul/Checkout/src/Models/Cart.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Checkout\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Webkul\Checkout\Contracts\Cart as CartContract;
 use Webkul\Checkout\Database\Factories\CartFactory;
@@ -203,9 +204,9 @@ class Cart extends Model implements CartContract
     /**
      * Create a new factory instance for the model
      *
-     * @return CartFactory
+     * @return Factory
      */
-    protected static function newFactory(): CartFactory
+    protected static function newFactory(): Factory
     {
         return CartFactory::new();
     }

--- a/packages/Webkul/Checkout/src/Models/CartAddress.php
+++ b/packages/Webkul/Checkout/src/Models/CartAddress.php
@@ -3,6 +3,7 @@
 namespace Webkul\Checkout\Models;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -70,9 +71,9 @@ class CartAddress extends Address implements CartAddressContract
     /**
      * Create a new factory instance for the model
      *
-     * @return CartAddressFactory
+     * @return Factory
      */
-    protected static function newFactory(): CartAddressFactory
+    protected static function newFactory(): Factory
     {
         return CartAddressFactory::new();
     }

--- a/packages/Webkul/Checkout/src/Models/CartItem.php
+++ b/packages/Webkul/Checkout/src/Models/CartItem.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Checkout\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Webkul\Product\Models\ProductProxy;
 use Webkul\Product\Models\ProductFlatProxy;
@@ -86,9 +87,9 @@ class CartItem extends Model implements CartItemContract
     /**
      * Create a new factory instance for the model
      *
-     * @return CartItemFactory
+     * @return Factory
      */
-    protected static function newFactory(): CartItemFactory
+    protected static function newFactory(): Factory
     {
         return CartItemFactory::new();
     }

--- a/packages/Webkul/Checkout/src/Models/CartPayment.php
+++ b/packages/Webkul/Checkout/src/Models/CartPayment.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Checkout\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Webkul\Checkout\Database\Factories\CartPaymentFactory;
@@ -16,9 +17,9 @@ class CartPayment extends Model implements CartPaymentContract
     /**
      * Create a new factory instance for the model
      *
-     * @return CartPaymentFactory
+     * @return Factory
      */
-    protected static function newFactory(): CartPaymentFactory
+    protected static function newFactory(): Factory
     {
         return CartPaymentFactory::new();
     }

--- a/packages/Webkul/Core/src/Models/Channel.php
+++ b/packages/Webkul/Core/src/Models/Channel.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Core\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Storage;
 use Webkul\Category\Models\CategoryProxy;
 use Webkul\Core\Eloquent\TranslatableModel;
@@ -133,9 +134,9 @@ class Channel extends TranslatableModel implements ChannelContract
     /**
      * Create a new factory instance for the model
      *
-     * @return ChannelFactory
+     * @return Factory
      */
-    protected static function newFactory(): ChannelFactory
+    protected static function newFactory(): Factory
     {
         return ChannelFactory::new();
     }

--- a/packages/Webkul/Core/src/Models/Currency.php
+++ b/packages/Webkul/Core/src/Models/Currency.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Core\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Webkul\Core\Database\Factories\CurrencyFactory;
@@ -46,9 +47,9 @@ class Currency extends Model implements CurrencyContract
     /**
      * Create a new factory instance for the model.
      *
-     * @return CurrencyFactory
+     * @return Factory
      */
-    protected static function newFactory(): CurrencyFactory
+    protected static function newFactory(): Factory
     {
         return CurrencyFactory::new();
     }

--- a/packages/Webkul/Core/src/Models/Locale.php
+++ b/packages/Webkul/Core/src/Models/Locale.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Core\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Webkul\Core\Database\Factories\LocaleFactory;
 use Webkul\Core\Contracts\Locale as LocaleContract;
@@ -25,9 +26,9 @@ class Locale extends Model implements LocaleContract
     /**
      * Create a new factory instance for the model.
      *
-     * @return LocaleFactory
+     * @return Factory
      */
-    protected static function newFactory(): LocaleFactory
+    protected static function newFactory(): Factory
     {
         return LocaleFactory::new();
     }

--- a/packages/Webkul/Core/src/Models/SubscribersList.php
+++ b/packages/Webkul/Core/src/Models/SubscribersList.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Core\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Webkul\Customer\Models\CustomerProxy;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -42,9 +43,9 @@ class SubscribersList extends Model implements SubscribersListContract
     /**
      * Create a new factory instance for the model.
      *
-     * @return SubscriberListFactory
+     * @return Factory
      */
-    protected static function newFactory(): SubscriberListFactory
+    protected static function newFactory(): Factory
     {
         return SubscriberListFactory::new();
     }

--- a/packages/Webkul/Customer/src/Models/CustomerAddress.php
+++ b/packages/Webkul/Customer/src/Models/CustomerAddress.php
@@ -3,6 +3,7 @@
 namespace Webkul\Customer\Models;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Webkul\Core\Models\Address;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Webkul\Customer\Database\Factories\CustomerAddressFactory;
@@ -38,9 +39,9 @@ class CustomerAddress extends Address implements CustomerAddressContract
     /**
      * Create a new factory instance for the model
      *
-     * @return CustomerAddressFactory
+     * @return Factory
      */
-    protected static function newFactory(): CustomerAddressFactory
+    protected static function newFactory(): Factory
     {
         return CustomerAddressFactory::new();
     }

--- a/packages/Webkul/Customer/src/Models/CustomerGroup.php
+++ b/packages/Webkul/Customer/src/Models/CustomerGroup.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Customer\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -31,9 +32,9 @@ class CustomerGroup extends Model implements CustomerGroupContract
     /**
      * Create a new factory instance for the model
      *
-     * @return CustomerGroupFactory
+     * @return Factory
      */
-    protected static function newFactory(): CustomerGroupFactory
+    protected static function newFactory(): Factory
     {
         return CustomerGroupFactory::new();
     }

--- a/packages/Webkul/Inventory/src/Models/InventorySource.php
+++ b/packages/Webkul/Inventory/src/Models/InventorySource.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Inventory\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Webkul\Inventory\Database\Factories\InventorySourceFactory;
@@ -16,9 +17,9 @@ class InventorySource extends Model implements InventorySourceContract
     /**
      * Create a new factory instance for the model.
      *
-     * @return InventorySourceFactory
+     * @return Factory
      */
-    protected static function newFactory(): InventorySourceFactory
+    protected static function newFactory(): Factory
     {
         return InventorySourceFactory::new();
     }

--- a/packages/Webkul/Product/src/Models/Product.php
+++ b/packages/Webkul/Product/src/Models/Product.php
@@ -3,6 +3,7 @@
 namespace Webkul\Product\Models;
 
 use Exception;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Webkul\Attribute\Models\AttributeFamilyProxy;
@@ -534,9 +535,9 @@ class Product extends Model implements ProductContract
     /**
      * Create a new factory instance for the model.
      *
-     * @return ProductFactory
+     * @return Factory
      */
-    protected static function newFactory(): ProductFactory
+    protected static function newFactory(): Factory
     {
         return ProductFactory::new();
     }

--- a/packages/Webkul/Product/src/Models/ProductAttributeValue.php
+++ b/packages/Webkul/Product/src/Models/ProductAttributeValue.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Product\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Webkul\Attribute\Models\AttributeProxy;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -77,9 +78,9 @@ class ProductAttributeValue extends Model implements ProductAttributeValueContra
     /**
      * Create a new factory instance for the model.
      *
-     * @return ProductAttributeValueFactory
+     * @return Factory
      */
-    protected static function newFactory(): ProductAttributeValueFactory
+    protected static function newFactory(): Factory
     {
         return ProductAttributeValueFactory::new();
     }

--- a/packages/Webkul/Product/src/Models/ProductDownloadableLink.php
+++ b/packages/Webkul/Product/src/Models/ProductDownloadableLink.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Product\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Webkul\Core\Eloquent\TranslatableModel;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -93,9 +94,9 @@ class ProductDownloadableLink extends TranslatableModel implements ProductDownlo
     /**
      * Create a new factory instance for the model.
      *
-     * @return ProductDownloadableLinkFactory
+     * @return Factory
      */
-    protected static function newFactory(): ProductDownloadableLinkFactory
+    protected static function newFactory(): Factory
     {
         return ProductDownloadableLinkFactory::new();
     }

--- a/packages/Webkul/Product/src/Models/ProductDownloadableLinkTranslation.php
+++ b/packages/Webkul/Product/src/Models/ProductDownloadableLinkTranslation.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Product\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Webkul\Product\Database\Factories\ProductDownloadableLinkTranslationFactory;
@@ -18,9 +19,9 @@ class ProductDownloadableLinkTranslation extends Model implements ProductDownloa
     /**
      * Create a new factory instance for the model.
      *
-     * @return ProductDownloadableLinkTranslationFactory
+     * @return Factory
      */
-    protected static function newFactory(): ProductDownloadableLinkTranslationFactory
+    protected static function newFactory(): Factory
     {
         return ProductDownloadableLinkTranslationFactory::new();
     }

--- a/packages/Webkul/Product/src/Models/ProductInventory.php
+++ b/packages/Webkul/Product/src/Models/ProductInventory.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Product\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Webkul\Inventory\Models\InventorySourceProxy;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -41,9 +42,9 @@ class ProductInventory extends Model implements ProductInventoryContract
     /**
      * Create a new factory instance for the model.
      *
-     * @return ProductInventoryFactory
+     * @return Factory
      */
-    protected static function newFactory(): ProductInventoryFactory
+    protected static function newFactory(): Factory
     {
         return ProductInventoryFactory::new();
     }

--- a/packages/Webkul/Product/src/Models/ProductReview.php
+++ b/packages/Webkul/Product/src/Models/ProductReview.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Product\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Webkul\Customer\Models\CustomerProxy;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -51,9 +52,9 @@ class ProductReview extends Model implements ProductReviewContract
     /**
      * Create a new factory instance for the model.
      *
-     * @return ProductReviewFactory
+     * @return Factory
      */
-    protected static function newFactory(): ProductReviewFactory
+    protected static function newFactory(): Factory
     {
         return ProductReviewFactory::new();
     }

--- a/packages/Webkul/Sales/src/Models/Invoice.php
+++ b/packages/Webkul/Sales/src/Models/Invoice.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Sales\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -91,9 +92,9 @@ class Invoice extends Model implements InvoiceContract
     /**
      * Create a new factory instance for the model.
      *
-     * @return InvoiceFactory
+     * @return Factory
      */
-    protected static function newFactory(): InvoiceFactory
+    protected static function newFactory(): Factory
     {
         return InvoiceFactory::new();
     }

--- a/packages/Webkul/Sales/src/Models/InvoiceItem.php
+++ b/packages/Webkul/Sales/src/Models/InvoiceItem.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Sales\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Webkul\Product\Type\AbstractType;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOne;
@@ -87,9 +88,9 @@ class InvoiceItem extends Model implements InvoiceItemContract
     /**
      * Create a new factory instance for the model.
      *
-     * @return InvoiceItemFactory
+     * @return Factory
      */
-    protected static function newFactory(): InvoiceItemFactory
+    protected static function newFactory(): Factory
     {
         return InvoiceItemFactory::new();
     }

--- a/packages/Webkul/Sales/src/Models/Order.php
+++ b/packages/Webkul/Sales/src/Models/Order.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Sales\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Webkul\Checkout\Models\CartProxy;
 use Illuminate\Database\Eloquent\Model;
 use Webkul\Sales\Contracts\Order as OrderContract;
@@ -273,7 +274,7 @@ class Order extends Model implements OrderContract
 
         return false;
     }
-    
+
     /**
      * Verify if a invoice is still unpaid
      *
@@ -360,9 +361,9 @@ class Order extends Model implements OrderContract
     /**
      * Create a new factory instance for the model.
      *
-     * @return OrderFactory
+     * @return Factory
      */
-    protected static function newFactory(): OrderFactory
+    protected static function newFactory(): Factory
     {
         return OrderFactory::new();
     }

--- a/packages/Webkul/Sales/src/Models/OrderAddress.php
+++ b/packages/Webkul/Sales/src/Models/OrderAddress.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Sales\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Webkul\Checkout\Models\CartAddress;
 use Webkul\Core\Models\Address;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -73,9 +74,9 @@ class OrderAddress extends Address implements OrderAddressContract
     /**
      * Create a new factory instance for the model.
      *
-     * @return OrderAddressFactory
+     * @return Factory
      */
-    protected static function newFactory(): OrderAddressFactory
+    protected static function newFactory(): Factory
     {
         return OrderAddressFactory::new();
     }

--- a/packages/Webkul/Sales/src/Models/OrderItem.php
+++ b/packages/Webkul/Sales/src/Models/OrderItem.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Sales\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Webkul\Product\Type\AbstractType;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOne;
@@ -226,9 +227,9 @@ class OrderItem extends Model implements OrderItemContract
     /**
      * Create a new factory instance for the model.
      *
-     * @return OrderItemFactory
+     * @return Factory
      */
-    protected static function newFactory(): OrderItemFactory
+    protected static function newFactory(): Factory
     {
         return OrderItemFactory::new();
     }

--- a/packages/Webkul/Sales/src/Models/OrderPayment.php
+++ b/packages/Webkul/Sales/src/Models/OrderPayment.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Sales\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Webkul\Sales\Database\Factories\OrderPaymentFactory;
@@ -26,9 +27,9 @@ class OrderPayment extends Model implements OrderPaymentContract
     /**
      * Create a new factory instance for the model.
      *
-     * @return OrderPaymentFactory
+     * @return Factory
      */
-    protected static function newFactory(): OrderPaymentFactory
+    protected static function newFactory(): Factory
     {
         return OrderPaymentFactory::new();
     }

--- a/packages/Webkul/Sales/src/Models/Refund.php
+++ b/packages/Webkul/Sales/src/Models/Refund.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Sales\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Webkul\Sales\Database\Factories\RefundFactory;
 use Webkul\Sales\Contracts\Refund as RefundContract;
@@ -74,9 +75,9 @@ class Refund extends Model implements RefundContract
     /**
      * Create a new factory instance for the model.
      *
-     * @return RefundFactory
+     * @return Factory
      */
-    protected static function newFactory(): RefundFactory
+    protected static function newFactory(): Factory
     {
         return RefundFactory::new();
     }

--- a/packages/Webkul/Sales/src/Models/Shipment.php
+++ b/packages/Webkul/Sales/src/Models/Shipment.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Sales\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Webkul\Inventory\Models\InventorySource;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
@@ -65,9 +66,9 @@ class Shipment extends Model implements ShipmentContract
     /**
      * Create a new factory instance for the model.
      *
-     * @return ShipmentFactory
+     * @return Factory
      */
-    protected static function newFactory(): ShipmentFactory
+    protected static function newFactory(): Factory
     {
         return ShipmentFactory::new();
     }

--- a/packages/Webkul/Tax/src/Models/TaxCategory.php
+++ b/packages/Webkul/Tax/src/Models/TaxCategory.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Tax\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Webkul\Tax\Database\Factories\TaxCategoryFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -36,9 +37,9 @@ class TaxCategory extends Model implements TaxCategoryContract
     /**
      * Create a new factory instance for the model.
      *
-     * @return TaxCategoryFactory
+     * @return Factory
      */
-    protected static function newFactory(): TaxCategoryFactory
+    protected static function newFactory(): Factory
     {
         return TaxCategoryFactory::new();
     }

--- a/packages/Webkul/Tax/src/Models/TaxMap.php
+++ b/packages/Webkul/Tax/src/Models/TaxMap.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Tax\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Webkul\Tax\Database\Factories\TaxMapFactory;
 use Webkul\Tax\Contracts\TaxMap as TaxMapContract;
@@ -27,9 +28,9 @@ class TaxMap extends Model implements TaxMapContract
     /**
      * Create a new factory instance for the model.
      *
-     * @return TaxMapFactory
+     * @return Factory
      */
-    protected static function newFactory(): TaxMapFactory
+    protected static function newFactory(): Factory
     {
         return TaxMapFactory::new();
     }

--- a/packages/Webkul/Tax/src/Models/TaxRate.php
+++ b/packages/Webkul/Tax/src/Models/TaxRate.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\Tax\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Webkul\Tax\Database\Factories\TaxRateFactory;
 use Webkul\Tax\Contracts\TaxRate as TaxRateContract;
@@ -39,9 +40,9 @@ class TaxRate extends Model implements TaxRateContract
     /**
      * Create a new factory instance for the model.
      *
-     * @return TaxRateFactory
+     * @return Factory
      */
-    protected static function newFactory(): TaxRateFactory
+    protected static function newFactory(): Factory
     {
         return TaxRateFactory::new();
     }

--- a/packages/Webkul/User/src/Models/Admin.php
+++ b/packages/Webkul/User/src/Models/Admin.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\User\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -78,9 +79,9 @@ class Admin extends Authenticatable implements AdminContract, JWTSubject
     /**
      * Create a new factory instance for the model.
      *
-     * @return AdminFactory
+     * @return Factory
      */
-    protected static function newFactory(): AdminFactory
+    protected static function newFactory(): Factory
     {
         return AdminFactory::new();
     }


### PR DESCRIPTION
Better to put the type of return to the generic than to the child, so it is extensible, don't you think? @devansh-webkul 