### PR TITLE
Fix ShowModal Call

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/catalog/families/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/families/edit.blade.php
@@ -83,7 +83,7 @@
 
     <script type="text/x-template" id="group-list-template">
         <div style="margin-top: 20px">
-            <button type="button" style="margin-bottom : 20px" class="btn btn-md btn-primary" @click="showModal('addGroupForm')">
+            <button type="button" style="margin-bottom : 20px" class="btn btn-md btn-primary" @click="$root.showModal('addGroupForm')">
                 {{ __('admin::app.catalog.families.add-group-title') }}
             </button>
 


### PR DESCRIPTION
Error: admin.js:2 ReferenceError: showModal is not defined
fix add Group in Edit family - it was missing $root

## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->

## Description
<!--- Please describe your changes in detail. -->

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->
