### PR TITLE
Improved address creation and edit form control groups positions

### DIFF
--- a/packages/Webkul/Shop/src/Resources/views/customers/account/addresses/create.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/customers/account/addresses/create.blade.php
@@ -24,103 +24,79 @@
                 <x-shop::form :action="route('shop.customers.account.addresses.store')">
                     {!! view_render_event('bagisto.shop.customers.account.addresses.create_form_controls.before') !!}
 
-                    <!--Company Name -->
-                    <x-shop::form.control-group>
-                        <x-shop::form.control-group.label>
-                            @lang('shop::app.customers.account.addresses.company-name')
-                        </x-shop::form.control-group.label>
-            
-                        <x-shop::form.control-group.control
-                            type="text"
-                            name="company_name"
-                            :value="old('company_name')"
-                            :label="trans('shop::app.customers.account.addresses.company-name')"
-                            :placeholder="trans('shop::app.customers.account.addresses.company-name')"
-                        />
-            
-                        <x-shop::form.control-group.error control-name="company_name" />
-                    </x-shop::form.control-group>
+                    <div class="grid grid-cols-2 gap-x-5">
+                        <!--Company Name -->
+                        <x-shop::form.control-group>
+                            <x-shop::form.control-group.label>
+                                @lang('shop::app.customers.account.addresses.company-name')
+                            </x-shop::form.control-group.label>
+                    
+                            <x-shop::form.control-group.control type="text" name="company_name" :value="old('company_name')"
+                                :label="trans('shop::app.customers.account.addresses.company-name')"
+                                :placeholder="trans('shop::app.customers.account.addresses.company-name')" />
+                    
+                            <x-shop::form.control-group.error control-name="company_name" />
+                        </x-shop::form.control-group>
+                    
+                        {!! view_render_event('bagisto.shop.customers.account.addresses.create_form_controls.company_name.after') !!}
+                    
+                        <!-- Vat Id -->
+                        <x-shop::form.control-group>
+                            <x-shop::form.control-group.label>
+                                @lang('shop::app.customers.account.addresses.vat-id')
+                            </x-shop::form.control-group.label>
+                    
+                            <x-shop::form.control-group.control type="text" name="vat_id" :value="old('vat_id')"
+                                :label="trans('shop::app.customers.account.addresses.vat-id')"
+                                :placeholder="trans('shop::app.customers.account.addresses.vat-id')" />
+                    
+                            <x-shop::form.control-group.error control-name="vat_id" />
+                        </x-shop::form.control-group>
+                    
+                        {!! view_render_event('bagisto.shop.customers.account.addresses.create_form_controls.vat_id.after') !!}
+                    </div>
 
