### PR TITLE
Add missing space around content on subscriber page

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/marketing/email-marketing/subscribers/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/marketing/email-marketing/subscribers/edit.blade.php
@@ -5,7 +5,6 @@
 @stop
 
 @section('content')
-
     <div class="content">
         <form method="POST" action="{{ route('admin.customers.subscribers.update', $subscriber->id) }}" @submit.prevent="onSubmit" enctype="multipart/form-data">
             <div class="page-header">
@@ -23,24 +22,27 @@
                     </button>
                 </div>
             </div>
-            @csrf
-            @method('PUT')
 
-            <div class="control-group" :class="[errors.has('email') ? 'has-error' : '']">
-                <label for="title">{{ __('admin::app.customers.subscribers.email') }}</label>
-                <input type="text" class="control" name="email" v-validate="'required'" data-vv-as="&quot;{{ __('admin::app.customers.subscribers.email') }}&quot;" value="{{ $subscriber->email ?: old('email') }}" disabled>
-                <span class="control-error" v-if="errors.has('email')">@{{ errors.first('email') }}</span>
-            </div>
+            <div class="page-content">
+                @csrf
+                @method('PUT')
 
-            <div class="control-group" :class="[errors.has('is_subscribed') ? 'has-error' : '']">
-                <label for="title">{{ __('admin::app.customers.subscribers.is_subscribed') }}</label>
+                <div class="control-group" :class="[errors.has('email') ? 'has-error' : '']">
+                    <label for="title">{{ __('admin::app.customers.subscribers.email') }}</label>
+                    <input type="text" class="control" name="email" v-validate="'required'" data-vv-as="&quot;{{ __('admin::app.customers.subscribers.email') }}&quot;" value="{{ $subscriber->email ?: old('email') }}" disabled>
+                    <span class="control-error" v-if="errors.has('email')">@{{ errors.first('email') }}</span>
+                </div>
 
-                <select class="control" name="is_subscribed" v-validate="'required'" data-vv-as="&quot;{{ __('admin::app.customers.subscribers.is_subscribed') }}&quot;">
-                    <option value="1" @if ($subscriber->is_subscribed == 1) selected @endif>{{ __('admin::app.common.true') }}</option>
-                    <option value="0" @if ($subscriber->is_subscribed == 0) selected @endif>{{ __('admin::app.common.false') }}</option>
-                </select>
+                <div class="control-group" :class="[errors.has('is_subscribed') ? 'has-error' : '']">
+                    <label for="title">{{ __('admin::app.customers.subscribers.is_subscribed') }}</label>
 
-                <span class="control-error" v-if="errors.has('is_subscribed')">@{{ errors.first('is_subscribed') }}</span>
+                    <select class="control" name="is_subscribed" v-validate="'required'" data-vv-as="&quot;{{ __('admin::app.customers.subscribers.is_subscribed') }}&quot;">
+                        <option value="1" @if ($subscriber->is_subscribed == 1) selected @endif>{{ __('admin::app.common.true') }}</option>
+                        <option value="0" @if ($subscriber->is_subscribed == 0) selected @endif>{{ __('admin::app.common.false') }}</option>
+                    </select>
+
+                    <span class="control-error" v-if="errors.has('is_subscribed')">@{{ errors.first('is_subscribed') }}</span>
+                </div>
             </div>
         </form>
     </div>


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->

## Description
<!--- Please describe your changes in detail. -->

All other similar admin edit pages have a mandatory space around its content.

## How To Test This?

Try to open a page with editing any newsletter subscriber:


| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/195079765-91eef774-a7e1-434d-acf3-9b83667b311d.png) | ![image](https://user-images.githubusercontent.com/4408379/195079829-aa2ddba3-5a05-4337-b7d7-0700efbca646.png) |

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->
