### PR TITLE
Make tables responsive on view order page

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/sales/orders/view.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/sales/orders/view.blade.php
@@ -163,7 +163,7 @@
                                             {!! view_render_event('sales.order.customer_group.after', ['order' => $order]) !!}
                                         </div>
                                     </div>
-                                </div>                               
+                                </div>
 
                             </div>
                         </accordian>
@@ -202,7 +202,7 @@
                                                 </div>
                                             </div>
                                         @endif
-                                    </div>                                   
+                                    </div>
                                 </div>
                             </accordian>
                         @endif
@@ -286,7 +286,7 @@
                                             </div>
                                         </div>
                                     @endif
-                                </div>                               
+                                </div>
                             </div>
                         </accordian>
 
@@ -374,7 +374,7 @@
                                         </table>
                                     </div>
                                 </div>
-                               
+
 
                                 <div class="summary-comment-container">
                                     <div class="comment-container">
@@ -492,43 +492,45 @@
                 <tab name="{{ __('admin::app.sales.orders.invoices') }}">
 
                     <div class="table" style="padding: 20px 0">
-                        <table>
-                            <thead>
-                                <tr>
-                                    <th>{{ __('admin::app.sales.invoices.id') }}</th>
-                                    <th>{{ __('admin::app.sales.invoices.date') }}</th>
-                                    <th>{{ __('admin::app.sales.invoices.order-id') }}</th>
-                                    <th>{{ __('admin::app.sales.invoices.customer-name') }}</th>
-                                    <th>{{ __('admin::app.sales.invoices.status') }}</th>
-                                    <th>{{ __('admin::app.sales.invoices.amount') }}</th>
-                                    <th>{{ __('admin::app.sales.invoices.action') }}</th>
-                                </tr>
-                            </thead>
-
-                            <tbody>
-                                @foreach ($order->invoices as $invoice)
+                        <div class="table-responsive">
+                            <table>
+                                <thead>
                                     <tr>
-                                        <td>#{{ $invoice->increment_id ?? $invoice->id }}</td>
-                                        <td>{{ $invoice->created_at }}</td>
-                                        <td>#{{ $invoice->order->increment_id }}</td>
-                                        <td>{{ $order->customer_full_name }}</td>
-                                        <td>{{ $invoice->status_label }}</td>
-                                        <td>{{ core()->formatBasePrice($invoice->base_grand_total) }}</td>
-                                        <td class="action">
-                                            <a href="{{ route('admin.sales.invoices.view', $invoice->id) }}">
-                                                <i class="icon eye-icon"></i>
-                                            </a>
-                                        </td>
+                                        <th>{{ __('admin::app.sales.invoices.id') }}</th>
+                                        <th>{{ __('admin::app.sales.invoices.date') }}</th>
+                                        <th>{{ __('admin::app.sales.invoices.order-id') }}</th>
+                                        <th>{{ __('admin::app.sales.invoices.customer-name') }}</th>
+                                        <th>{{ __('admin::app.sales.invoices.status') }}</th>
+                                        <th>{{ __('admin::app.sales.invoices.amount') }}</th>
+                                        <th>{{ __('admin::app.sales.invoices.action') }}</th>
                                     </tr>
-                                @endforeach
+                                </thead>
 
-                                @if (! $order->invoices->count())
-                                    <tr>
-                                        <td class="empty" colspan="7">{{ __('admin::app.common.no-result-found') }}</td>
-                                    <tr>
-                                @endif
-                            </tbody>
-                        </table>
+                                <tbody>
+                                    @foreach ($order->invoices as $invoice)
+                                        <tr>
+                                            <td>#{{ $invoice->increment_id ?? $invoice->id }}</td>
+                                            <td>{{ $invoice->created_at }}</td>
+                                            <td>#{{ $invoice->order->increment_id }}</td>
+                                            <td>{{ $order->customer_full_name }}</td>
+                                            <td>{{ $invoice->status_label }}</td>
+                                            <td>{{ core()->formatBasePrice($invoice->base_grand_total) }}</td>
+                                            <td class="action">
+                                                <a href="{{ route('admin.sales.invoices.view', $invoice->id) }}">
+                                                    <i class="icon eye-icon"></i>
+                                                </a>
+                                            </td>
+                                        </tr>
+                                    @endforeach
+
+                                    @if (! $order->invoices->count())
+                                        <tr>
+                                            <td class="empty" colspan="7">{{ __('admin::app.common.no-result-found') }}</td>
+                                        <tr>
+                                    @endif
+                                </tbody>
+                            </table>
+                        </div>
                     </div>
 
                 </tab>
