### PR TITLE
fixed add or remove image(s) for image_carousel type

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/ThemeController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/ThemeController.php
@@ -102,9 +102,9 @@ class ThemeController extends Controller
 
         $data['status'] = request()->input('status') == 'on';
 
-        if (in_array($data['type'], ['image_carousel', 'services_content'])) {
-            unset($data[$locale]['options']);
-        }
+        // if (in_array($data['type'], ['image_carousel', 'services_content'])) {
+        //     unset($data[$locale]['options']);
+        // }
 
         Event::dispatch('theme_customization.update.before', $id);
 
@@ -114,7 +114,7 @@ class ThemeController extends Controller
             $this->themeCustomizationRepository->uploadImage(
                 $data[$locale],
                 $theme,
-                request()->input('deleted_sliders', []),
+                request()->input("{$locale}.deleted_sliders", []),
             );
         }
 

--- a/packages/Webkul/Theme/src/Repositories/ThemeCustomizationRepository.php
+++ b/packages/Webkul/Theme/src/Repositories/ThemeCustomizationRepository.php
@@ -61,6 +61,7 @@ class ThemeCustomizationRepository extends Repository
                     $options['images'][] = [
                         'image' => 'storage/'.$path,
                         'link'  => $image['link'],
+                        'title'  => $image['title'],
                     ];
                 } else {
                     $options['images'][] = $image;


### PR DESCRIPTION
## Issue Reference
#9369 

## Description

> If I edit the url /admin/settings/themes/edit/{id} I can see the theme but the images aren't displayed/saved in db. Please check this out. Also if I edit an image carousel (the default ones) doesn;t work at all.

## How To Test This?

### Create New Carousel and add new images
1. diedumping on request data to check payload structure
2. commenting out line 105 to 107 and again add new images

### Delete images from New Carousel or Existing Carousel (default ones)
1. diedumping on request data to check payload structure
2. modified request payload key on line 117 and agin delete image(s)