### PR TITLE
Issue #8263 fixed

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Catalog/CategoryDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Catalog/CategoryDataGrid.php
@@ -95,9 +95,13 @@ class CategoryDataGrid extends DataGrid
         $this->addColumn([
             'index'      => 'status',
             'label'      => trans('admin::app.catalog.categories.index.datagrid.status'),
-            'type'       => 'boolean',
+            'type'       => 'select',
             'searchable' => false,
             'filterable' => true,
+            'filter_options' => [
+                0 => trans('admin::app.catalog.categories.index.datagrid.inactive'),
+                1 => trans('admin::app.catalog.categories.index.datagrid.active')
+            ],
             'sortable'   => true,
             'closure'    => function ($value) {
                 if ($value->status) {

--- a/packages/Webkul/Admin/src/Resources/views/components/datagrid/filters.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/datagrid/filters.blade.php
@@ -167,7 +167,44 @@
                 </div>
             </div>
         </div>
+        <!-- Select -->
+        <div v-else-if="column.type === 'select'">
+            <div class="flex items-center justify-between">
+                <p
+                    class="text-[14px] font-medium leading-[24px]  dark:text-white"
+                    v-text="column.label"
+                >
+                </p>
 
+                <div
+                    class="flex items-center gap-x-[5px]"
+                    @click="removeAppliedColumnAllValues(column.index)"
+                >
+                    <p
+                        class="cursor-pointer text-[12px] font-medium leading-[24px] text-blue-600"
+                        v-if="hasAnyAppliedColumnValues(column.index)"
+                    >
+                        @lang('admin::app.components.datagrid.filters.custom-filters.clear-all')
+                    </p>
+                </div>
+            </div>
+
+            <div class="mb-[8px] mt-[5px] grid">
+                   <select
+                        :name="column.index"
+                        class="custom-select flex w-full min-h-[39px] py-[6px] px-[12px] bg-white dark:bg-gray-900 border dark:border-gray-800 rounded-[6px] text-[14px] text-gray-600 dark:text-gray-300 font-normal transition-all hover:border-gray-400"
+                        @change="filterPage($event, column)"
+                        
+                    >
+                        <option>Select</option>
+                        <option v-for='(label, index) in column.filter_options' :value="index" :selected="index == getAppliedColumnValues(column.index)[0]">
+                            @{{ label }}
+                        </option>
+                    </select>
+            </div>
+
+            
+        </div>
         <!-- Rest -->
         <div v-else>
             <div class="flex items-center justify-between">

--- a/packages/Webkul/Admin/src/Resources/views/components/datagrid/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/datagrid/index.blade.php
@@ -349,6 +349,7 @@
                 },
 
                 applyFilter(column, requestedValue, additional = {}) {
+                    console.log(column);
                     let appliedColumn = this.findAppliedColumn(column?.index);
 
                     /**
@@ -422,7 +423,16 @@
                                 }
 
                                 break;
-
+                            case 'select':
+                                if (appliedColumn) {
+                                    appliedColumn.value = requestedValue
+                                } else {
+                                    this.applied.filters.columns.push({
+                                        ...column,
+                                        value: requestedValue
+                                    });
+                                }
+                                break;
                             default:
                                 if (appliedColumn) {
                                     appliedColumn.value.push(requestedValue);
@@ -454,7 +464,7 @@
 
                 getAppliedColumnValues(columnIndex) {
                     let appliedColumn = this.findAppliedColumn(columnIndex);
-
+                
                     return appliedColumn?.value ?? [];
                 },
 

--- a/packages/Webkul/DataGrid/src/Column.php
+++ b/packages/Webkul/DataGrid/src/Column.php
@@ -34,6 +34,7 @@ class Column
         public string $type,
         public bool $searchable = false,
         public bool $filterable = false,
+        public array $filter_options = [],
         public bool $sortable = false,
         public mixed $closure = null,
     ) {

--- a/packages/Webkul/DataGrid/src/DataGrid.php
+++ b/packages/Webkul/DataGrid/src/DataGrid.php
@@ -109,9 +109,11 @@ abstract class DataGrid
             type: $column['type'],
             searchable: $column['searchable'],
             filterable: $column['filterable'],
+            filter_options: (isset($column['filter_options'])) ? $column['filter_options'] : [],
             sortable: $column['sortable'],
             closure: $column['closure'] ?? null,
         );
+       // echo "<pre>";print_r($this->columns);exit;
     }
 
     /**
@@ -210,7 +212,12 @@ abstract class DataGrid
                         });
 
                         break;
+                    case ColumnTypeEnum::SELECT->value:
+                        $this->queryBuilder->where(function ($scopeQueryBuilder) use ($column, $requestedValues) {
+                            $scopeQueryBuilder->where($column->getDatabaseColumnName(), $requestedValues);
+                        });
 
+                        break;    
                     default:
                         $this->queryBuilder->where(function ($scopeQueryBuilder) use ($column, $requestedValues) {
                             foreach ($requestedValues as $value) {

--- a/packages/Webkul/DataGrid/src/DataGrid.php
+++ b/packages/Webkul/DataGrid/src/DataGrid.php
@@ -113,7 +113,6 @@ abstract class DataGrid
             sortable: $column['sortable'],
             closure: $column['closure'] ?? null,
         );
-       // echo "<pre>";print_r($this->columns);exit;
     }
 
     /**

--- a/packages/Webkul/DataGrid/src/Enums/ColumnTypeEnum.php
+++ b/packages/Webkul/DataGrid/src/Enums/ColumnTypeEnum.php
@@ -8,6 +8,11 @@ enum ColumnTypeEnum: string
      * Boolean.
      */
     case BOOLEAN = 'boolean';
+        
+    /**
+     * Select.
+     */
+    case SELECT = 'select';    
 
     /**
      * Date range.


### PR DESCRIPTION
## Issue Reference
As mentioned in #8263 status filter was not working if we put Active/Inactive value as filter.

## Description
I have done the new enhancement for select type column. If the column is select type then use type as select in the datagrid and add filter_options with options in array. So now if you want to use select filter in data grid then you can follow the same what I have done status filter in category grid. 

Feel free to share your feedback.

Thanks

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->
