### PR TITLE
Issue #6770 Fixed

### DIFF
--- a/packages/Webkul/Product/src/Repositories/ProductRepository.php
+++ b/packages/Webkul/Product/src/Repositories/ProductRepository.php
@@ -512,10 +512,13 @@ class ProductRepository extends Repository
                 ->addSelect('product_flat.*')
                 ->addSelect('product_flat.product_id as id')
                 ->leftJoin('products', 'product_flat.product_id', '=', 'products.id')
+                ->leftJoin('product_inventories', 'product_flat.product_id', '=', 'product_inventories.product_id')
                 ->where('products.type', 'simple')
                 ->where('product_flat.channel', $channel)
                 ->where('product_flat.locale', $locale)
+                ->where('product_flat.status', '1')
                 ->where('product_flat.name', 'like', '%' . urldecode($term) . '%')
+                ->where('product_inventories.qty','>','0')
                 ->orderBy('product_id', 'desc');
         })->get();
     }


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
#6770 
## Description
<!--- Please describe your changes in detail. -->
As per pointed issue, Inactive & Out of Stock products also showing in search products while creating group & bundle products,  Now After fixed this issue, Out of stock & Inactive products will not searched while creating group & bundle products.
## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->
1. Log in as an admin.
2. Click on products inside the catalog tab.
3. Create a bundle product.
4. Try to add any inactive or out-of-stock product to bundle items.
5. You will not see inactive & out of stock products in searched listing
## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->
