### PR TITLE
refactored conditions with simpler terms

### DIFF
--- a/packages/Webkul/Product/src/Http/Controllers/ProductController.php
+++ b/packages/Webkul/Product/src/Http/Controllers/ProductController.php
@@ -329,7 +329,7 @@ class ProductController extends Controller
             return redirect()->back();
         }
 
-        if (! $data['massaction-type'] == 'update') {
+        if ($data['massaction-type'] !== 'update') {
             return redirect()->back();
         }
 

--- a/packages/Webkul/Product/src/Http/Controllers/ReviewController.php
+++ b/packages/Webkul/Product/src/Http/Controllers/ReviewController.php
@@ -150,7 +150,7 @@ class ReviewController extends Controller
                         return redirect()->back();
                     }
 
-                    if (! $data['massaction-type'] == 'update') {
+                    if ($data['massaction-type'] !== 'update') {
                         return redirect()->back();
                     }
 

--- a/packages/Webkul/Product/src/Repositories/ProductFlatRepository.php
+++ b/packages/Webkul/Product/src/Repositories/ProductFlatRepository.php
@@ -192,7 +192,7 @@ class ProductFlatRepository extends Repository
             $filterAttributes = $this->getProductsRelatedFilterableAttributes($category);
         }
 
-        if (! count($filterAttributes) > 0) {
+        if (empty($filterAttributes)) {
             $filterAttributes = $this->attributeRepository->getFilterAttributes();
         }
 

--- a/packages/Webkul/Shop/src/Http/Controllers/ProductController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/ProductController.php
@@ -114,7 +114,7 @@ class ProductController extends Controller
             $filterAttributes = $this->productFlatRepository->getFilterAttributes($category);
         }
 
-        if (! count($filterAttributes) > 0) {
+        if (empty($filterAttributes)) {
             $filterAttributes = $attributeRepository->getFilterAttributes();
         }
 

--- a/packages/Webkul/Velocity/src/Helpers/Helper.php
+++ b/packages/Webkul/Velocity/src/Helpers/Helper.php
@@ -274,7 +274,7 @@ class Helper extends Review
 
         $priceHTML = view('shop::products.price', ['product' => $product])->render();
 
-        $isProductNew = ($product->new && ! strpos($priceHTML, 'sticker sale') > 0) ? __('shop::app.products.new') : false;
+        $isProductNew = ($product->new && strpos($priceHTML, 'sticker sale') === false) ? __('shop::app.products.new') : false;
 
         return [
             'priceHTML'        => $priceHTML,


### PR DESCRIPTION
## Description
Refactoring of some conditions to improve readability. 

In `! $data['massaction-type'] == 'update' ` , the ! operator is applied first, leading to `$data['massaction-type']` to become a boolean (most probably true), then 'update' is also type-juggled into a boolean (true, this time) and finally, both are compared. In fact, when $data['massaction-type'] = 'update' the condition fails, while when $data['massaction-type'] == '' (empty string), it works.  

In `! count($filterAttributes) > 0`, when count() is positive (array filled), it is turned into a false boolean, then a 0, which makes the condition fail. This is replaced with a call to `empty()` 

In `! strpos($priceHTML, 'sticker sale') > 0` when 'sticker sale' is found in the $priceHTML variable, strpos() returns a postive value (possibly 0, though), which is turned into a boolean, then with 0 and compared to 0. This is replaced with a direct comparison with false, to show that the sticker price was not found. 

## How To Test This?
This is refactoring, so unit test are passing the same way as before.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
No need for documentation, this is a code change without feature change. All is still working as before.