-                    {!! view_render_event('bagisto.shop.customers.account.addresses.create_form_controls.company_name.after') !!}
-
-                    <!-- First Name -->
-                    <x-shop::form.control-group>
-                        <x-shop::form.control-group.label class="required">
-                            @lang('shop::app.customers.account.addresses.first-name')
-                        </x-shop::form.control-group.label>
-
-                        <x-shop::form.control-group.control
-                            type="text"
-                            name="first_name"
-                            rules="required"
-                            :value="old('first_name')"
-                            :label="trans('shop::app.customers.account.addresses.first-name')"
-                            :placeholder="trans('shop::app.customers.account.addresses.first-name')"
-                        />
-
-                        <x-shop::form.control-group.error control-name="first_name" />
-                    </x-shop::form.control-group>
-
-                    {!! view_render_event('bagisto.shop.customers.account.addresses.create_form_controls.first_name.after') !!}
-
-                    <!-- Last Name  -->
-                    <x-shop::form.control-group>
-                        <x-shop::form.control-group.label class="required">
-                            @lang('shop::app.customers.account.addresses.last-name')
-                        </x-shop::form.control-group.label>
-
-                        <x-shop::form.control-group.control
-                            type="text"
-                            name="last_name"
-                            rules="required"
-                            :value="old('last_name')"
-                            :label="trans('shop::app.customers.account.addresses.last-name')"
-                            :placeholder="trans('shop::app.customers.account.addresses.last-name')"
-                        />
-
-                        <x-shop::form.control-group.error control-name="last_name" />
-                    </x-shop::form.control-group>
-
-                    {!! view_render_event('bagisto.shop.customers.account.addresses.create_form_controls.last_name.after') !!}
-
-                    <!-- E-mail -->
-                    <x-shop::form.control-group>
-                        <x-shop::form.control-group.label class="required">
-                            @lang('shop::app.customers.account.addresses.email')
-                        </x-shop::form.control-group.label>
-
-                        <x-shop::form.control-group.control
-                            type="text"
-                            name="email"
-                            rules="required|email"
-                            :value="old('email')"
-                            :label="trans('shop::app.customers.account.addresses.email')"
-                            :placeholder="trans('shop::app.customers.account.addresses.email')"
-                        />
-
-                        <x-shop::form.control-group.error control-name="email" />
-                    </x-shop::form.control-group>
-
-                    {!! view_render_event('bagisto.shop.customers.account.addresses.create_form_controls.email.after') !!}
-
-                    <!-- Vat Id -->
-                    <x-shop::form.control-group>
-                        <x-shop::form.control-group.label>
-                            @lang('shop::app.customers.account.addresses.vat-id')
-                        </x-shop::form.control-group.label>
-
-                        <x-shop::form.control-group.control
-                            type="text"
-                            name="vat_id"
-                            :value="old('vat_id')"
-                            :label="trans('shop::app.customers.account.addresses.vat-id')"
-                            :placeholder="trans('shop::app.customers.account.addresses.vat-id')"
-                        />
-
-                        <x-shop::form.control-group.error control-name="vat_id" />
-                    </x-shop::form.control-group>
-
-                    {!! view_render_event('bagisto.shop.customers.account.addresses.create_form_controls.vat_id.after') !!}
+                    <div class="grid grid-cols-2 gap-x-5">
+                        <!-- First Name -->
+                        <x-shop::form.control-group>
+                            <x-shop::form.control-group.label class="required">
+                                @lang('shop::app.customers.account.addresses.first-name')
+                            </x-shop::form.control-group.label>
+                            
+                            <x-shop::form.control-group.control
+                                type="text"
+                                name="first_name"
+                                rules="required"
+                                :value="old('first_name')"
+                                :label="trans('shop::app.customers.account.addresses.first-name')"
+                                :placeholder="trans('shop::app.customers.account.addresses.first-name')"
+                            />
+                            
+                            <x-shop::form.control-group.error control-name="first_name" />
+                        </x-shop::form.control-group>
+                        
+                        {!! view_render_event('bagisto.shop.customers.account.addresses.create_form_controls.first_name.after') !!}
+                        
+                        <!-- Last Name  -->
+                        <x-shop::form.control-group>
+                            <x-shop::form.control-group.label class="required">
+                                @lang('shop::app.customers.account.addresses.last-name')
+                            </x-shop::form.control-group.label>
+                            
+                            <x-shop::form.control-group.control
+                                type="text"
+                                name="last_name"
+                                rules="required"
+                                :value="old('last_name')"
+                                :label="trans('shop::app.customers.account.addresses.last-name')"
+                                :placeholder="trans('shop::app.customers.account.addresses.last-name')"
+                            />
+                            
+                            <x-shop::form.control-group.error control-name="last_name" />
+                        </x-shop::form.control-group>
+                        
+                        {!! view_render_event('bagisto.shop.customers.account.addresses.create_form_controls.last_name.after') !!}
+                    </div>
 
                     <!-- Street Address -->
                     <x-shop::form.control-group>
@@ -165,132 +141,123 @@
 
                     {!! view_render_event('bagisto.shop.customers.account.addresses.create_form_controls.street_address.after') !!}
 
