### PR TITLE
README.md typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 
 [Bagisto](https://www.bagisto.com/) is a hand-tailored E-Commerce framework built on some of the hottest open-source technologies such as [Laravel](https://laravel.com/) (a [PHP](https://secure.php.net/) framework) and [Vue.js](https://vuejs.org/) a progressive Javascript framework.
 
-Bagisto can help you cut down your time, cost, and workforce for building online stores or migrating from physical stores to the ever-demanding online world. Your business -- whether small or huge -- can benefit. The best part, it's straightforward to set it up!
+Bagisto can help you cut down your time, cost, and workforce for building online stores or migrating from physical stores to the ever-demanding online world. Your business—whether small or huge—can benefit. The best part, it's straightforward to set it up!
 
 ![enter image description here](https://raw.githubusercontent.com/bagisto/temp-media/master/stats.png)
 
@@ -59,7 +59,7 @@ You can browse through the Free **[Live Demo](https://demo.bagisto.com/)**
 
 # Headless Commerce
 
-The power of headless commerce now comes to Bagisto enabling you to experience seamless and easily scalable storefront performance. Backed by some of the hottest tech stacks Vue and React, Bagisto commerce can now be used to build powerful headless commerce solutions offering blazing-fast speed and easy customization powered by Vue Storefront and Next.js
+The power of headless commerce now comes to Bagisto enabling you to experience seamless and easily scalable storefront performance. Backed by some of the hottest tech stacks (Vue and React), Bagisto commerce can now be used to build powerful headless commerce solutions offering blazing-fast speed and easy customization powered by Vue Storefront and Next.js
 
 ## Vue Storefront
 
@@ -73,7 +73,7 @@ Vue Storefront 2 integration for Bagisto: [https://github.com/bagisto/vuestorefr
 
 Develop and deploy your next headless commerce storefronts with Next JS and Bagisto: [https://github.com/bagisto/nextjs-commerce](https://github.com/bagisto/nextjs-commerce)
 
-# Commerce For Every Needs
+# Commerce For Every Need
 
 ![enter image description here](https://raw.githubusercontent.com/bagisto/temp-media/master/every-need.png)
 
@@ -90,7 +90,7 @@ Make use of 100+ Bagisto pre built extensions from [Bagisto Extension Markeptlac
 ![enter image description here](https://raw.githubusercontent.com/bagisto/temp-media/master/community.png)
 
 Get Bagisto support on Facebook Group and [Forum](https://forum.sylius.com/)
-Would like to help us build the most developer-friendly eCommerce platform? Start by reading our [Contributing Guide](https://github.com/bagisto/bagisto/blob/master/.github/CONTRIBUTING.md)!
+Would like to help us build the most developer-friendly E-Commerce platform? Start by reading our [Contributing Guide](https://github.com/bagisto/bagisto/blob/master/.github/CONTRIBUTING.md)!
 
 # License
 Bagisto is a truly open-source E-Commerce framework that will always be free under the [MIT License](https://github.com/bagisto/bagisto/blob/master/LICENSE).


### PR DESCRIPTION
## Description
Fix some typos in the README.md file:
- Use em-dash (—) instead of double dashes (--) (https://www.thesaurus.com/e/grammar/em-dash/)
- Use parentheses
- Change "eCommerce" to "E-Commerce" for consistency

This is a second try, after I messed up #6787.