@@ -536,42 +538,44 @@
                 <tab name="{{ __('admin::app.sales.orders.shipments') }}">
 
                     <div class="table" style="padding: 20px 0">
-                        <table>
-                            <thead>
-                                <tr>
-                                    <th>{{ __('admin::app.sales.shipments.id') }}</th>
-                                    <th>{{ __('admin::app.sales.shipments.date') }}</th>
-                                    <th>{{ __('admin::app.sales.shipments.carrier-title') }}</th>
-                                    <th>{{ __('admin::app.sales.shipments.tracking-number') }}</th>
-                                    <th>{{ __('admin::app.sales.shipments.total-qty') }}</th>
-                                    <th>{{ __('admin::app.sales.shipments.action') }}</th>
-                                </tr>
-                            </thead>
-
-                            <tbody>
-
-                                @foreach ($order->shipments as $shipment)
+                        <div class="table-responsive">
+                            <table>
+                                <thead>
                                     <tr>
-                                        <td>#{{ $shipment->id }}</td>
-                                        <td>{{ $shipment->created_at }}</td>
-                                        <td>{{ $shipment->carrier_title }}</td>
-                                        <td>{{ $shipment->track_number }}</td>
-                                        <td>{{ $shipment->total_qty }}</td>
-                                        <td class="action">
-                                            <a href="{{ route('admin.sales.shipments.view', $shipment->id) }}">
-                                                <i class="icon eye-icon"></i>
-                                            </a>
-                                        </td>
+                                        <th>{{ __('admin::app.sales.shipments.id') }}</th>
+                                        <th>{{ __('admin::app.sales.shipments.date') }}</th>
+                                        <th>{{ __('admin::app.sales.shipments.carrier-title') }}</th>
+                                        <th>{{ __('admin::app.sales.shipments.tracking-number') }}</th>
+                                        <th>{{ __('admin::app.sales.shipments.total-qty') }}</th>
+                                        <th>{{ __('admin::app.sales.shipments.action') }}</th>
                                     </tr>
-                                @endforeach
+                                </thead>
 
-                                @if (! $order->shipments->count())
-                                    <tr>
-                                        <td class="empty" colspan="7">{{ __('admin::app.common.no-result-found') }}</td>
-                                    <tr>
-                                @endif
-                            </tbody>
-                        </table>
+                                <tbody>
+
+                                    @foreach ($order->shipments as $shipment)
+                                        <tr>
+                                            <td>#{{ $shipment->id }}</td>
+                                            <td>{{ $shipment->created_at }}</td>
+                                            <td>{{ $shipment->carrier_title }}</td>
+                                            <td>{{ $shipment->track_number }}</td>
+                                            <td>{{ $shipment->total_qty }}</td>
+                                            <td class="action">
+                                                <a href="{{ route('admin.sales.shipments.view', $shipment->id) }}">
+                                                    <i class="icon eye-icon"></i>
+                                                </a>
+                                            </td>
+                                        </tr>
+                                    @endforeach
+
+                                    @if (! $order->shipments->count())
+                                        <tr>
+                                            <td class="empty" colspan="7">{{ __('admin::app.common.no-result-found') }}</td>
+                                        <tr>
+                                    @endif
+                                </tbody>
+                            </table>
+                        </div>
                     </div>
 
                 </tab>
@@ -579,44 +583,46 @@
                 <tab name="{{ __('admin::app.sales.orders.refunds') }}">
 
                     <div class="table" style="padding: 20px 0">
