### PR TITLE
fix(api-shop-cart): handle empty cart item with try catch

### DIFF
--- a/packages/Webkul/Shop/src/Http/Controllers/API/CartController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/API/CartController.php
@@ -229,21 +229,23 @@ class CartController extends APIController
      */
     public function crossSellProducts()
     {
-        try {
-            $productIds = Cart::getCart()->items->pluck('product_id')->toArray();
+        $cart = Cart::getCart();
 
-            $products = $this->productRepository
-                ->select('products.*', 'product_cross_sells.child_id')
-                ->join('product_cross_sells', 'products.id', '=', 'product_cross_sells.child_id')
-                ->whereIn('product_cross_sells.parent_id', $productIds)
-                ->groupBy('product_cross_sells.child_id')
-                ->paginate();
-
-            return ProductResource::collection($products);
-        } catch (\Exception $exception) {
+        if (! $cart) {
             return new JsonResource([
-                'message' => $exception->getMessage(),
+                'data' => []
             ]);
         }
+
+        $productIds = $cart->items->pluck('product_id')->toArray();
+
+        $products = $this->productRepository
+            ->select('products.*', 'product_cross_sells.child_id')
+            ->join('product_cross_sells', 'products.id', '=', 'product_cross_sells.child_id')
+            ->whereIn('product_cross_sells.parent_id', $productIds)
+            ->groupBy('product_cross_sells.child_id')
+            ->paginate();
+
+        return ProductResource::collection($products);
     }
 }

--- a/packages/Webkul/Shop/src/Http/Controllers/API/CartController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/API/CartController.php
@@ -242,7 +242,7 @@ class CartController extends APIController
             return ProductResource::collection($products);
         } catch (\Exception $exception) {
             return new JsonResource([
-                'data' => $exception->getMessage(),
+                'message' => $exception->getMessage(),
             ]);
         }
     }

--- a/packages/Webkul/Shop/src/Http/Controllers/API/CartController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/API/CartController.php
@@ -229,15 +229,21 @@ class CartController extends APIController
      */
     public function crossSellProducts()
     {
-        $productIds = Cart::getCart()->items->pluck('product_id')->toArray();
+        try {
+            $productIds = Cart::getCart()->items->pluck('product_id')->toArray();
 
-        $products = $this->productRepository
-            ->select('products.*', 'product_cross_sells.child_id')
-            ->join('product_cross_sells', 'products.id', '=', 'product_cross_sells.child_id')
-            ->whereIn('product_cross_sells.parent_id', $productIds)
-            ->groupBy('product_cross_sells.child_id')
-            ->paginate();
+            $products = $this->productRepository
+                ->select('products.*', 'product_cross_sells.child_id')
+                ->join('product_cross_sells', 'products.id', '=', 'product_cross_sells.child_id')
+                ->whereIn('product_cross_sells.parent_id', $productIds)
+                ->groupBy('product_cross_sells.child_id')
+                ->paginate();
 
-        return ProductResource::collection($products);
+            return ProductResource::collection($products);
+        } catch (\Exception $exception) {
+            return new JsonResource([
+                'data' => $exception->getMessage(),
+            ]);
+        }
     }
 }


### PR DESCRIPTION
## Issue Reference
500 api response when there is no item in cart on cart page.

## Description
When there is no item in cart and go to checkout/cart path, api response is 500, and also display cross sell loading effect.

![msedge_pKwsApojbI](https://github.com/bagisto/bagisto/assets/12383757/c7845764-a34b-4e69-bf6c-848acdbec456)

## How To Test This?
1. Go to checkout/cart path without adding an item to cart.

## Documentation
- [x] Needs to handle empty cart with try catch