### PR TITLE
Fixed 8696

### DIFF
--- a/packages/Webkul/Admin/src/Mail/Order/CreatedNotification.php
+++ b/packages/Webkul/Admin/src/Mail/Order/CreatedNotification.php
@@ -29,7 +29,7 @@ class CreatedNotification extends Mailable
     public function build()
     {
         return $this->from(core()->getSenderEmailDetails()['email'], core()->getSenderEmailDetails()['name'])
-            ->to($this->order->customer_email, $this->order->customer_full_name)
+            ->to(core()->getAdminEmailDetails()['email'], core()->getAdminEmailDetails()['name'])
             ->subject(trans('admin::app.emails.orders.created.subject'))
             ->view('admin::emails.orders.created');
     }

--- a/packages/Webkul/Admin/src/Resources/lang/ar/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ar/app.php
@@ -3355,7 +3355,7 @@ return [
     ],
 
     'emails' => [
-        'dear'   => 'عزيزي :customer_name',
+        'dear'   => 'عزيزي :admin_name',
         'thanks' => 'إذا كنت بحاجة إلى أي نوع من المساعدة، يرجى الاتصال بنا على <a href=":link" style=":style">:email</a>.<br/>شكرًا لك!',
 
         'admin' => [

--- a/packages/Webkul/Admin/src/Resources/lang/bn/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/bn/app.php
@@ -3355,7 +3355,7 @@ return [
     ],
 
     'emails' => [
-        'dear'   => 'প্রিয় :customer_name',
+        'dear'   => 'প্রিয় :admin_name',
         'thanks' => 'আপনি যদি কোনও সাহায্যের দরকার হয়, তবে আমাদের সাথে যোগাযোগ করুন <a href=":link" style=":style">:email</a>।<br/>ধন্যবাদ!',
 
         'admin' => [

--- a/packages/Webkul/Admin/src/Resources/lang/de/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/de/app.php
@@ -3355,7 +3355,7 @@ return [
     ],
 
     'emails' => [
-        'dear'   => 'Liebe:r :customer_name',
+        'dear'   => 'Liebe:r :admin_name',
         'thanks' => 'Wenn Sie irgendwelche Hilfe benötigen, kontaktieren Sie uns bitte unter <a href=":link" style=":style">:email</a>.<br/>Vielen Dank!',
 
         'admin' => [

--- a/packages/Webkul/Admin/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en/app.php
@@ -3355,7 +3355,7 @@ return [
     ],
 
     'emails' => [
-        'dear'   => 'Dear :customer_name',
+        'dear'   => 'Dear :admin_name',
         'thanks' => 'If you need any kind of help please contact us at <a href=":link" style=":style">:email</a>.<br/>Thanks!',
 
         'admin' => [

--- a/packages/Webkul/Admin/src/Resources/lang/es/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/es/app.php
@@ -3355,7 +3355,7 @@ return [
     ],
 
     'emails' => [
-        'dear'   => 'Estimado :customer_name',
+        'dear'   => 'Estimado :admin_name',
         'thanks' => 'Si necesitas cualquier tipo de ayuda, por favor contáctanos en <a href=":link" style=":style">:email</a>.<br/>¡Gracias!',
 
         'admin' => [

--- a/packages/Webkul/Admin/src/Resources/lang/fa/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/fa/app.php
@@ -3355,7 +3355,7 @@ return [
     ],
 
     'emails' => [
-        'dear'   => 'عزیز :customer_name',
+        'dear'   => 'عزیز :admin_name',
         'thanks' => 'اگر نیاز به هر نوع کمک دارید، لطفاً با ما تماس بگیرید به آدرس <a href=":link" style=":style">:email</a>.<br/>با تشکر!',
 
         'admin' => [

--- a/packages/Webkul/Admin/src/Resources/lang/fr/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/fr/app.php
@@ -3355,7 +3355,7 @@ return [
     ],
 
     'emails' => [
-        'dear'   => 'Cher :customer_name',
+        'dear'   => 'Cher :admin_name',
         'thanks' => 'Si vous avez besoin d\'aide, veuillez nous contacter à <a href=":link" style=":style">:email</a>.<br/>Merci !',
 
         'admin' => [

--- a/packages/Webkul/Admin/src/Resources/lang/he/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/he/app.php
@@ -3355,7 +3355,7 @@ return [
     ],
 
     'emails' => [
-        'dear'   => 'יקר :customer_name',
+        'dear'   => 'יקר :admin_name',
         'thanks' => 'אם תזדקק לעזרה בכל סוג שהוא, אנא פנה אלינו ב-<a href=":link" style=":style">:email</a>.<br/>תודה!',
 
         'admin' => [

--- a/packages/Webkul/Admin/src/Resources/lang/hi_IN/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/hi_IN/app.php
@@ -3355,7 +3355,7 @@ return [
     ],
 
     'emails' => [
-        'dear'   => 'प्रिय :customer_name',
+        'dear'   => 'प्रिय :admin_name',
         'thanks' => 'यदि आपको किसी प्रकार की मदद चाहिए, तो कृपया हमसे <a href=":link" style=":style">:email</a> पर संपर्क करें।<br/>धन्यवाद!',
 
         'admin' => [

--- a/packages/Webkul/Admin/src/Resources/lang/it/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/it/app.php
@@ -3355,7 +3355,7 @@ return [
     ],
 
     'emails' => [
-        'dear'   => 'Caro :customer_name',
+        'dear'   => 'Caro :admin_name',
         'thanks' => 'Se hai bisogno di assistenza, ti preghiamo di contattarci su <a href=":link" style=":style">:email</a>.<br/>Grazie!',
 
         'admin' => [

--- a/packages/Webkul/Admin/src/Resources/lang/ja/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ja/app.php
@@ -3355,7 +3355,7 @@ return [
     ],
 
     'emails' => [
-        'dear'   => '尊敬する :customer_name さん',
+        'dear'   => '尊敬する :admin_name さん',
         'thanks' => '何かお手伝いが必要な場合は、<a href=":link" style=":style">:email</a> でお問い合わせいただくか、ご連絡ください。<br/>ありがとうございます！',
 
         'admin' => [

--- a/packages/Webkul/Admin/src/Resources/lang/nl/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/nl/app.php
@@ -3355,7 +3355,7 @@ return [
     ],
 
     'emails' => [
-        'dear'   => 'Beste :customer_name',
+        'dear'   => 'Beste :admin_name',
         'thanks' => 'Als u hulp nodig heeft, neem dan contact met ons op via <a href=":link" style=":style">:email</a>.<br/>Bedankt!',
 
         'admin' => [

--- a/packages/Webkul/Admin/src/Resources/lang/pl/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/pl/app.php
@@ -3355,7 +3355,7 @@ return [
     ],
 
     'emails' => [
-        'dear'   => 'Szanowny(a) :customer_name',
+        'dear'   => 'Szanowny(a) :admin_name',
         'thanks' => 'Jeśli potrzebujesz pomocy, skontaktuj się z nami pod adresem <a href=":link" style=":style">:email</a>.<br/>Dziękujemy!',
 
         'admin' => [

--- a/packages/Webkul/Admin/src/Resources/lang/pt_BR/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/pt_BR/app.php
@@ -3355,7 +3355,7 @@ return [
     ],
 
     'emails' => [
-        'dear'   => 'Estimado/a :customer_name',
+        'dear'   => 'Estimado/a :admin_name',
         'thanks' => 'Si necesita cualquier tipo de ayuda, por favor contáctenos en <a href=":link" style=":style">:email</a>.<br/>¡Gracias!',
 
         'admin' => [

--- a/packages/Webkul/Admin/src/Resources/lang/ru/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ru/app.php
@@ -3342,7 +3342,7 @@ return [
     ],
 
     'emails' => [
-        'dear'   => 'Уважаемый :customer_name',
+        'dear'   => 'Уважаемый :admin_name',
         'thanks' => 'Если вам нужна какая-либо помощь, пожалуйста, свяжитесь с нами по адресу <a href=":link" style=":style">:email</a>.<br/>Спасибо!',
 
         'admin' => [

--- a/packages/Webkul/Admin/src/Resources/lang/sin/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/sin/app.php
@@ -3355,7 +3355,7 @@ return [
     ],
 
     'emails' => [
-        'dear'   => 'මහේෂ් :customer_name',
+        'dear'   => 'මහේෂ් :admin_name',
         'thanks' => 'ඔබට කුමු උපකාර අවශ්‍යයිද? කරුණාකර <a href=":link" style=":style">:email</a> අමතන්න.<br/>ස්තූති!',
 
         'admin' => [

--- a/packages/Webkul/Admin/src/Resources/lang/tr/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/tr/app.php
@@ -3355,7 +3355,7 @@ return [
     ],
 
     'emails' => [
-        'dear'   => 'Sayın :customer_name',
+        'dear'   => 'Sayın :admin_name',
         'thanks' => 'Herhangi bir yardıma ihtiyacınız varsa, lütfen bize <a href=":link" style=":style">:email</a> adresinden ulaşın.<br/>Teşekkürler!',
 
         'admin' => [

--- a/packages/Webkul/Admin/src/Resources/lang/uk/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/uk/app.php
@@ -3357,7 +3357,7 @@ return [
     ],
 
     'emails' => [
-        'dear'   => 'Шановний :customer_name',
+        'dear'   => 'Шановний :admin_name',
         'thanks' => 'Якщо вам потрібна будь-яка допомога, будь ласка, зв\'яжіться з нами за адресою <a href=":link" style=":style">:email</a>.<br/>Дякуємо!',
 
         'admin' => [

--- a/packages/Webkul/Admin/src/Resources/lang/zh_CN/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/zh_CN/app.php
@@ -3355,7 +3355,7 @@ return [
     ],
 
     'emails' => [
-        'dear'   => '尊敬的 :customer_name',
+        'dear'   => '尊敬的 :admin_name',
         'thanks' => '如果您需要任何帮助，请联系我们：<a href=":link" style=":style">:email</a>。<br/>谢谢！',
 
         'admin' => [

--- a/packages/Webkul/Admin/src/Resources/views/emails/orders/created.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/emails/orders/created.blade.php
@@ -5,7 +5,7 @@
         </span> <br>
 
         <p style="font-size: 16px;color: #5E5E5E;line-height: 24px;">
-            @lang('admin::app.emails.dear', ['customer_name' => $order->customer_full_name]),👋
+            @lang('admin::app.emails.dear', ['admin_name' => core()->getAdminEmailDetails()['name']]),👋
         </p>
 
         <p style="font-size: 16px;color: #5E5E5E;line-height: 24px;">


### PR DESCRIPTION
## Issue Reference
#8696 
## Description

- Upon placing an order, both the customer and admin receive confirmation email.
- The placeholder ":customer_name" has been replaced with ":admin_name" and updated in all languages.

## How To Test This?

- Navigate to the admin panel, then access the "Configuration" section, proceed to "Emails Settings," and configure the "Admin Email" and "Admin Name." 
- After completing this step, place an order and receive emails accordingly at both the customer's and admin's email addresses.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->