-                        <table>
-                            <thead>
-                                <tr>
-                                    <th>{{ __('admin::app.sales.refunds.id') }}</th>
-                                    <th>{{ __('admin::app.sales.refunds.date') }}</th>
-                                    <th>{{ __('admin::app.sales.refunds.order-id') }}</th>
-                                    <th>{{ __('admin::app.sales.refunds.customer-name') }}</th>
-                                    <th>{{ __('admin::app.sales.refunds.status') }}</th>
-                                    <th>{{ __('admin::app.sales.refunds.refunded') }}</th>
-                                    <th>{{ __('admin::app.sales.refunds.action') }}</th>
-                                </tr>
-                            </thead>
-
-                            <tbody>
-
-                                @foreach ($order->refunds as $refund)
+                        <div class="table-responsive">
+                            <table>
+                                <thead>
                                     <tr>
-                                        <td>#{{ $refund->id }}</td>
-                                        <td>{{ $refund->created_at }}</td>
-                                        <td>#{{ $refund->order->increment_id }}</td>
-                                        <td>{{ $refund->order->customer_full_name }}</td>
-                                        <td>{{ __('admin::app.sales.refunds.refunded') }}</td>
-                                        <td>{{ core()->formatBasePrice($refund->base_grand_total) }}</td>
-                                        <td class="action">
-                                            <a href="{{ route('admin.sales.refunds.view', $refund->id) }}">
-                                                <i class="icon eye-icon"></i>
-                                            </a>
-                                        </td>
+                                        <th>{{ __('admin::app.sales.refunds.id') }}</th>
+                                        <th>{{ __('admin::app.sales.refunds.date') }}</th>
+                                        <th>{{ __('admin::app.sales.refunds.order-id') }}</th>
+                                        <th>{{ __('admin::app.sales.refunds.customer-name') }}</th>
+                                        <th>{{ __('admin::app.sales.refunds.status') }}</th>
+                                        <th>{{ __('admin::app.sales.refunds.refunded') }}</th>
+                                        <th>{{ __('admin::app.sales.refunds.action') }}</th>
                                     </tr>
-                                @endforeach
+                                </thead>
 
-                                @if (! $order->refunds->count())
-                                    <tr>
-                                        <td class="empty" colspan="7">{{ __('admin::app.common.no-result-found') }}</td>
-                                    <tr>
-                                @endif
-                            </tbody>
-                        </table>
+                                <tbody>
+
+                                    @foreach ($order->refunds as $refund)
+                                        <tr>
+                                            <td>#{{ $refund->id }}</td>
+                                            <td>{{ $refund->created_at }}</td>
+                                            <td>#{{ $refund->order->increment_id }}</td>
+                                            <td>{{ $refund->order->customer_full_name }}</td>
+                                            <td>{{ __('admin::app.sales.refunds.refunded') }}</td>
+                                            <td>{{ core()->formatBasePrice($refund->base_grand_total) }}</td>
+                                            <td class="action">
+                                                <a href="{{ route('admin.sales.refunds.view', $refund->id) }}">
+                                                    <i class="icon eye-icon"></i>
+                                                </a>
+                                            </td>
+                                        </tr>
+                                    @endforeach
+
+                                    @if (! $order->refunds->count())
+                                        <tr>
+                                            <td class="empty" colspan="7">{{ __('admin::app.common.no-result-found') }}</td>
+                                        <tr>
+                                    @endif
+                                </tbody>
+                            </table>
+                        </div>
                     </div>
 
                 </tab>


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->

## Description
<!--- Please describe your changes in detail. -->

The tables on order view page in admin are not responsive and therefore do not visible correctly on mobiles. 

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->

Try opening some order on mobiles in admin panel and tab on Invoices (for example) tab.

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/194717858-d533a767-2262-45a7-bdf3-9504e584d05f.png) | ![image](https://user-images.githubusercontent.com/4408379/194717880-53ec6f19-2ca6-4f3f-8203-78584598e804.png) |

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->
