### PR TITLE
Allow dynamic evaluation of invoice number prefix

### DIFF
--- a/packages/Webkul/Sales/src/Generators/InvoiceSequencer.php
+++ b/packages/Webkul/Sales/src/Generators/InvoiceSequencer.php
@@ -24,7 +24,13 @@ class InvoiceSequencer extends Sequencer
      */
     public function setAllConfigs()
     {
-        $this->prefix = core()->getConfigData('sales.invoice_settings.invoice_number.invoice_number_prefix');
+        $prefixConfig = core()->getConfigData('sales.invoice_settings.invoice_number.invoice_number_prefix');
+
+        if (strpos($prefixConfig, 'date(') !== false) {
+            $this->prefix = eval("return $prefixConfig;");
+        } else {
+            $this->prefix = $prefixConfig;
+        }
 
         $this->length = core()->getConfigData('sales.invoice_settings.invoice_number.invoice_number_length');
 

--- a/packages/Webkul/Sales/src/Generators/InvoiceSequencer.php
+++ b/packages/Webkul/Sales/src/Generators/InvoiceSequencer.php
@@ -27,7 +27,11 @@ class InvoiceSequencer extends Sequencer
         $prefixConfig = core()->getConfigData('sales.invoice_settings.invoice_number.invoice_number_prefix');
 
         if (strpos($prefixConfig, 'date(') !== false) {
-            $this->prefix = eval("return $prefixConfig;");
+            preg_match('/date\(\'([^\']+)\'\)/', $prefixConfig, $matches);
+
+            if (isset($matches[1])) {
+                $this->prefix = date($matches[1]);
+            }
         } else {
             $this->prefix = $prefixConfig;
         }


### PR DESCRIPTION
## Description
This pull request enhances the functionality of the **InvoiceSequencer** class by enabling dynamic evaluation of the invoice number prefix configured in the admin panel. Previously, the prefix was treated as a plain string, limiting its flexibility.  
With this enhancement, users can now enter dynamic PHP expressions such as **date('Ym')** in the admin panel, and the system will evaluate them to include the current year in the invoice numbers. 

This improvement enhances the customization options available to users, allowing for more flexible and dynamic invoice number generation in Bagisto.

![image](https://github.com/bagisto/bagisto/assets/1594411/c6d8f711-cfef-40ca-ae9d-b1d13431a78e)
**Result**

![image](https://github.com/bagisto/bagisto/assets/1594411/09fd57b9-fbd5-4859-a8ee-07c488066b68)

### Additionally, this modification ensures backward compatibility by continuing to support plain string prefixes.  

![image](https://github.com/bagisto/bagisto/assets/1594411/bcbf11ca-0ad4-4026-b4ee-6a174af8a61d)

**Result**

![image](https://github.com/bagisto/bagisto/assets/1594411/f0a5ac96-e516-4d06-99ea-4ecf040096ad)

## Documentation
- [X] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->
