### PR TITLE
Fix Quantity Issue While Moving Product From Cart To Wishlist.

### DIFF
--- a/packages/Webkul/Customer/src/Database/Factories/CustomerWishlistFactory.php
+++ b/packages/Webkul/Customer/src/Database/Factories/CustomerWishlistFactory.php
@@ -23,7 +23,7 @@ class CustomerWishlistFactory extends Factory
     {
         return [
             'additional'  => [
-                'quantity' => 1
+                'quantity' => 1,
             ],
         ];
     }

--- a/packages/Webkul/Customer/src/Database/Factories/CustomerWishlistFactory.php
+++ b/packages/Webkul/Customer/src/Database/Factories/CustomerWishlistFactory.php
@@ -21,6 +21,10 @@ class CustomerWishlistFactory extends Factory
      */
     public function definition(): array
     {
-        return [];
+        return [
+            'additional'  => [
+                'quantity' => 1
+            ],
+        ];
     }
 }

--- a/packages/Webkul/Shop/src/Http/Controllers/API/CartController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/API/CartController.php
@@ -144,8 +144,10 @@ class CartController extends APIController
      */
     public function moveToWishlist(): JsonResource
     {
-        foreach (request()->input('ids') as $id) {
-            Cart::moveToWishlist($id);
+        foreach (request()->input('ids') as $index => $id) {
+            $qty = request()->input('qtys')[$index];
+
+            Cart::moveToWishlist($id, $qty);
         }
 
         return new JsonResource([

--- a/packages/Webkul/Shop/src/Http/Controllers/API/WishlistController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/API/WishlistController.php
@@ -97,7 +97,7 @@ class WishlistController extends APIController
         }
 
         try {
-            $result = Cart::moveToCart($wishlistItem);
+            $result = Cart::moveToCart($wishlistItem, request()->quantity);
 
             if ($result) {
                 return new JsonResource([
@@ -115,7 +115,6 @@ class WishlistController extends APIController
                 'data'     => route('shop.product_or_category.index', $wishlistItem->product->url_key),
                 'message'  => trans('shop::app.checkout.cart.missing-options'),
             ]);
-
         } catch (\Exception $exception) {
             return new JsonResource([
                 'redirect' => true,

--- a/packages/Webkul/Shop/src/Http/Resources/WishlistResource.php
+++ b/packages/Webkul/Shop/src/Http/Resources/WishlistResource.php
@@ -15,10 +15,10 @@ class WishlistResource extends JsonResource
     public function toArray($request)
     {
         return [
-            'id'      => $this->id,
-            'options' => array_values($this->resource->additional['attributes'] ?? []),
-            'product' => new ProductResource($this->product),
+            'id'       => $this->id,
+            'options'  => array_values($this->resource->additional['attributes'] ?? []),
+            'product'  => new ProductResource($this->product),
+            'quantity' => $this['additional']['quantity'],
         ];
-
     }
 }

--- a/packages/Webkul/Shop/src/Http/Resources/WishlistResource.php
+++ b/packages/Webkul/Shop/src/Http/Resources/WishlistResource.php
@@ -18,7 +18,7 @@ class WishlistResource extends JsonResource
             'id'       => $this->id,
             'options'  => array_values($this->resource->additional['attributes'] ?? []),
             'product'  => new ProductResource($this->product),
-            'quantity' => $this['additional']['quantity'],
+            'quantity' => $this['additional'] ? $this['additional']['quantity'] : 1,
         ];
     }
 }

--- a/packages/Webkul/Shop/src/Resources/views/checkout/cart/index.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/checkout/cart/index.blade.php
@@ -490,8 +490,13 @@
                             agree: () => {
                                 const selectedItemsIds = this.cart.items.flatMap(item => item.selected ? item.id : []);
 
+                                const selectedItemsQtys = this.cart.items
+                                    .filter(item => item.selected)
+                                    .map(item => this.applied.quantity[item.id] ?? item.quantity);
+
                                 this.$axios.post('{{ route('shop.api.checkout.cart.move_to_wishlist') }}', {
                                         'ids': selectedItemsIds,
+                                        'qtys':selectedItemsQtys, 
                                     })
                                     .then(response => {
                                         this.cart = response.data.data;

--- a/packages/Webkul/Shop/src/Resources/views/customers/account/wishlist/index.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/customers/account/wishlist/index.blade.php
@@ -144,6 +144,7 @@
                                                 <x-shop::quantity-changer
                                                     name="quantity"
                                                     class="flex gap-x-2.5 items-center max-h-10 py-1.5 px-3.5 border border-navyBlue  rounded-[54px]"
+                                                    ::value="item?.quantity"
                                                     @change="setItemQuantity($event, item)"
                                                 />
 
@@ -153,7 +154,7 @@
                                                     :title="trans('shop::app.customers.account.wishlist.move-to-cart')"
                                                     :loading="false"
                                                     ref="moveToCart"
-                                                    @click="moveToCart(item.id,index)"
+                                                    @click="moveToCart(item.id,index,item?.quantity)"
                                                 />
                                             </div>
 
@@ -226,7 +227,7 @@
                                 this.isLoading = false;
 
                                 this.wishlist = response.data.data
-                                    .map((wishlist) => ({ ...wishlist, quantity: 1 }));
+                                    .map((wishlist) => ({ ...wishlist, quantity: wishlist.quantity }));
                             })
                             .catch(error => {});
                     },
@@ -258,7 +259,7 @@
                         });
                     },
 