-                    <!-- Country List-->
-                    <x-shop::form.control-group>
-                        <x-shop::form.control-group.label class="{{ core()->isCountryRequired() ? 'required' : '' }}">
-                            @lang('shop::app.customers.account.addresses.country')
-                        </x-shop::form.control-group.label>
-            
-                        <x-shop::form.control-group.control
-                            type="select"
-                            name="country"
-                            rules="{{ core()->isCountryRequired() ? 'required' : '' }}"
-                            v-model="country"
-                            aria-label="trans('shop::app.customers.account.addresses.country')"
-                            :label="trans('shop::app.customers.account.addresses.country')"
-                        >
-                            <option value="">
-                                @lang('shop::app.customers.account.addresses.select-country')
-                            </option>
-            
-                            @foreach (core()->countries() as $country)
-                                <option value="{{ $country->code }}">{{ $country->name }}</option>
-                            @endforeach
-                        </x-shop::form.control-group.control>
-            
-                        <x-shop::form.control-group.error control-name="country" />
-                    </x-shop::form.control-group>
-        
-                    <!-- State Name -->
-                    <x-shop::form.control-group>
-                        <x-shop::form.control-group.label class="{{ core()->isStateRequired() ? 'required' : '' }}">
-                            @lang('shop::app.customers.account.addresses.state')
-                        </x-shop::form.control-group.label>
-        
-                        <template v-if="haveStates()">
-                            <x-shop::form.control-group.control
-                                type="select"
-                                id="state"
-                                name="state"
-                                rules="{{ core()->isStateRequired() ? 'required' : '' }}"
-                                v-model="state"
-                                :label="trans('shop::app.customers.account.addresses.state')"
-                                :placeholder="trans('shop::app.customers.account.addresses.state')"
-                            >
-                                <option 
-                                    v-for='(state, index) in countryStates[country]'
-                                    :value="state.code"
-                                    v-text="state.default_name"
-                                >
+                    <div class="grid grid-cols-2 gap-x-5">
+                        <!-- City -->
+                        <x-shop::form.control-group>
+                            <x-shop::form.control-group.label class="required">
+                                @lang('shop::app.customers.account.addresses.city')
+                            </x-shop::form.control-group.label>
+                    
+                            <x-shop::form.control-group.control type="text" name="city" rules="required" :value="old('city')"
+                                :label="trans('shop::app.customers.account.addresses.city')"
+                                :placeholder="trans('shop::app.customers.account.addresses.city')" />
+                    
+                            <x-shop::form.control-group.error control-name="city" />
+                        </x-shop::form.control-group>
+                    
+                        {!! view_render_event('bagisto.shop.customers.account.addresses.create_form_controls.city.after') !!}
+                    
+                        <!-- Post Code -->
+                        <x-shop::form.control-group>
+                            <x-shop::form.control-group.label class="{{ core()->isPostCodeRequired() ? 'required' : '' }}">
+                                @lang('shop::app.customers.account.addresses.post-code')
+                            </x-shop::form.control-group.label>
+                    
+                            <x-shop::form.control-group.control type="text" name="postcode"
+                                rules="{{ core()->isPostCodeRequired() ? 'required' : '' }}|numeric" :value="old('postcode')"
+                                :label="trans('shop::app.customers.account.addresses.post-code')"
+                                :placeholder="trans('shop::app.customers.account.addresses.post-code')" />
+                    
+                            <x-shop::form.control-group.error control-name="postcode" />
+                        </x-shop::form.control-group>
+                    
+                        {!! view_render_event('bagisto.shop.customers.account.addresses.create_form_controls.postcode.after') !!}
+                    </div>
+
+                    <div class="grid grid-cols-2 gap-x-5">
+                        <!-- Country List-->
+                        <x-shop::form.control-group>
+                            <x-shop::form.control-group.label class="{{ core()->isCountryRequired() ? 'required' : '' }}">
+                                @lang('shop::app.customers.account.addresses.country')
+                            </x-shop::form.control-group.label>
+                    
+                            <x-shop::form.control-group.control type="select" name="country"
+                                rules="{{ core()->isCountryRequired() ? 'required' : '' }}" v-model="country"
+                                aria-label="trans('shop::app.customers.account.addresses.country')"
+                                :label="trans('shop::app.customers.account.addresses.country')">
+                                <option value="">
+                                    @lang('shop::app.customers.account.addresses.select-country')
                                 </option>
+                    
+                                @foreach (core()->countries() as $country)
+                                <option value="{{ $country->code }}">{{ $country->name }}</option>
+                                @endforeach
                             </x-shop::form.control-group.control>
-                        </template>
-        
-                        <template v-else>
-                            <x-shop::form.control-group.control
-                                type="text"
-                                name="state"
-                                :value="old('state')"
-                                rules="{{ core()->isStateRequired() ? 'required' : '' }}"
-                                :label="trans('shop::app.customers.account.addresses.state')"
-                                :placeholder="trans('shop::app.customers.account.addresses.state')"
-                            />
-                        </template>
-        
-                        <x-shop::form.control-group.error control-name="state" />
-                    </x-shop::form.control-group>
+                    
+                            <x-shop::form.control-group.error control-name="country" />
+                        </x-shop::form.control-group>
+                    
+                        <!-- State Name -->
+                        <x-shop::form.control-group>
+                            <x-shop::form.control-group.label class="{{ core()->isStateRequired() ? 'required' : '' }}">
+                                @lang('shop::app.customers.account.addresses.state')
+                            </x-shop::form.control-group.label>
+                    
+                            <template v-if="haveStates()">
+                                <x-shop::form.control-group.control type="select" id="state" name="state"
+                                    rules="{{ core()->isStateRequired() ? 'required' : '' }}" v-model="state"
+                                    :label="trans('shop::app.customers.account.addresses.state')"
+                                    :placeholder="trans('shop::app.customers.account.addresses.state')">
+                                    <option v-for='(state, index) in countryStates[country]' :value="state.code"
+                                        v-text="state.default_name">
+                                    </option>
+                                </x-shop::form.control-group.control>
+                            </template>
+                    
+                            <template v-else>
+                                <x-shop::form.control-group.control type="text" name="state" :value="old('state')"
+                                    rules="{{ core()->isStateRequired() ? 'required' : '' }}"
+                                    :label="trans('shop::app.customers.account.addresses.state')"
+                                    :placeholder="trans('shop::app.customers.account.addresses.state')" />
+                            </template>
+                    
+                            <x-shop::form.control-group.error control-name="state" />
+                        </x-shop::form.control-group>
+                    
+                        {!! view_render_event('bagisto.shop.customers.account.addresses.create_form_controls.state.after') !!}
+                    </div>
 
