### PR TITLE
fix error check acl admin

### DIFF
--- a/packages/Webkul/User/src/Models/Admin.php
+++ b/packages/Webkul/User/src/Models/Admin.php
@@ -92,6 +92,10 @@ class Admin extends Authenticatable implements AdminContract
      */
     public function hasPermission($permission)
     {
+        if ($this->role->permission_type == 'all') {
+            return true;
+        }
+
         if (
             $this->role->permission_type == 'custom'
             && ! $this->role->permissions


### PR DESCRIPTION
## Description
When I want to use `bouncer()->allow('any')
`
The following code gives an error
`return in_array($permission, $this->role->permissions);`
that `$this->role->permission` is null