-                    moveToCart(id, index) {
+                    moveToCart(id, index, qty) {
                         this.$refs.moveToCart[index].isLoading = true;
 
                         let url = `{{ route('shop.api.customers.account.wishlist.move_to_cart', ':wishlist_id:') }}`;
@@ -268,8 +269,7 @@
 
                         if (existingItem) {
                             this.$axios.post(url, {
-                                    quantity: existingItem.quantity,
-                                    product_id: id
+                                    quantity: qty,
                                 })
                                 .then(response => {
                                     if (response.data.redirect) {

--- a/packages/Webkul/Shop/tests/Feature/Customers/WishlistTest.php
+++ b/packages/Webkul/Shop/tests/Feature/Customers/WishlistTest.php
@@ -178,17 +178,13 @@ it('should move wishlisted product to the cart', function () {
         'channel_id'  => core()->getCurrentChannel()->id,
         'product_id'  => $product->id,
         'customer_id' => $customer->id,
-        'additional'  => [
-            'product_id' => $product->id,
-            'quantity' => 1,
-        ],
     ]);
 
     // Act and Assert
     $this->loginAsCustomer($customer);
 
     postJson(route('shop.api.customers.account.wishlist.move_to_cart', $wishList->id), [
-        'quantity' => 1
+        'quantity' => 1,
     ])
         ->assertOk()
         ->assertJsonPath('message', trans('shop::app.customers.account.wishlist.moved-success'));

--- a/packages/Webkul/Shop/tests/Feature/Customers/WishlistTest.php
+++ b/packages/Webkul/Shop/tests/Feature/Customers/WishlistTest.php
@@ -178,12 +178,18 @@ it('should move wishlisted product to the cart', function () {
         'channel_id'  => core()->getCurrentChannel()->id,
         'product_id'  => $product->id,
         'customer_id' => $customer->id,
+        'additional'  => [
+            'product_id' => $product->id,
+            'quantity' => 1,
+        ],
     ]);
 
     // Act and Assert
     $this->loginAsCustomer($customer);
 
-    postJson(route('shop.api.customers.account.wishlist.move_to_cart', $wishList->id))
+    postJson(route('shop.api.customers.account.wishlist.move_to_cart', $wishList->id), [
+        'quantity' => 1
+    ])
         ->assertOk()
         ->assertJsonPath('message', trans('shop::app.customers.account.wishlist.moved-success'));
 });


### PR DESCRIPTION
## Issue Reference
We have an issue with product quantity when we first add a product to the wishlist, then increase the product quantity and move it to the cart for that particular selected product. After that comes to the cart, the same quantity or updated quantity of the product moves to the wishlist. Then, inside the wish list, we have an error on product quantity. 