-                    {!! view_render_event('bagisto.shop.customers.account.addresses.create_form_controls.state.after') !!}
-
-                    <!-- City -->
-                    <x-shop::form.control-group>
-                        <x-shop::form.control-group.label class="required">
-                            @lang('shop::app.customers.account.addresses.city')
-                        </x-shop::form.control-group.label>
-
-                        <x-shop::form.control-group.control
-                            type="text"
-                            name="city"
-                            rules="required"
-                            :value="old('city')"
-                            :label="trans('shop::app.customers.account.addresses.city')"
-                            :placeholder="trans('shop::app.customers.account.addresses.city')"
-                        />
-
-                        <x-shop::form.control-group.error control-name="city" />
-                    </x-shop::form.control-group>
-
-                    {!! view_render_event('bagisto.shop.customers.account.addresses.create_form_controls.city.after') !!}
-
-                    <!-- Post Code -->
-                    <x-shop::form.control-group>
-                        <x-shop::form.control-group.label class="{{ core()->isPostCodeRequired() ? 'required' : '' }}">
-                            @lang('shop::app.customers.account.addresses.post-code')
-                        </x-shop::form.control-group.label>
-
-                        <x-shop::form.control-group.control
-                            type="text"
-                            name="postcode"
-                            rules="{{ core()->isPostCodeRequired() ? 'required' : '' }}|numeric"
-                            :value="old('postcode')"
-                            :label="trans('shop::app.customers.account.addresses.post-code')"
-                            :placeholder="trans('shop::app.customers.account.addresses.post-code')"
-                        />
-
-                        <x-shop::form.control-group.error control-name="postcode" />
-                    </x-shop::form.control-group>
-
-                    {!! view_render_event('bagisto.shop.customers.account.addresses.create_form_controls.postcode.after') !!}
-
-                    <!-- Contact -->
-                    <x-shop::form.control-group>
-                        <x-shop::form.control-group.label class="required">
-                            @lang('shop::app.customers.account.addresses.phone')
-                        </x-shop::form.control-group.label>
-
-                        <x-shop::form.control-group.control
-                            type="text"
-                            name="phone"
-                            rules="required|integer"
-                            :value="old('phone')"
-                            :label="trans('shop::app.customers.account.addresses.phone')"
-                            :placeholder="trans('shop::app.customers.account.addresses.phone')"
-                        />
-
-                        <x-shop::form.control-group.error control-name="phone" />
-                    </x-shop::form.control-group>
-
-                    {!! view_render_event('bagisto.shop.customers.account.addresses.create_form_controls.phone.after') !!}
+                    <div class="grid grid-cols-2 gap-x-5">
+                        <!-- Contact -->
+                        <x-shop::form.control-group>
+                            <x-shop::form.control-group.label class="required">
+                                @lang('shop::app.customers.account.addresses.phone')
+                            </x-shop::form.control-group.label>
+                    
+                            <x-shop::form.control-group.control type="text" name="phone" rules="required|integer" :value="old('phone')"
+                                :label="trans('shop::app.customers.account.addresses.phone')"
+                                :placeholder="trans('shop::app.customers.account.addresses.phone')" />
+                    
+                            <x-shop::form.control-group.error control-name="phone" />
+                        </x-shop::form.control-group>
+                    
+                        {!! view_render_event('bagisto.shop.customers.account.addresses.create_form_controls.phone.after') !!}
+                    
+                        <!-- E-mail -->
+                        <x-shop::form.control-group>
+                            <x-shop::form.control-group.label class="required">
+                                @lang('shop::app.customers.account.addresses.email')
+                            </x-shop::form.control-group.label>
+                    
+                            <x-shop::form.control-group.control type="text" name="email" rules="required|email" :value="old('email')"
+                                :label="trans('shop::app.customers.account.addresses.email')"
+                                :placeholder="trans('shop::app.customers.account.addresses.email')" />
+                    
+                            <x-shop::form.control-group.error control-name="email" />
+                        </x-shop::form.control-group>
+                    
+                        {!! view_render_event('bagisto.shop.customers.account.addresses.create_form_controls.email.after') !!}
+                    </div>
 
                     <!-- Set As Default -->
                     <div class="text-md mb-4 flex select-none items-center gap-x-1.5 text-[#6E6E6E]">

--- a/packages/Webkul/Shop/src/Resources/views/customers/account/addresses/edit.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/customers/account/addresses/edit.blade.php
@@ -36,99 +36,68 @@
             >
                 {!! view_render_event('bagisto.shop.customers.account.address.edit_form_controls.before', ['address' => $address]) !!}
 
