### PR TITLE
Fixed - #8700

### DIFF
--- a/packages/Webkul/Sales/src/Generators/Sequencer.php
+++ b/packages/Webkul/Sales/src/Generators/Sequencer.php
@@ -110,20 +110,9 @@ class Sequencer implements SequencerContract
      */
     public function generate(): string
     {
-        if (
-            $this->length
-            && (
-                $this->prefix || $this->suffix
-            )
-        ) {
-            $number = ($this->prefix) . sprintf(
-                "%0{$this->length}d",
-                ($this->lastId + 1)
-            ) . ($this->suffix);
-        } else {
-            $number = $this->lastId + 1;
-        }
-
-        return $number;
+        return ($this->prefix) . sprintf(
+            "%0{$this->length}d",
+            ($this->lastId + 1)
+        ) . ($this->suffix);
     }
 }

--- a/packages/Webkul/Shop/src/Resources/views/customers/account/orders/view.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/customers/account/orders/view.blade.php
@@ -1,7 +1,7 @@
 <x-shop::layouts.account>
     {{-- Page Title --}}
     <x-slot:title>
-        @lang('shop::app.customers.account.orders.view.page-title', ['order_id' => $order->id])
+        @lang('shop::app.customers.account.orders.view.page-title', ['order_id' => $order->increment_id])
     </x-slot:title>
     
     {{-- Breadcrumbs --}}
@@ -12,7 +12,7 @@
     <div class="flex justify-between items-center">
         <div class="">
             <h2 class="text-[26px] font-medium">
-                @lang('shop::app.customers.account.orders.view.page-title', ['order_id' => $order->id])
+                @lang('shop::app.customers.account.orders.view.page-title', ['order_id' => $order->increment_id])
             </h2>
         </div>
 


### PR DESCRIPTION
## Issue Reference
#8700 

## Description
Changes were made to the sequencer. Now, if the length, prefix, and suffix are set from the admin panel, they will be added; otherwise, the order ID is displayed normally. Additionally, the order ID is correctly displayed on the order view page, with the prefix, suffix, and length applied.

## How To Test This?

1. Navigate to 'Admin > Configuration > Sales > Order Settings.' and adjust the settings accordingly.
2. Similarly, visit 'Admin > Configuration > Sales > Invoice Settings' and adjust the settings accordingly.
3. After making these changes, create an order and generate an invoice.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->
