### PR TITLE
Fixed issue with coupon usage limit

### DIFF
--- a/packages/Webkul/CartRule/src/Repositories/CartRuleRepository.php
+++ b/packages/Webkul/CartRule/src/Repositories/CartRuleRepository.php
@@ -78,7 +78,7 @@ class CartRuleRepository extends Repository
             $this->cartRuleCouponRepository->create([
                 'cart_rule_id'       => $cartRule->id,
                 'code'               => $data['coupon_code'],
-                'usage_limit'        => $data['usage_per_customer'] ?? 0,
+                'usage_limit'        => $data['uses_per_coupon'] ?? 0,
                 'usage_per_customer' => $data['usage_per_customer'] ?? 0,
                 'is_primary'         => 1,
                 'expired_at'         => $data['ends_till'] ?: null,


### PR DESCRIPTION
## Description
<!--- Please describe your changes in detail. -->
I just fixed the issue, when the admin wanted to set the usage limit NOT per customer.
## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->
- Create cart rule with coupon, do not set usage per customer and try to apply cart rule on checkout