-                <x-shop::form.control-group>
-                    <x-shop::form.control-group.label>
-                        @lang('shop::app.customers.account.addresses.company-name')
-                    </x-shop::form.control-group.label>
+                <div class="grid grid-cols-2 gap-x-5">
+                    <x-shop::form.control-group>
+                        <x-shop::form.control-group.label>
+                            @lang('shop::app.customers.account.addresses.company-name')
+                        </x-shop::form.control-group.label>
+                
+                        <x-shop::form.control-group.control type="text" name="company_name"
+                            :value="old('company_name') ?? $address->company_name"
+                            :label="trans('shop::app.customers.account.addresses.company-name')"
+                            :placeholder="trans('shop::app.customers.account.addresses.company-name')" />
+                
+                        <x-shop::form.control-group.error control-name="company_name" />
+                    </x-shop::form.control-group>
+                
+                    {!! view_render_event('bagisto.shop.customers.account.addresses.edit_form_controls.company_name.after', ['address' => $address]) !!}
+                
+                    <x-shop::form.control-group>
+                        <x-shop::form.control-group.label>
+                            @lang('shop::app.customers.account.addresses.vat-id')
+                        </x-shop::form.control-group.label>
+                
+                        <x-shop::form.control-group.control type="text" name="vat_id" :value="old('vat_id') ?? $address->vat_id"
+                            :label="trans('shop::app.customers.account.addresses.vat-id')"
+                            :placeholder="trans('shop::app.customers.account.addresses.vat-id')" />
+                
+                        <x-shop::form.control-group.error control-name="vat_id" />
+                    </x-shop::form.control-group>
+                
+                    {!! view_render_event('bagisto.shop.customers.account.addresses.edit_form_controls.vat_id.after', ['address' => $address]) !!}
+                </div>
 
-                    <x-shop::form.control-group.control
-                        type="text"
-                        name="company_name"
-                        :value="old('company_name') ?? $address->company_name"
-                        :label="trans('shop::app.customers.account.addresses.company-name')"
-                        :placeholder="trans('shop::app.customers.account.addresses.company-name')"
-                    />
-
-                    <x-shop::form.control-group.error control-name="company_name" />
-                </x-shop::form.control-group>
-
-                {!! view_render_event('bagisto.shop.customers.account.addresses.edit_form_controls.company_name.after', ['address' => $address]) !!}
-
-                <x-shop::form.control-group>
-                    <x-shop::form.control-group.label class="required">
-                        @lang('shop::app.customers.account.addresses.first-name')
-                    </x-shop::form.control-group.label>
-
-                    <x-shop::form.control-group.control
-                        type="text"
-                        name="first_name"
-                        rules="required"
-                        :value="old('first_name') ?? $address->first_name"
-                        :label="trans('shop::app.customers.account.addresses.first-name')"
-                        :placeholder="trans('shop::app.customers.account.addresses.first-name')"
-                    />
-
-                    <x-shop::form.control-group.error control-name="first_name" />
-                </x-shop::form.control-group>
-
-                {!! view_render_event('bagisto.shop.customers.account.addresses.edit_form_controls.first_name.after', ['address' => $address]) !!}
-
-                <x-shop::form.control-group>
-                    <x-shop::form.control-group.label class="required">
-                        @lang('shop::app.customers.account.addresses.last-name')
-                    </x-shop::form.control-group.label>
-
-                    <x-shop::form.control-group.control
-                        type="text"
-                        name="last_name"
-                        rules="required"
-                        :value="old('last_name') ?? $address->last_name"
-                        :label="trans('shop::app.customers.account.addresses.last-name')"
-                        :placeholder="trans('shop::app.customers.account.addresses.last-name')"
-                    />
-
-                    <x-shop::form.control-group.error control-name="last_name" />
-                </x-shop::form.control-group>
-
-                {!! view_render_event('bagisto.shop.customers.account.addresses.edit_form_controls.last_name.after', ['address' => $address]) !!}
-
-                <!-- E-mail -->
-                <x-shop::form.control-group>
-                    <x-shop::form.control-group.label class="required">
-                        @lang('Email')
-                    </x-shop::form.control-group.label>
-
-                    <x-shop::form.control-group.control
-                        type="text"
-                        name="email"
-                        rules="required|email"
-                        :value="old('email') ?? $address->email"
-                        :label="trans('Email')"
-                        :placeholder="trans('Email')"
-                    />
-
-                    <x-shop::form.control-group.error control-name="email" />
-                </x-shop::form.control-group>
-
-                {!! view_render_event('bagisto.shop.customers.account.addresses.edit_form_controls.email.after', ['address' => $address]) !!}
-
-                <x-shop::form.control-group>
-                    <x-shop::form.control-group.label>
-                        @lang('shop::app.customers.account.addresses.vat-id')
-                    </x-shop::form.control-group.label>
-
-                    <x-shop::form.control-group.control
-                        type="text"
-                        name="vat_id"
-                        :value="old('vat_id') ?? $address->vat_id"
-                        :label="trans('shop::app.customers.account.addresses.vat-id')"
-                        :placeholder="trans('shop::app.customers.account.addresses.vat-id')"
-                    />
-
-                    <x-shop::form.control-group.error control-name="vat_id" />
-                </x-shop::form.control-group>
-
-                {!! view_render_event('bagisto.shop.customers.account.addresses.edit_form_controls.vat_id.after', ['address' => $address]) !!}
+                <div class="grid grid-cols-2 gap-x-5">
+                    <x-shop::form.control-group>
+                        <x-shop::form.control-group.label class="required">
+                            @lang('shop::app.customers.account.addresses.first-name')
+                        </x-shop::form.control-group.label>
+                
+                        <x-shop::form.control-group.control type="text" name="first_name" rules="required"
+                            :value="old('first_name') ?? $address->first_name"
+                            :label="trans('shop::app.customers.account.addresses.first-name')"
+                            :placeholder="trans('shop::app.customers.account.addresses.first-name')" />
+                
+                        <x-shop::form.control-group.error control-name="first_name" />
+                    </x-shop::form.control-group>
+                
+                    {!! view_render_event('bagisto.shop.customers.account.addresses.edit_form_controls.first_name.after', ['address' => $address]) !!}
+                
+                    <x-shop::form.control-group>
+                        <x-shop::form.control-group.label class="required">
+                            @lang('shop::app.customers.account.addresses.last-name')
+                        </x-shop::form.control-group.label>
+                
+                        <x-shop::form.control-group.control type="text" name="last_name" rules="required"
+                            :value="old('last_name') ?? $address->last_name"
+                            :label="trans('shop::app.customers.account.addresses.last-name')"
+                            :placeholder="trans('shop::app.customers.account.addresses.last-name')" />
+                
+                        <x-shop::form.control-group.error control-name="last_name" />
+                    </x-shop::form.control-group>
+                
+                    {!! view_render_event('bagisto.shop.customers.account.addresses.edit_form_controls.last_name.after', ['address' => $address]) !!}
+                </div>
 
                 @php
                     $addresses = explode(PHP_EOL, $address->address);
