### PR TITLE
Address State Fixed #5501

### DIFF
--- a/packages/Webkul/Customer/src/Http/Requests/CustomerAddressRequest.php
+++ b/packages/Webkul/Customer/src/Http/Requests/CustomerAddressRequest.php
@@ -34,7 +34,7 @@ class CustomerAddressRequest extends FormRequest
             'address1'     => ['required', 'array'],
             'address1.*'   => ['required', new Address],
             'country'      => ['required', 'alpha'],
-            'state'        => ['required', 'alpha'],
+            'state'        => ['required', new AlphaNumericSpace],
             'city'         => ['required'],
             'postcode'     => ['required', 'numeric'],
             'phone'        => ['required', new PhoneNumber],


### PR DESCRIPTION
## Issue Reference
Link: https://github.com/bagisto/bagisto/issues/5501

## Info
- Maybe for other countries states can use space alphabets and numbers (rarely). I am not sure but I just reverted to the previous one.
