### PR TITLE
Feature: Add events before and after mobile category view

### DIFF
--- a/packages/Webkul/Shop/src/Resources/views/components/layouts/header/mobile/index.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/components/layouts/header/mobile/index.blade.php
@@ -65,8 +65,12 @@
                         @endauth
                     </div>
 
+                    {!! view_render_event('bagisto.shop.components.layouts.header.mobile.drawer.categories.before') !!}
+
                     <!-- Mobile category view -->
                     <v-mobile-category></v-mobile-category>
+
+                    {!! view_render_event('bagisto.shop.components.layouts.header.mobile.drawer.categories.after') !!}
 
                     <!-- Localization & Currency Section -->
                     <div class="absolute w-full flex bottom-0 left-0 bg-white shadow-lg p-4 gap-x-5 justify-between items-center mb-4">


### PR DESCRIPTION
Two new events have been added to the mobile view of the shop layout. These events are triggered before and after the category view is rendered. This could assist in adding custom functionality or tracking user interaction with this section.

## Issue Reference
There is no way no in mobile drawer to add links before or after the categories.

## Description
If you need to add a new link, like "Blog" for example, you can do that on Desktop view, but in mobile view, there is no way without changing the Theme files to add links before or after the categories. 
By adding these `view_render_event('...')` before and after `<v-mobile-category>` you can now add your own menus, or some other packages can add their own.

## How To Test This?
You can add an Event listener that inserts the link there like these example:
```php
Event::listen('bagisto.shop.components.layouts.header.mobile.drawer.categories.after', function($viewRenderEventManager) {
              $template = '<div class="flex justify-between items-center border border-b border-l-0 border-r-0 border-t-0 border-[#f3f3f5]">
                      <a
                          href="/blog"
                          class="flex items-center justify-between pb-5 mt-5"
                        
                      >Blog</a> 
                  </div>';
            $viewRenderEventManager->addTemplate($template);
        });
```