@@ -174,131 +143,126 @@
 
                 {!! view_render_event('bagisto.shop.customers.account.addresses.edit_form_controls.street-addres.after', ['address' => $address]) !!}
 
-                <!-- Country Name -->
-                <x-shop::form.control-group>
-                    <x-shop::form.control-group.label class="{{ core()->isCountryRequired() ? 'required' : '' }}">
-                        @lang('shop::app.customers.account.addresses.country')
-                    </x-shop::form.control-group.label>
+                <div class="grid grid-cols-2 gap-x-5">
+                    <x-shop::form.control-group>
+                        <x-shop::form.control-group.label class="required">
+                            @lang('shop::app.customers.account.addresses.city')
+                        </x-shop::form.control-group.label>
+                
+                        <x-shop::form.control-group.control type="text" name="city" rules="required"
+                            :value="old('city') ?? $address->city" :label="trans('shop::app.customers.account.addresses.city')"
+                            :placeholder="trans('shop::app.customers.account.addresses.city')" />
+                
+                        <x-shop::form.control-group.error control-name="city" />
+                    </x-shop::form.control-group>
+                
+                    {!! view_render_event('bagisto.shop.customers.account.addresses.edit_form_controls.city.after', ['address' => $address]) !!}
+                
+                    <x-shop::form.control-group>
+                        <x-shop::form.control-group.label class="{{ core()->isPostCodeRequired() ? 'required' : '' }}">
+                            @lang('shop::app.customers.account.addresses.post-code')
+                        </x-shop::form.control-group.label>
+                
+                        <x-shop::form.control-group.control type="text" name="postcode"
+                            rules="{{ core()->isPostCodeRequired() ? 'required' : '' }}|numeric "
+                            :value="old('postal-code') ?? $address->postcode"
+                            :label="trans('shop::app.customers.account.addresses.post-code')"
+                            :placeholder="trans('shop::app.customers.account.addresses.post-code')" />
+                
+                        <x-shop::form.control-group.error control-name="postcode" />
+                    </x-shop::form.control-group>
+                
+                    {!! view_render_event('bagisto.shop.customers.account.addresses.edit_form_controls.postcode.after', ['address' => $address]) !!}
+                </div>
 
