### PR TITLE
Fix incompatible method signature in VisitorServiceProvider

### DIFF
--- a/packages/Webkul/Core/src/Providers/VisitorServiceProvider.php
+++ b/packages/Webkul/Core/src/Providers/VisitorServiceProvider.php
@@ -13,7 +13,7 @@ class VisitorServiceProvider extends BaseVisitorServiceProvider
      *
      * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         $this->registerMacroHelpers();
     }
@@ -23,7 +23,7 @@ class VisitorServiceProvider extends BaseVisitorServiceProvider
      *
      * @return void
      */
-    public function register()
+    public function register(): void
     {
         /**
          * Bind to service container.

--- a/packages/Webkul/Core/src/Providers/VisitorServiceProvider.php
+++ b/packages/Webkul/Core/src/Providers/VisitorServiceProvider.php
@@ -11,7 +11,6 @@ class VisitorServiceProvider extends BaseVisitorServiceProvider
     /**
      * Perform post-registration booting of services.
      *
-     * @return void
      */
     public function boot(): void
     {
@@ -21,7 +20,6 @@ class VisitorServiceProvider extends BaseVisitorServiceProvider
     /**
      * Register any package services.
      *
-     * @return void
      */
     public function register(): void
     {

--- a/packages/Webkul/Core/src/Providers/VisitorServiceProvider.php
+++ b/packages/Webkul/Core/src/Providers/VisitorServiceProvider.php
@@ -10,7 +10,6 @@ class VisitorServiceProvider extends BaseVisitorServiceProvider
 {
     /**
      * Perform post-registration booting of services.
-     *
      */
     public function boot(): void
     {
@@ -19,7 +18,6 @@ class VisitorServiceProvider extends BaseVisitorServiceProvider
 
     /**
      * Register any package services.
-     *
      */
     public function register(): void
     {


### PR DESCRIPTION
This commit resolves the issue with the incompatible method signature in the `Webkul\Core\Providers\VisitorServiceProvider` class. The `boot` and `register` methods in this class have been updated to include the `void` return type, ensuring compatibility with the parent class `Shetabit\Visitor\Provider\VisitorServiceProvider`.