### PR TITLE
data grid sum Priceissue

### DIFF
--- a/packages/Webkul/Ui/src/DataGrid/Traits/ProvideCollection.php
+++ b/packages/Webkul/Ui/src/DataGrid/Traits/ProvideCollection.php
@@ -208,6 +208,8 @@ trait ProvideCollection
                     $this->resolve($collection, $columnName, $condition, $filterValue, 'whereDate');
                 } else if ($columnType === 'boolean') {
                     $this->resolve($collection, $columnName, $condition, $filterValue, 'where', 'resolveBooleanQuery');
+                } else if ($columnType === 'price') {
+                    $this->resolve($collection, $columnName, $condition, $filterValue, 'having');
                 } else {
                     $this->resolve($collection, $columnName, $condition, $filterValue);
                 }


### PR DESCRIPTION
Data grid price filter when using sum wasn't working with where clause.
So, updated the price data type with having clause.
This way it's working fine for both prices whether it's the sum of the price or the simple price.