### PR TITLE
update utf8mb4_unicode_ci to utf8mb4_general_ci

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -48,7 +48,7 @@ return [
             'password' => env('DB_PASSWORD', ''),
             'unix_socket' => env('DB_SOCKET', ''),
             'charset' => 'utf8mb4',
-            'collation' => 'utf8mb4_unicode_ci',
+            'collation' => 'utf8mb4_general_ci',
             'prefix' => env('DB_PREFIX', ''),
             'strict' => false,
             'engine' => 'InnoDB ROW_FORMAT=DYNAMIC',


### PR DESCRIPTION
update utf8mb4_unicode_ci to utf8mb4_general_ci

## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
[#2901](https://github.com/bagisto/bagisto/issues/2901)

## Description
Faced a category creation conflict with utf8mb4_unicode_ci. `Illegal mix of collations (utf8mb4_unicode_ci,IMPLICIT) and (utf8mb4_general_ci,IMPLICIT) for operation '='`. This change in coallation fixes this issue.

## How To Test This?
Just change back the coallation and use `php artisan bagisto:install` on windows laragon. It'll show this error while creating category on admin panel. 

## Documentation
No update required on documentation. It fixes the issue which was not mentioned in documentation.