-                    <x-shop::form.control-group.control
-                        type="select"
-                        name="country"
-                        rules="{{ core()->isStateRequired() ? 'required' : '' }}"
-                        v-model="addressData.country"
-                        :aria-label="trans('shop::app.customers.account.addresses.country')"
-                        :label="trans('shop::app.customers.account.addresses.country')"
-                    >
-                        @foreach (core()->countries() as $country)
-                            <option 
-                                {{ $country->code === config('app.default_country') ? 'selected' : '' }}  
+                <div class="grid grid-cols-2 gap-x-5">
+                    <!-- Country Name -->
+                    <x-shop::form.control-group>
+                        <x-shop::form.control-group.label class="{{ core()->isCountryRequired() ? 'required' : '' }}">
+                            @lang('shop::app.customers.account.addresses.country')
+                        </x-shop::form.control-group.label>
+                
+                        <x-shop::form.control-group.control type="select" name="country"
+                            rules="{{ core()->isStateRequired() ? 'required' : '' }}" v-model="addressData.country"
+                            :aria-label="trans('shop::app.customers.account.addresses.country')"
+                            :label="trans('shop::app.customers.account.addresses.country')">
+                            @foreach (core()->countries() as $country)
+                            <option {{ $country->code === config('app.default_country') ? 'selected' : '' }}
                                 value="{{ $country->code }}"
-                            >
+                                >
                                 {{ $country->name }}
                             </option>
-                        @endforeach
-                    </x-shop::form.control-group.control>
-
-                    <x-shop::form.control-group.error control-name="country" />
-                </x-shop::form.control-group>
-
-                {!! view_render_event('bagisto.shop.customers.account.addresses.edit_form_controls.country.after', ['address' => $address]) !!}
-
-                <!-- State Name -->
-                <x-shop::form.control-group>
-                    <x-shop::form.control-group.label class="{{ core()->isStateRequired() ? 'required' : '' }}">
-                        @lang('shop::app.customers.account.addresses.state')
-                    </x-shop::form.control-group.label>
-                    <template v-if="haveStates()">
-                        <x-shop::form.control-group.control
-                            type="select"
-                            name="state"
-                            id="state"
-                            rules="{{ core()->isStateRequired() ? 'required' : '' }}"
-                            v-model="addressData.state"
-                            :label="trans('shop::app.customers.account.addresses.state')"
-                            :placeholder="trans('shop::app.customers.account.addresses.state')"
-                        >
-                            <option 
-                                v-for='(state, index) in countryStates[addressData.country]'
-                                :value="state.code"
-                                v-text="state.default_name"
-                            >
-                            </option>
+                            @endforeach
                         </x-shop::form.control-group.control>
-                    </template>
+                
+                        <x-shop::form.control-group.error control-name="country" />
+                    </x-shop::form.control-group>
+                
+                    {!! view_render_event('bagisto.shop.customers.account.addresses.edit_form_controls.country.after', ['address' => $address]) !!}
+                
+                    <!-- State Name -->
+                    <x-shop::form.control-group>
+                        <x-shop::form.control-group.label class="{{ core()->isStateRequired() ? 'required' : '' }}">
+                            @lang('shop::app.customers.account.addresses.state')
+                        </x-shop::form.control-group.label>
+                        <template v-if="haveStates()">
+                            <x-shop::form.control-group.control type="select" name="state" id="state"
+                                rules="{{ core()->isStateRequired() ? 'required' : '' }}" v-model="addressData.state"
+                                :label="trans('shop::app.customers.account.addresses.state')"
+                                :placeholder="trans('shop::app.customers.account.addresses.state')">
+                                <option v-for='(state, index) in countryStates[addressData.country]' :value="state.code"
+                                    v-text="state.default_name">
+                                </option>
+                            </x-shop::form.control-group.control>
+                        </template>
+                
+                        <template v-else>
+                            <x-shop::form.control-group.control type="text" name="state"
+                                rules="{{ core()->isStateRequired() ? 'required' : '' }}" :value="old('state') ?? $address->state"
+                                :label="trans('shop::app.customers.account.addresses.state')"
+                                :placeholder="trans('shop::app.customers.account.addresses.state')" />
+                        </template>
+                
+                        <x-shop::form.control-group.error control-name="state" />
+                    </x-shop::form.control-group>
+                
+                    {!! view_render_event('bagisto.shop.customers.account.addresses.edit_form_controls.state.after', ['address' => $address]) !!}
+                </div>
 
-                    <template v-else>
+                <div class="grid grid-cols-2 gap-x-5">
+                    <!-- E-mail -->
+                    <x-shop::form.control-group>
+                        <x-shop::form.control-group.label class="required">
+                            @lang('Email')
+                        </x-shop::form.control-group.label>
+                
+                        <x-shop::form.control-group.control type="text" name="email" rules="required|email"
+                            :value="old('email') ?? $address->email" :label="trans('Email')" :placeholder="trans('Email')" />
+                
+                        <x-shop::form.control-group.error control-name="email" />
+                    </x-shop::form.control-group>
+                
+                    {!! view_render_event('bagisto.shop.customers.account.addresses.edit_form_controls.email.after', ['address' => $address]) !!}
+
+                    <x-shop::form.control-group>
+                        <x-shop::form.control-group.label class="required">
+                            @lang('shop::app.customers.account.addresses.phone')
+                        </x-shop::form.control-group.label>
+                        
                         <x-shop::form.control-group.control
                             type="text"
