### PR TITLE
Wish-list sharing link issue resolved #6441

### DIFF
--- a/packages/Webkul/Velocity/src/Resources/views/shop/customers/account/wishlist/wishlist.blade.php
+++ b/packages/Webkul/Velocity/src/Resources/views/shop/customers/account/wishlist/wishlist.blade.php
@@ -166,7 +166,7 @@
                     return {
                         isWishlistShared: parseInt("{{ $isWishlistShared }}"),
 
-                        wishlistSharedLink: "{{ $wishlistSharedLink }}".replace("&amp", "&"),
+                        wishlistSharedLink: "{{ $wishlistSharedLink }}".replace("&amp;", "&"),
                     }
                 },
 

--- a/packages/Webkul/Velocity/src/Resources/views/shop/customers/account/wishlist/wishlist.blade.php
+++ b/packages/Webkul/Velocity/src/Resources/views/shop/customers/account/wishlist/wishlist.blade.php
@@ -166,7 +166,7 @@
                     return {
                         isWishlistShared: parseInt("{{ $isWishlistShared }}"),
 
-                        wishlistSharedLink: "{{ $wishlistSharedLink }}",
+                        wishlistSharedLink: "{{ $wishlistSharedLink }}".replace("&amp", "&"),
                     }
                 },
 


### PR DESCRIPTION
## Issue Reference
#6441

## Description
There was an issue if we copy a already generated link then some extra string get add up with this so it always says page not found if somebody trying to access it.


