### PR TITLE
Fixed #8873 - Cancellation emails are being sent to both the customer…

### DIFF
--- a/packages/Webkul/Admin/src/Mail/Order/CanceledNotification.php
+++ b/packages/Webkul/Admin/src/Mail/Order/CanceledNotification.php
@@ -21,7 +21,7 @@ class CanceledNotification extends Mailable
     public function build()
     {
         return $this->from(core()->getSenderEmailDetails()['email'], core()->getSenderEmailDetails()['name'])
-            ->to($this->order->customer_email, $this->order->customer_full_name)
+            ->to(core()->getAdminEmailDetails()['email'], core()->getAdminEmailDetails()['name'])
             ->subject(trans('admin::app.emails.orders.canceled.subject'))
             ->view('admin::emails.orders.canceled');
     }

--- a/packages/Webkul/Admin/src/Resources/views/emails/orders/canceled.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/emails/orders/canceled.blade.php
@@ -5,7 +5,7 @@
         </span> <br>
 
         <p style="font-size: 16px;color: #5E5E5E;line-height: 24px;">
-            @lang('admin::app.emails.dear', ['customer_name' => $order->customer_full_name]),👋
+            @lang('admin::app.emails.dear', ['admin_name' => core()->getAdminEmailDetails()['name']]),👋
         </p>
 
         <p style="font-size: 16px;color: #5E5E5E;line-height: 24px;">

--- a/packages/Webkul/Shop/src/Mail/Order/CanceledNotification.php
+++ b/packages/Webkul/Shop/src/Mail/Order/CanceledNotification.php
@@ -23,6 +23,6 @@ class CanceledNotification extends Mailable
         return $this->from(core()->getSenderEmailDetails()['email'], core()->getSenderEmailDetails()['name'])
             ->to($this->order->customer_email, $this->order->customer_full_name)
             ->subject(trans('admin::app.emails.orders.canceled.subject'))
-            ->view('shop::shop.orders.canceled');
+            ->view('shop::emails.orders.canceled');
     }
 }


### PR DESCRIPTION
… and the admin correctly.

## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
#8873 

## Description
<!--- Please describe your changes in detail. -->
Cancellation emails are being sent to both the customer and the admin correctly.

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->

- Go to 'Shop'
- Add a product to the cart and proceed to checkout.
- Fill in all the required fields and select the preferred shipping/payment method.
- Click on the "Place Order" button.
- Access the 'Admin Panel.'
- Open the order and cancel it.
- Check the mailbox of the customer and the admin.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->
