### PR TITLE
Uses rounding precision of 4 to store cart item prices

### DIFF
--- a/packages/Webkul/Product/src/Type/AbstractType.php
+++ b/packages/Webkul/Product/src/Type/AbstractType.php
@@ -513,7 +513,7 @@ abstract class AbstractType
      */
     public function getFinalPrice($qty = null)
     {
-        return round($this->getMinimalPrice($qty), 2);
+        return round($this->getMinimalPrice($qty), 4);
     }
 
     /**
@@ -887,7 +887,7 @@ abstract class AbstractType
             return $result;
         }
 
-        $price = round($item->product->getTypeInstance()->getFinalPrice($item->quantity), 2);
+        $price = round($item->product->getTypeInstance()->getFinalPrice($item->quantity), 4);
 
         if ($price == $item->base_price) {
             return $result;


### PR DESCRIPTION
resolves #6501

## Issue Reference
#6501

## Description
Uses rounding precision of 4 to store cart item prices.
This prevents rounding errors after applying taxes.

## How To Test This?

- Create a product with the price 30.2550 € (excluding VAT)
- set tax rate to 19%
- add product to cart
- cart item displays 36.00 € not 36.01 € (as before the patch)