### PR TITLE
Improved updateEnvChoice to support suggest functionality

### DIFF
--- a/packages/Webkul/Installer/src/Console/Commands/Installer.php
+++ b/packages/Webkul/Installer/src/Console/Commands/Installer.php
@@ -14,6 +14,7 @@ use Webkul\Installer\Helpers\DatabaseManager;
 use function Laravel\Prompts\multiselect;
 use function Laravel\Prompts\password;
 use function Laravel\Prompts\select;
+use function Laravel\Prompts\suggest;
 use function Laravel\Prompts\text;
 
 class Installer extends Command
@@ -240,7 +241,8 @@ class Installer extends Command
         $this->updateEnvChoice(
             'APP_TIMEZONE',
             'Please select the application timezone',
-            $timezones
+            $timezones,
+            true
         );
 
         $defaultLocale = $this->updateEnvChoice(
@@ -487,13 +489,21 @@ class Installer extends Command
      *
      * @return string
      */
-    protected function updateEnvChoice(string $key, string $question, array $choices)
+    protected function updateEnvChoice(string $key, string $question, array $choices, bool $useSuggest = false)
     {
-        $choice = select(
-            label: $question,
-            options: $choices,
-            default: env($key)
-        );
+        if ($useSuggest) {
+            $choice = suggest(
+                label: $question,
+                options: $choices,
+                default: env($key)
+            );
+        } else {
+            $choice = select(
+                label: $question,
+                options: $choices,
+                default: env($key)
+            );
+        }
 
         $this->envUpdate($key, $choice);
 


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
#9946 

## Description
<!--- Please describe your changes in detail. -->
This pull request enhances the updateEnvChoice method by adding an optional parameter, `$useSuggest`.  
When this parameter is set to **true**, the method will use the **suggest** function instead of **select** for user prompts. 
This enhancement provides a more efficient way for users to find and select options, particularly useful for long lists like timezones.

Video for reference:
[![Watch the video](https://img.youtube.com/vi/0uSZ68Cw08s/default.jpg)](https://youtube.com/watch?v=0uSZ68Cw08s)

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->
run `php artisan bagisto:install` and select your timezone

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: master 

