### PR TITLE
Serialization of Closure on checkout end

### DIFF
--- a/packages/Webkul/Paypal/src/Http/Controllers/SmartButtonController.php
+++ b/packages/Webkul/Paypal/src/Http/Controllers/SmartButtonController.php
@@ -227,7 +227,7 @@ class SmartButtonController extends Controller
 
             Cart::deActivateCart();
 
-            session()->flash('order', $order);
+            session()->flash('order_id', $order->id);
 
             return response()->json([
                 'success' => true,

--- a/packages/Webkul/Paypal/src/Http/Controllers/StandardController.php
+++ b/packages/Webkul/Paypal/src/Http/Controllers/StandardController.php
@@ -53,7 +53,7 @@ class StandardController extends Controller
 
         Cart::deActivateCart();
 
-        session()->flash('order', $order);
+        session()->flash('order_id', $order->id);
 
         return redirect()->route('shop.checkout.onepage.success');
     }

--- a/packages/Webkul/Shop/src/Http/Controllers/API/OnepageController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/API/OnepageController.php
@@ -179,7 +179,7 @@ class OnepageController extends APIController
 
         Cart::deActivateCart();
 
-        session()->flash('order', $order->id);
+        session()->flash('order_id', $order->id);
 
         return new JsonResource([
             'redirect'     => true,

--- a/packages/Webkul/Shop/src/Http/Controllers/API/OnepageController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/API/OnepageController.php
@@ -179,7 +179,7 @@ class OnepageController extends APIController
 
         Cart::deActivateCart();
 
-        session()->flash('order', $order);
+        session()->flash('order', $order->id);
 
         return new JsonResource([
             'redirect'     => true,

--- a/packages/Webkul/Shop/src/Http/Controllers/OnepageController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/OnepageController.php
@@ -83,7 +83,7 @@ class OnepageController extends Controller
      */
     public function success(OrderRepository $orderRepository)
     {
-        if (! $order = $orderRepository->find(session('order'))) {
+        if (! $order = $orderRepository->find(session('order_id'))) {
             return redirect()->route('shop.checkout.cart.index');
         }
 

--- a/packages/Webkul/Shop/src/Http/Controllers/OnepageController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/OnepageController.php
@@ -5,6 +5,7 @@ namespace Webkul\Shop\Http\Controllers;
 use Illuminate\Support\Facades\Event;
 use Webkul\Checkout\Facades\Cart;
 use Webkul\MagicAI\Facades\MagicAI;
+use Webkul\Sales\Repositories\OrderRepository;
 
 class OnepageController extends Controller
 {
@@ -80,9 +81,9 @@ class OnepageController extends Controller
      *
      * @return \Illuminate\View\View|\Illuminate\Http\RedirectResponse
      */
-    public function success()
+    public function success(OrderRepository $orderRepository)
     {
-        if (! $order = session('order')) {
+        if (! $order = $orderRepository->find(session('order'))) {
             return redirect()->route('shop.checkout.cart.index');
         }
 


### PR DESCRIPTION
Serialization of 'Closure' is not allowed

## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
#9609

## Description
<!--- Please describe your changes in detail. -->
Checkout OnePage controller is storing unnecessary at session the full order object that leads to an error on redirections because of processing the Request object (loading/storing cookies and session).  

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->
New installation (master) with fake data and simple checkout.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->
