### PR TITLE
Translate Price toggle control added in admin panel on channel setting

### DIFF
--- a/packages/Webkul/Admin/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en/app.php
@@ -626,8 +626,8 @@ return [
             'image-size'                    => 'Image resolution should be like 640px X 640px',
             'create-success'                => 'Product created successfully.',
             'update-success'                => 'Product updated successfully.',
-            'delete-success'                => 'Product deleted successfully.',  
-            'delete-failed'                 => 'Error encountered while deleting Product.',          
+            'delete-success'                => 'Product deleted successfully.',
+            'delete-failed'                 => 'Error encountered while deleting Product.',
             'validations'                   => [
                 'quantity-required' => 'Quantity is required.',
                 'quantity-integer'  => 'Quantity should be integer.',
@@ -924,6 +924,7 @@ return [
             'default-locale'         => 'Default Locale',
             'currencies'             => 'Currencies',
             'base-currency'          => 'Default Currency',
+            'translate-price'        => 'Translate Price',
             'root-category'          => 'Root Category',
             'inventory_sources'      => 'Inventory Sources',
             'design'                 => 'Design',

--- a/packages/Webkul/Admin/src/Resources/views/settings/channels/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/channels/edit.blade.php
@@ -134,7 +134,7 @@
 
                             <div class="control-group" :class="[errors.has('default_locale_id') ? 'has-error' : '']">
                                 <label for="default_locale_id" class="required">{{ __('admin::app.settings.channels.default-locale') }}</label>
-                                
+
                                 @php $selectedOption = old('default_locale_id') ?: $channel->default_locale_id @endphp
 
                                 <select v-validate="'required'" class="control" id="default_locale_id" name="default_locale_id" data-vv-as="&quot;{{ __('admin::app.settings.channels.default-locale') }}&quot;">
@@ -176,7 +176,14 @@
                                 </select>
                                 <span class="control-error" v-if="errors.has('base_currency_id')">@{{ errors.first('base_currency_id') }}</span>
                             </div>
-
+                            <div class="control-group">
+                                <label for="translate-price-status">{{ __('admin::app.settings.channels.translate-price') }}</label>
+                                <label class="switch">
+                                    <input type="hidden" name="translate_price" value="0" />
+                                    <input type="checkbox" id="translate-price-status" name="translate_price" value="1" {{ $channel->translate_price ? 'checked' : ''}}>
+                                    <span class="slider round"></span>
+                                </label>
+                            </div>
                         </div>
                     </accordian>
 
@@ -217,7 +224,7 @@
                                 <label>{{ __('admin::app.settings.channels.logo') }}</label>
 
                                 <image-wrapper button-label="{{ __('admin::app.catalog.products.add-image-btn-title') }}" input-name="logo" :multiple="false" :images='"{{ $channel->logo_url }}"'></image-wrapper>
-                            
+
                                 <span class="control-info mt-10">{{ __('admin::app.settings.channels.logo-size') }}</span>
                             </div>
 
@@ -225,8 +232,8 @@
                                 <label>{{ __('admin::app.settings.channels.favicon') }}</label>
 
                                 <image-wrapper button-label="{{ __('admin::app.catalog.products.add-image-btn-title') }}" input-name="favicon" :multiple="false" :images='"{{ $channel->favicon_url }}"'></image-wrapper>
-                                
-                                <span class="control-info mt-10">{{ __('admin::app.settings.channels.favicon-size') }}</span> 
+
+                                <span class="control-info mt-10">{{ __('admin::app.settings.channels.favicon-size') }}</span>
                             </div>
 
                         </div>

--- a/packages/Webkul/Core/src/Core.php
+++ b/packages/Webkul/Core/src/Core.php
@@ -658,6 +658,7 @@ class Core
             ? $this->getAllCurrencies()->where('code', $currencyCode)->first()
             : $this->getCurrentCurrency();
 
+        $locale = (core()->getCurrentChannel()->translate_price) ? app()->getLocale() : 'en';
         $formatter = new \NumberFormatter(app()->getLocale(), \NumberFormatter::CURRENCY);
 
         $formatter->setAttribute(\NumberFormatter::FRACTION_DIGITS, $currency->decimal ?? 2);

--- a/packages/Webkul/Core/src/Database/Migrations/2023_02_08_131145_add_column_translate_price_in_channels_table.php
+++ b/packages/Webkul/Core/src/Database/Migrations/2023_02_08_131145_add_column_translate_price_in_channels_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddColumnTranslatePriceInChannelsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('channels', function (Blueprint $table) {
+            $table->boolean('translate_price')->after('base_currency_id')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('channels', function (Blueprint $table) {
+            $table->dropColumn('is_maintenance_on');
+        });
+    }
+};

--- a/packages/Webkul/Core/src/Http/Controllers/ChannelController.php
+++ b/packages/Webkul/Core/src/Http/Controllers/ChannelController.php
@@ -71,6 +71,7 @@ class ChannelController extends Controller
             'default_locale_id'     => 'required|in_array:locales.*',
             'currencies'            => 'required|array|min:1',
             'base_currency_id'      => 'required|in_array:currencies.*',
+            'translate_price'   => 'boolean',
 
             /* design */
             'theme'                 => 'nullable',
@@ -140,6 +141,7 @@ class ChannelController extends Controller
             'default_locale_id'                => 'required|in_array:locales.*',
             'currencies'                       => 'required|array|min:1',
             'base_currency_id'                 => 'required|in_array:currencies.*',
+            'translate_price'                  => 'boolean',
 
             /* design */
             'theme'                            => 'nullable',


### PR DESCRIPTION
Not all stores want their prices to be translated into different locales, this option allows admin to choose if they want to keep the prices as digits or translate them into the chosen locale.

## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->

## Description
The website admin is not able to disable price translation. 


## How To Test This?
Enable multiple locales for a channel. 
Switch the locale from the website front.
The price will get translated into the chosen locale.
for example:
For English, the price will look like AED 100.00
But if the customer switches to Arabic, it looks like ١٠٠٫٠٠ AED
It is clearly undesirable because no eCommerce store in the middle east wants to show prices like this.

