### PR TITLE
[Fixed: #8800]

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/catalog/attributes/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/attributes/edit.blade.php
@@ -235,8 +235,8 @@
                                             :list="optionsData"
                                             item-key="id"
                                         >
-                                            <template #item="{ element, index }" v-show="! element.isDelete">
-                                                <x-admin::table.thead.tr class="text-center hover:bg-gray-50 dark:hover:bg-gray-950">
+                                            <template #item="{ element, index }">
+                                                <x-admin::table.thead.tr class="text-center hover:bg-gray-50 dark:hover:bg-gray-950" v-show="! element.isDelete">
                                                     <input
                                                         type="hidden"
                                                         :name="'options[' + element.id + '][isNew]'"
@@ -1058,7 +1058,11 @@
                         let foundIndex = this.optionsData.findIndex(item => item.id === id);
 
                         if (foundIndex !== -1) {
-                            this.optionsData.splice(foundIndex, 1);
+                            if (this.optionsData[foundIndex].isNew) {
+                                this.optionsData.splice(foundIndex, 1);
+                            } else {
+                                this.optionsData[foundIndex].isDelete = true;
+                            }
                         }
                     },
 

--- a/packages/Webkul/Admin/src/Resources/views/catalog/attributes/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/attributes/edit.blade.php
@@ -236,7 +236,10 @@
                                             item-key="id"
                                         >
                                             <template #item="{ element, index }">
-                                                <x-admin::table.thead.tr class="text-center hover:bg-gray-50 dark:hover:bg-gray-950" v-show="! element.isDelete">
+                                                <x-admin::table.thead.tr 
+                                                    class="text-center hover:bg-gray-50 dark:hover:bg-gray-950"
+                                                    v-show="! element.isDelete"
+                                                >
                                                     <input
                                                         type="hidden"
                                                         :name="'options[' + element.id + '][isNew]'"


### PR DESCRIPTION
## Issue Reference
Not able to remove the attribute's option while editing the related attribute from the admin panel.

## Description
If you want to add some attribute options and want to remove any option from the related attribute, then not able to remove the option.

Not able to remove the attribute's option while editing the related attribute from the admin panel.
