### PR TITLE
Fix: #9360 - When there are non-stockable products in the cart, the C…

### DIFF
--- a/packages/Webkul/Payment/src/Payment.php
+++ b/packages/Webkul/Payment/src/Payment.php
@@ -32,10 +32,6 @@ class Payment
             $paymentMethod = app($paymentMethodConfig['class']);
 
             if ($paymentMethod->isAvailable()) {
-                if (! Cart::getCart()->haveStockableItems() && $paymentMethod->getCode() == 'cashondelivery') {
-                    continue;
-                }
-
                 $paymentMethods[] = [
                     'method'       => $paymentMethod->getCode(),
                     'method_title' => $paymentMethod->getTitle(),

--- a/packages/Webkul/Payment/src/Payment.php
+++ b/packages/Webkul/Payment/src/Payment.php
@@ -3,6 +3,7 @@
 namespace Webkul\Payment;
 
 use Illuminate\Support\Facades\Config;
+use Webkul\Checkout\Facades\Cart;
 
 class Payment
 {
@@ -31,6 +32,10 @@ class Payment
             $paymentMethod = app($paymentMethodConfig['class']);
 
             if ($paymentMethod->isAvailable()) {
+                if (! Cart::getCart()->haveStockableItems() && $paymentMethod->getCode() == 'cashondelivery') {
+                    continue;
+                }
+
                 $paymentMethods[] = [
                     'method'       => $paymentMethod->getCode(),
                     'method_title' => $paymentMethod->getTitle(),

--- a/packages/Webkul/Payment/src/Payment.php
+++ b/packages/Webkul/Payment/src/Payment.php
@@ -3,7 +3,6 @@
 namespace Webkul\Payment;
 
 use Illuminate\Support\Facades\Config;
-use Webkul\Checkout\Facades\Cart;
 
 class Payment
 {

--- a/packages/Webkul/Payment/src/Payment/CashOnDelivery.php
+++ b/packages/Webkul/Payment/src/Payment/CashOnDelivery.php
@@ -8,29 +8,33 @@ use Webkul\Checkout\Facades\Cart;
 class CashOnDelivery extends Payment
 {
     /**
-     * Payment method code
+     * Payment method code.
      *
      * @var string
      */
     protected $code = 'cashondelivery';
 
     /**
-     * Return cashondelivery redirect url
+     * Get redirect url.
      *
      * @return string
      */
     public function getRedirectUrl()
     {
-
     }
 
+    /**
+     * Is available.
+     *
+     * @return bool
+     */
     public function isAvailable()
     {
         return $this->cart->haveStockableItems() && $this->getConfigData('active');
     }
 
     /**
-     * Returns payment method image
+     * Get payment method image.
      *
      * @return array
      */

--- a/packages/Webkul/Payment/src/Payment/CashOnDelivery.php
+++ b/packages/Webkul/Payment/src/Payment/CashOnDelivery.php
@@ -26,7 +26,7 @@ class CashOnDelivery extends Payment
 
     public function isAvailable()
     {
-        return (Cart::getCart()->haveStockableItems() && $this->getConfigData('active')) ? true : false;
+        return $this->cart->haveStockableItems() && $this->getConfigData('active');
     }
 
     /**

--- a/packages/Webkul/Payment/src/Payment/CashOnDelivery.php
+++ b/packages/Webkul/Payment/src/Payment/CashOnDelivery.php
@@ -29,7 +29,7 @@ class CashOnDelivery extends Payment
      */
     public function isAvailable()
     {
-        return $this->cart->haveStockableItems() && $this->getConfigData('active');
+        return $this->getConfigData('active') && $this->cart?->haveStockableItems();
     }
 
     /**

--- a/packages/Webkul/Payment/src/Payment/CashOnDelivery.php
+++ b/packages/Webkul/Payment/src/Payment/CashOnDelivery.php
@@ -3,6 +3,7 @@
 namespace Webkul\Payment\Payment;
 
 use Illuminate\Support\Facades\Storage;
+use Webkul\Checkout\Facades\Cart;
 
 class CashOnDelivery extends Payment
 {
@@ -21,6 +22,11 @@ class CashOnDelivery extends Payment
     public function getRedirectUrl()
     {
 
+    }
+
+    public function isAvailable()
+    {
+        return (Cart::getCart()->haveStockableItems() && $this->getConfigData('active')) ? true : false;
     }
 
     /**

--- a/packages/Webkul/Payment/src/Payment/CashOnDelivery.php
+++ b/packages/Webkul/Payment/src/Payment/CashOnDelivery.php
@@ -3,7 +3,6 @@
 namespace Webkul\Payment\Payment;
 
 use Illuminate\Support\Facades\Storage;
-use Webkul\Checkout\Facades\Cart;
 
 class CashOnDelivery extends Payment
 {


### PR DESCRIPTION
…ash on Delivery payment method has been made unavailable.

## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
#9360 
## Description
<!--- Please describe your changes in detail. -->
Cash on delivery payment method not available when ordering only downloadable or virtual products.

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->

- Add only downloadable and virtual products in cart.
- Continue to checkout.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->
