### PR TITLE
issue #7426 fixed

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/CartRuleDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/CartRuleDataGrid.php
@@ -144,10 +144,7 @@ class CartRuleDataGrid extends DataGrid
             'sortable'   => true,
             'filterable' => true,
             'closure'    => function ($value) {
-                if ($value->coupon_code) {
-                   return $value->coupon_code; 
-                }
-                return '-';   
+                return $value->coupon_code ?? '-';
             },
         ]);
 

--- a/packages/Webkul/Admin/src/DataGrids/CartRuleDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/CartRuleDataGrid.php
@@ -144,12 +144,10 @@ class CartRuleDataGrid extends DataGrid
             'sortable'   => true,
             'filterable' => true,
             'closure'    => function ($value) {
-                if($value->coupon_code){
-                   return $value->coupon_code ; 
+                if ($value->coupon_code) {
+                   return $value->coupon_code; 
                 }
-                else{
-                   return '-';   
-                }
+                return '-';   
             },
         ]);
 

--- a/packages/Webkul/Admin/src/DataGrids/CartRuleDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/CartRuleDataGrid.php
@@ -143,6 +143,14 @@ class CartRuleDataGrid extends DataGrid
             'searchable' => true,
             'sortable'   => true,
             'filterable' => true,
+            'closure'    => function ($value) {
+                if($value->coupon_code){
+                   return $value->coupon_code ; 
+                }
+                else{
+                   return '-';   
+                }
+            },
         ]);
 
         $this->addColumn([


### PR DESCRIPTION
### Issue Reference
#7426 
 -> We can use (-) icon in Coupon Code Column instead of blank column.
-> for this changes in cartrule data grid file check condition for coupon code value.
-> find screen shot here  https://prnt.sc/QTU_rSKDe99Y
 