### PR TITLE
Fixed #8683

### DIFF
--- a/packages/Webkul/Customer/src/Repositories/CustomerAddressRepository.php
+++ b/packages/Webkul/Customer/src/Repositories/CustomerAddressRepository.php
@@ -49,7 +49,7 @@ class CustomerAddressRepository extends Repository
     {
         $address = $this->find($id);
 
-        $data['default_address'] = isset($data['default_address']) ? $data['default_address'] : $address->default_address;
+        $data['default_address'] = $data['default_address'] ?? $address->default_address;
 
         $default_address = $this
             ->findWhere(['customer_id' => $address->customer_id, 'default_address' => 1])

--- a/packages/Webkul/Customer/src/Repositories/CustomerAddressRepository.php
+++ b/packages/Webkul/Customer/src/Repositories/CustomerAddressRepository.php
@@ -49,7 +49,7 @@ class CustomerAddressRepository extends Repository
     {
         $address = $this->find($id);
 
-        $data['default_address'] = isset($data['default_address']);
+        $data['default_address'] = isset($data['default_address']) ? $data['default_address'] : $address->default_address;
 
         $default_address = $this
             ->findWhere(['customer_id' => $address->customer_id, 'default_address' => 1])
@@ -62,7 +62,7 @@ class CustomerAddressRepository extends Repository
             if ($default_address->id != $address->id) {
                 $default_address->update(['default_address' => 0]);
             }
-            
+
             $address->update($data);
         } else {
             $address->update($data);


### PR DESCRIPTION
## Issue Reference
#8683 

## Description
For fixing #8683  Set existing default_address bit on update address, (prevent to set default address 0) 

## How To Test This?
Customer must be logged in.
Customer should have at least one added address and set it as default.
Go to 'Shop' and login as User
Edit the default address and save it inside the Accounts/Addresses
