### PR TITLE
Update VisitorServiceProvider.php

### DIFF
--- a/packages/Webkul/Core/src/Providers/VisitorServiceProvider.php
+++ b/packages/Webkul/Core/src/Providers/VisitorServiceProvider.php
@@ -13,7 +13,7 @@ class VisitorServiceProvider extends BaseVisitorServiceProvider
      *
      * @return void
      */
-    public function boot()
+    public function boot():void
     {
         $this->registerMacroHelpers();
     }
@@ -23,7 +23,7 @@ class VisitorServiceProvider extends BaseVisitorServiceProvider
      *
      * @return void
      */
-    public function register()
+    public function register():void
     {
         /**
          * Bind to service container.


### PR DESCRIPTION
fix: php artisan fatal error during composer install when used php 8.3 because of declaration type not exist.

## Issue Reference
Declaration of Webkul\Core\Providers\VisitorServiceProvider::boot() must be compatible with Shetabit\Visitor\Provider\VisitorServiceProvider::boot(): void

## Description
:void type declartion has been added to related functions

## How To Test This?
Use php 8.3 and run composer install
