### PR TITLE
Fix DB::getTablePrefix() issue

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Customers/CustomerController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Customers/CustomerController.php
@@ -237,7 +237,7 @@ class CustomerController extends Controller
     {
         $customers = $this->customerRepository->scopeQuery(function ($query) {
             return $query->where('email', 'like', '%'.urldecode(request()->input('query')).'%')
-                ->orWhere(DB::raw('CONCAT('.DB::getTablePrefix().'first_name, " ", '.DB::getTablePrefix().'last_name)'), 'like', '%'.urldecode(request()->input('query')).'%')
+                ->orWhere(DB::raw('CONCAT(first_name, " ", last_name)'), 'like', '%' . urldecode(request()->input('query')) . '%')
                 ->orderBy('created_at', 'desc');
         })->paginate(self::COUNT);
 

--- a/packages/Webkul/Admin/src/Http/Controllers/Customers/CustomerController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Customers/CustomerController.php
@@ -237,7 +237,7 @@ class CustomerController extends Controller
     {
         $customers = $this->customerRepository->scopeQuery(function ($query) {
             return $query->where('email', 'like', '%'.urldecode(request()->input('query')).'%')
-                ->orWhere(DB::raw('CONCAT(first_name, " ", last_name)'), 'like', '%' . urldecode(request()->input('query')) . '%')
+                ->orWhere(DB::raw('CONCAT(first_name, " ", last_name)'), 'like', '%'.urldecode(request()->input('query')).'%')
                 ->orderBy('created_at', 'desc');
         })->paginate(self::COUNT);
 


### PR DESCRIPTION
## Issue Reference
Request: GET
Url: domain/admin/customers/customers/search?query=test
Response
Status Code: 500
error message:  "SQLSTATE[42S22]: Column not found: 1054 Unknown column '__msh__first_name' in 'where clause' (Connection: mysql, SQL: select count(*) as aggregate from `__msh__customers` where `email` like %test% or CONCAT(__msh__first_name, \" \", __msh__last_name) like %test%)",

