### PR TITLE
[Fixed: #8809]

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Catalog/AttributeController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Catalog/AttributeController.php
@@ -102,7 +102,7 @@ class AttributeController extends Controller
     {
         $attribute = $this->attributeRepository->findOrFail($id);
 
-        return $attribute->options()->get();
+        return $attribute->options()->orderBy('sort_order')->get();
     }
 
     /**

--- a/packages/Webkul/Admin/src/Resources/views/catalog/attributes/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/attributes/edit.blade.php
@@ -258,7 +258,7 @@
 
                                                         <input
                                                             type="hidden"
-                                                            :name="'options[' + element.id + '][position]'"
+                                                            :name="'options[' + element.id + '][sort_order]'"
                                                             :value="index"
                                                         />
                                                     </x-admin::table.td>


### PR DESCRIPTION
## Issue Reference
#8809

## Description
Draggable functionality is not working for Attribute Options at the Admin end.
https://prnt.sc/S1E7FlfWFGpj

## How To Test This?
Go to 'Admin Panel'
Click on 'Edit Attribute & rearrange the order of options'
Save with changed order
See error
If you check by editing the same attribute, It will not reflect.


Fixed.