-                            name="state"
-                            rules="{{ core()->isStateRequired() ? 'required' : '' }}"
-                            :value="old('state') ?? $address->state"
-                            :label="trans('shop::app.customers.account.addresses.state')"
-                            :placeholder="trans('shop::app.customers.account.addresses.state')"
+                            name="phone"
+                            rules="required|integer"
+                            :value="old('phone') ?? $address->phone"
+                            :label="trans('shop::app.customers.account.addresses.phone')"
+                            :placeholder="trans('shop::app.customers.account.addresses.phone')"
                         />
-                    </template>
-
-                    <x-shop::form.control-group.error control-name="state" />
-                </x-shop::form.control-group>
-
-                {!! view_render_event('bagisto.shop.customers.account.addresses.edit_form_controls.state.after', ['address' => $address]) !!}
-
-                <x-shop::form.control-group>
-                    <x-shop::form.control-group.label class="required">
-                        @lang('shop::app.customers.account.addresses.city')
-                    </x-shop::form.control-group.label>
-
-                    <x-shop::form.control-group.control
-                        type="text"
-                        name="city"
-                        rules="required"
-                        :value="old('city') ?? $address->city"
-                        :label="trans('shop::app.customers.account.addresses.city')"
-                        :placeholder="trans('shop::app.customers.account.addresses.city')"
-                    />
-
-                    <x-shop::form.control-group.error control-name="city" />
-                </x-shop::form.control-group>
-
-                {!! view_render_event('bagisto.shop.customers.account.addresses.edit_form_controls.city.after', ['address' => $address]) !!}
-
-                <x-shop::form.control-group>
-                    <x-shop::form.control-group.label class="{{ core()->isPostCodeRequired() ? 'required' : '' }}">
-                        @lang('shop::app.customers.account.addresses.post-code')
-                    </x-shop::form.control-group.label>
-
-                    <x-shop::form.control-group.control
-                        type="text"
-                        name="postcode"
-                        rules="{{ core()->isPostCodeRequired() ? 'required' : '' }}|numeric "
-                        :value="old('postal-code') ?? $address->postcode"
-                        :label="trans('shop::app.customers.account.addresses.post-code')"
-                        :placeholder="trans('shop::app.customers.account.addresses.post-code')"
-                    />
-
-                    <x-shop::form.control-group.error control-name="postcode" />
-                </x-shop::form.control-group>
-
-                {!! view_render_event('bagisto.shop.customers.account.addresses.edit_form_controls.postcode.after', ['address' => $address]) !!}
-
-                <x-shop::form.control-group>
-                    <x-shop::form.control-group.label class="required">
-                        @lang('shop::app.customers.account.addresses.phone')
-                    </x-shop::form.control-group.label>
-
-                    <x-shop::form.control-group.control
-                        type="text"
-                        name="phone"
-                        rules="required|integer"
-                        :value="old('phone') ?? $address->phone"
-                        :label="trans('shop::app.customers.account.addresses.phone')"
-                        :placeholder="trans('shop::app.customers.account.addresses.phone')"
-                    />
-
-                    <x-shop::form.control-group.error control-name="phone" />
-                </x-shop::form.control-group>
-
-                {!! view_render_event('bagisto.shop.customers.account.addresses.edit_form_controls.phone.after', ['address' => $address]) !!}
+                        
+                        <x-shop::form.control-group.error control-name="phone" />
+                    </x-shop::form.control-group>
+                    
+                    {!! view_render_event('bagisto.shop.customers.account.addresses.edit_form_controls.phone.after', ['address' => $address]) !!}
+                </div>
 
                 <button
                     type="submit"


### PR DESCRIPTION
## Description
This pull request addresses the issue of long page length by rearranging the positions of form control groups. By doing so, we aim to improve the overall user experience and make the page more manageable.

## Changes Made
- Rearranged the positions of form control groups to optimize page length.
- Ensured the logical flow and accessibility of form elements remain intact.

# Screenshots
### Add address
![image](https://github.com/bagisto/bagisto/assets/1594411/83846669-f88c-4e9d-b639-e9290345fbe7)

### Edit form
![image](https://github.com/bagisto/bagisto/assets/1594411/547c421f-43b6-4597-b58b-d9b7d8cbb6ec)

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->

1. Login as a customer
2. Go to the account settings -> Addresses
3. Add a new address and try to edit it.
