### PR TITLE
Refactor code to use 'auto' instead of 'scroll' for body overflow in drawer and modal components

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/components/drawer/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/drawer/index.blade.php
@@ -168,7 +168,7 @@
                     if (this.isOpen) {
                         document.body.style.overflow = 'hidden';
                     } else {
-                        document.body.style.overflow ='scroll';
+                        document.body.style.overflow ='auto';
                     }
 
                     this.$emit('toggle', { isActive: this.isOpen });

--- a/packages/Webkul/Admin/src/Resources/views/components/modal/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/modal/index.blade.php
@@ -125,7 +125,7 @@
                     if (this.isOpen) {
                         document.body.style.overflow = 'hidden';
                     } else {
-                        document.body.style.overflow ='scroll';
+                        document.body.style.overflow ='auto';
                     }
 
                     this.$emit('toggle', { isActive: this.isOpen });

--- a/packages/Webkul/Shop/src/Resources/views/components/drawer/index.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/components/drawer/index.blade.php
@@ -169,7 +169,7 @@
                     if (this.isOpen) {
                         document.body.style.overflow = 'hidden';
                     } else {
-                        document.body.style.overflow ='scroll';
+                        document.body.style.overflow ='auto';
                     }
 
                     this.$emit('toggle', { isActive: this.isOpen });

--- a/packages/Webkul/Shop/src/Resources/views/components/modal/index.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/components/modal/index.blade.php
@@ -124,7 +124,7 @@
                     if (this.isOpen) {
                         document.body.style.overflow = 'hidden';
                     } else {
-                        document.body.style.overflow ='scroll';
+                        document.body.style.overflow ='auto';
                     }
 
                     this.$emit('toggle', { isActive: this.isOpen });


### PR DESCRIPTION
Refactor code to use 'auto' instead of 'scroll' for body overflow in drawer and modal components