### PR TITLE
Fixed #8721 - Velocity theme: "-&gt;" is not decoded to "->" when add…

### DIFF
--- a/packages/Webkul/Velocity/src/Http/Controllers/Admin/ConfigurationController.php
+++ b/packages/Webkul/Velocity/src/Http/Controllers/Admin/ConfigurationController.php
@@ -100,8 +100,7 @@ class ConfigurationController extends Controller
         }
 
         $params['advertisement'] = json_encode($params['advertisement']);
-        $params['home_page_content'] = str_replace('=&gt;', '=>', $params['home_page_content']);
-
+        $params['home_page_content'] = str_replace(['=&gt;','-&gt;'], ['=>', '->'], $params['home_page_content']);
         unset($params['images']);
         unset($params['slides']);
 


### PR DESCRIPTION
## Issue Reference
#8721

## Description
using str_replace() to decode `-&gt;` to  `->` when storing `home_page_content` in `velocity_meta_data`

## How To Test This?
1. Go to "/admin/velocity/meta-data"
2. Click on  "Home Page Content" field
3. Click on the source code and add the code below
```php
@php 
    $categories=app('Webkul\Category\Repositories\CategoryRepository')->getVisibleCategoryTree(core()->getCurrentChannel()->root_category_id);
@endphp
```
This will not throw an error anymore, the categories are fetched successfully

## Documentation
- [ ] My pull request requires an update on the documentation repository.
