### PR TITLE
Added `HandleCors` to  global middleware stack.

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -14,6 +14,7 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected $middleware = [
+        \Illuminate\Http\Middleware\HandleCors::class,
         \Webkul\Core\Http\Middleware\CheckForMaintenanceMode::class,
         \App\Http\Middleware\EncryptCookies::class,
         \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,


### PR DESCRIPTION

## Description
Added `HandleCors` to  global middleware stack.
this will fix the CORS error when sending requests to Bagisto Web API routes and make use of `config/cors.php` file.
