### PR TITLE
Update admin email layout.blade.php

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/emails/layout.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/emails/layout.blade.php
@@ -17,7 +17,7 @@
                     <a href="{{ route('shop.home.index') }}">
                         @if ($logo = core()->getConfigData('general.design.admin_logo.logo_image'))
                             <img
-                                src="{{ $logo }}"
+                                src="{{ Storage::url($logo) }}"
                                 alt="{{ config('app.name') }}"
                                 style="height: 40px; width: 110px;"
                             />


### PR DESCRIPTION
The logo URL is not correct, and the image is not displayed in the admin emails.  In the admin layouts where the logo is shown, it's displayed using `{{ Storage::url($logo) }}`