### PR TITLE
Add Smartarget Whatsapp plugin in default bagisto installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "paypal/paypal-checkout-sdk": "1.0.1",
         "prettus/l5-repository": "^2.6",
         "pusher/pusher-php-server": "^7.0",
+        "smartarget/bagisto-whatsapp-contact-us": "^1.0",
         "spatie/laravel-ignition": "^1.0",
         "spatie/laravel-sitemap": "^6.1"
     },

--- a/config/app.php
+++ b/config/app.php
@@ -283,7 +283,9 @@ return [
         Webkul\DebugBar\Providers\DebugBarServiceProvider::class,
         Webkul\Marketing\Providers\MarketingServiceProvider::class,
         Webkul\Notification\Providers\NotificationServiceProvider::class,
-        Webkul\Sitemap\Providers\SitemapServiceProvider::class
+        Webkul\Sitemap\Providers\SitemapServiceProvider::class,
+
+        Smartarget\WhatsappContactUs\Providers\WhatsappContactUsServiceProvider::class
     ],
 
     /*


### PR DESCRIPTION
## Issue Reference
The issue is here: https://github.com/bagisto/bagisto/issues/6942

## Description
We created our WhatsApp module for Bagisto (https://gitlab.com/erezson/smartarget-bagisto-whatsapp-contact-us), but many of you customers are non-technical, so they need our help all the time to install the module.

Unlike other platforms, extenstions cannot be installed with a single click. So we would like to contribute our code to the core bagisto module and add our extension but it will be disabled, so only if customers wants, they can enable it (but they won't need to install it manually using composer/etc)

## How To Test This?
Install bagisto using composer, run it, and go to Whatsapp tab in main menu and configure app

## Documentation
- My pull request does not require an update on the documentation repository.
