### PR TITLE
feat: integer and decimal type enhanced

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Catalog/ProductDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Catalog/ProductDataGrid.php
@@ -139,7 +139,7 @@ class ProductDataGrid extends DataGrid
         $this->addColumn([
             'index'      => 'price',
             'label'      => trans('admin::app.catalog.products.index.datagrid.price'),
-            'type'       => 'float',
+            'type'       => 'decimal',
             'filterable' => true,
             'sortable'   => true,
         ]);

--- a/packages/Webkul/Admin/src/DataGrids/Catalog/ProductDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Catalog/ProductDataGrid.php
@@ -139,7 +139,7 @@ class ProductDataGrid extends DataGrid
         $this->addColumn([
             'index'      => 'price',
             'label'      => trans('admin::app.catalog.products.index.datagrid.price'),
-            'type'       => 'string',
+            'type'       => 'float',
             'filterable' => true,
             'sortable'   => true,
         ]);

--- a/packages/Webkul/DataGrid/src/ColumnTypes/Aggregate.php
+++ b/packages/Webkul/DataGrid/src/ColumnTypes/Aggregate.php
@@ -4,6 +4,7 @@ namespace Webkul\DataGrid\ColumnTypes;
 
 use Webkul\DataGrid\Column;
 use Webkul\DataGrid\Enums\FilterTypeEnum;
+use Webkul\DataGrid\Exceptions\InvalidColumnExpressionException;
 
 class Aggregate extends Column
 {
@@ -16,12 +17,12 @@ class Aggregate extends Column
             return $queryBuilder->having(function ($scopeQueryBuilder) use ($requestedValues) {
                 if (is_string($requestedValues)) {
                     $scopeQueryBuilder->orHaving($this->columnName, $requestedValues);
-
-                    return;
-                }
-
-                foreach ($requestedValues as $value) {
-                    $scopeQueryBuilder->orHaving($this->columnName, $value);
+                } elseif (is_array($requestedValues)) {
+                    foreach ($requestedValues as $value) {
+                        $scopeQueryBuilder->orHaving($this->columnName, $value);
+                    }
+                } else {
+                    throw new InvalidColumnExpressionException('Only string and array are allowed for text column type.');
                 }
             });
         }
@@ -29,12 +30,12 @@ class Aggregate extends Column
         return $queryBuilder->having(function ($scopeQueryBuilder) use ($requestedValues) {
             if (is_string($requestedValues)) {
                 $scopeQueryBuilder->orHaving($this->columnName, 'LIKE', '%'.$requestedValues.'%');
-
-                return;
-            }
-
-            foreach ($requestedValues as $value) {
-                $scopeQueryBuilder->orHaving($this->columnName, 'LIKE', '%'.$value.'%');
+            } elseif (is_array($requestedValues)) {
+                foreach ($requestedValues as $value) {
+                    $scopeQueryBuilder->orHaving($this->columnName, 'LIKE', '%'.$value.'%');
+                }
+            } else {
+                throw new InvalidColumnExpressionException('Only string and array are allowed for text column type.');
             }
         });
     }

--- a/packages/Webkul/DataGrid/src/ColumnTypes/Boolean.php
+++ b/packages/Webkul/DataGrid/src/ColumnTypes/Boolean.php
@@ -5,6 +5,7 @@ namespace Webkul\DataGrid\ColumnTypes;
 use Webkul\DataGrid\Column;
 use Webkul\DataGrid\Enums\FilterTypeEnum;
 use Webkul\DataGrid\Exceptions\InvalidColumnException;
+use Webkul\DataGrid\Exceptions\InvalidColumnExpressionException;
 
 class Boolean extends Column
 {
@@ -56,12 +57,12 @@ class Boolean extends Column
         return $queryBuilder->where(function ($scopeQueryBuilder) use ($requestedValues) {
             if (is_string($requestedValues)) {
                 $scopeQueryBuilder->orWhere($this->columnName, $requestedValues);
-
-                return;
-            }
-
-            foreach ($requestedValues as $value) {
-                $scopeQueryBuilder->orWhere($this->columnName, $value);
+            } elseif (is_array($requestedValues)) {
+                foreach ($requestedValues as $value) {
+                    $scopeQueryBuilder->orWhere($this->columnName, $value);
+                }
+            } else {
+                throw new InvalidColumnExpressionException('Only string and array are allowed for boolean column type.');
             }
         });
     }

--- a/packages/Webkul/DataGrid/src/ColumnTypes/Date.php
+++ b/packages/Webkul/DataGrid/src/ColumnTypes/Date.php
@@ -6,6 +6,7 @@ use Webkul\DataGrid\Column;
 use Webkul\DataGrid\Enums\DateRangeOptionEnum;
 use Webkul\DataGrid\Enums\FilterTypeEnum;
 use Webkul\DataGrid\Exceptions\InvalidColumnException;
+use Webkul\DataGrid\Exceptions\InvalidColumnExpressionException;
 
 class Date extends Column
 {
@@ -48,13 +49,15 @@ class Date extends Column
                 $requestedDates = ! $rangeOption
                     ? [[$requestedDates, $requestedDates]]
                     : [[$rangeOption['from'], $rangeOption['to']]];
-            }
-
-            foreach ($requestedDates as $value) {
-                $scopeQueryBuilder->whereBetween($this->columnName, [
-                    ($value[0] ?? '').' 00:00:01',
-                    ($value[1] ?? '').' 23:59:59',
-                ]);
+            } elseif (is_array($requestedDates)) {
+                foreach ($requestedDates as $value) {
+                    $scopeQueryBuilder->whereBetween($this->columnName, [
+                        ($value[0] ?? '').' 00:00:01',
+                        ($value[1] ?? '').' 23:59:59',
+                    ]);
+                }
+            } else {
+                throw new InvalidColumnExpressionException('Only string and array are allowed for date column type.');
             }
         });
     }

--- a/packages/Webkul/DataGrid/src/ColumnTypes/Datetime.php
+++ b/packages/Webkul/DataGrid/src/ColumnTypes/Datetime.php
@@ -6,6 +6,7 @@ use Webkul\DataGrid\Column;
 use Webkul\DataGrid\Enums\DateRangeOptionEnum;
 use Webkul\DataGrid\Enums\FilterTypeEnum;
 use Webkul\DataGrid\Exceptions\InvalidColumnException;
+use Webkul\DataGrid\Exceptions\InvalidColumnExpressionException;
 
 class Datetime extends Column
 {
@@ -48,10 +49,12 @@ class Datetime extends Column
                 $requestedDates = ! $rangeOption
                     ? [[$requestedDates, $requestedDates]]
                     : [[$rangeOption['from'], $rangeOption['to']]];
-            }
-
-            foreach ($requestedDates as $value) {
-                $scopeQueryBuilder->whereBetween($this->columnName, [$value[0] ?? '', $value[1] ?? '']);
+            } elseif (is_array($requestedDates)) {
+                foreach ($requestedDates as $value) {
+                    $scopeQueryBuilder->whereBetween($this->columnName, [$value[0] ?? '', $value[1] ?? '']);
+                }
+            } else {
+                throw new InvalidColumnExpressionException('Only string and array are allowed for datetime column type.');
             }
         });
     }

--- a/packages/Webkul/DataGrid/src/ColumnTypes/Decimal.php
+++ b/packages/Webkul/DataGrid/src/ColumnTypes/Decimal.php
@@ -19,9 +19,9 @@ class Decimal extends Column
                 foreach ($requestedValues as $value) {
                     $this->applyDecimalFilter($scopeQueryBuilder, $value);
                 }
+            } else {
+                throw new InvalidColumnExpressionException('Only string and array are allowed for decimal column type.');
             }
-
-            throw new InvalidColumnExpressionException('Only string and array are allowed for decimal column type.');
         });
     }
 

--- a/packages/Webkul/DataGrid/src/ColumnTypes/Decimal.php
+++ b/packages/Webkul/DataGrid/src/ColumnTypes/Decimal.php
@@ -3,6 +3,7 @@
 namespace Webkul\DataGrid\ColumnTypes;
 
 use Webkul\DataGrid\Column;
+use Webkul\DataGrid\Exceptions\InvalidColumnExpressionException;
 
 class Decimal extends Column
 {
@@ -13,14 +14,36 @@ class Decimal extends Column
     {
         return $queryBuilder->where(function ($scopeQueryBuilder) use ($requestedValues) {
             if (is_string($requestedValues)) {
-                $scopeQueryBuilder->orWhere($this->columnName, $requestedValues);
-
-                return;
+                $this->applyDecimalFilter($scopeQueryBuilder, $requestedValues);
+            } elseif (is_array($requestedValues)) {
+                foreach ($requestedValues as $value) {
+                    $this->applyDecimalFilter($scopeQueryBuilder, $value);
+                }
             }
 
-            foreach ($requestedValues as $value) {
-                $scopeQueryBuilder->orWhere($this->columnName, $value);
-            }
+            throw new InvalidColumnExpressionException('Only string and array are allowed for decimal column type.');
         });
+    }
+
+    /**
+     * Apply decimal filter.
+     */
+    private function applyDecimalFilter($queryBuilder, $value)
+    {
+        if (preg_match('/^([<>]=?|=)\s*(-?[\d.]+)$/', $value, $matches)) {
+            $operator = $matches[1];
+
+            $decimalValue = (float) $matches[2];
+
+            $queryBuilder->orWhere($this->columnName, $operator, $decimalValue);
+        } elseif (preg_match('/^(-?[\d.]+)\s*-\s*(-?[\d.]+)$/', $value, $matches)) {
+            $min = (float) $matches[1];
+
+            $max = (float) $matches[2];
+
+            $queryBuilder->orWhereBetween($this->columnName, [$min, $max]);
+        } else {
+            $queryBuilder->orWhere($this->columnName, '=', (float) $value);
+        }
     }
 }

--- a/packages/Webkul/DataGrid/src/ColumnTypes/Integer.php
+++ b/packages/Webkul/DataGrid/src/ColumnTypes/Integer.php
@@ -19,9 +19,9 @@ class Integer extends Column
                 foreach ($requestedValues as $value) {
                     $this->applyIntegerFilter($scopeQueryBuilder, $value);
                 }
+            } else {
+                throw new InvalidColumnExpressionException('Only string and array are allowed for integer column type.');
             }
-
-            throw new InvalidColumnExpressionException('Only string and array are allowed for integer column type.');
         });
     }
 

--- a/packages/Webkul/DataGrid/src/ColumnTypes/Integer.php
+++ b/packages/Webkul/DataGrid/src/ColumnTypes/Integer.php
@@ -3,6 +3,7 @@
 namespace Webkul\DataGrid\ColumnTypes;
 
 use Webkul\DataGrid\Column;
+use Webkul\DataGrid\Exceptions\InvalidColumnExpressionException;
 
 class Integer extends Column
 {
@@ -13,14 +14,36 @@ class Integer extends Column
     {
         return $queryBuilder->where(function ($scopeQueryBuilder) use ($requestedValues) {
             if (is_string($requestedValues)) {
-                $scopeQueryBuilder->orWhere($this->columnName, $requestedValues);
-
-                return;
+                $this->applyIntegerFilter($scopeQueryBuilder, $requestedValues);
+            } elseif (is_array($requestedValues)) {
+                foreach ($requestedValues as $value) {
+                    $this->applyIntegerFilter($scopeQueryBuilder, $value);
+                }
             }
 
-            foreach ($requestedValues as $value) {
-                $scopeQueryBuilder->orWhere($this->columnName, $value);
-            }
+            throw new InvalidColumnExpressionException('Only string and array are allowed for integer column type.');
         });
+    }
+
+    /**
+     * Apply integer filter.
+     */
+    private function applyIntegerFilter($queryBuilder, $value)
+    {
+        if (preg_match('/^([<>]=?|=)\s*(-?\d+)$/', $value, $matches)) {
+            $operator = $matches[1];
+
+            $intValue = (int) $matches[2];
+
+            $queryBuilder->orWhere($this->columnName, $operator, $intValue);
+        } elseif (preg_match('/^(-?\d+)\s*-\s*(-?\d+)$/', $value, $matches)) {
+            $min = (int) $matches[1];
+
+            $max = (int) $matches[2];
+
+            $queryBuilder->orWhereBetween($this->columnName, [$min, $max]);
+        } else {
+            $queryBuilder->orWhere($this->columnName, '=', (int) $value);
+        }
     }
 }

--- a/packages/Webkul/DataGrid/src/ColumnTypes/Text.php
+++ b/packages/Webkul/DataGrid/src/ColumnTypes/Text.php
@@ -4,6 +4,7 @@ namespace Webkul\DataGrid\ColumnTypes;
 
 use Webkul\DataGrid\Column;
 use Webkul\DataGrid\Enums\FilterTypeEnum;
+use Webkul\DataGrid\Exceptions\InvalidColumnExpressionException;
 
 class Text extends Column
 {
@@ -16,12 +17,12 @@ class Text extends Column
             return $queryBuilder->where(function ($scopeQueryBuilder) use ($requestedValues) {
                 if (is_string($requestedValues)) {
                     $scopeQueryBuilder->orWhere($this->columnName, $requestedValues);
-
-                    return;
-                }
-
-                foreach ($requestedValues as $value) {
-                    $scopeQueryBuilder->orWhere($this->columnName, $value);
+                } elseif (is_array($requestedValues)) {
+                    foreach ($requestedValues as $value) {
+                        $scopeQueryBuilder->orWhere($this->columnName, $value);
+                    }
+                } else {
+                    throw new InvalidColumnExpressionException('Only string and array are allowed for text column type.');
                 }
             });
         }
@@ -29,12 +30,12 @@ class Text extends Column
         return $queryBuilder->where(function ($scopeQueryBuilder) use ($requestedValues) {
             if (is_string($requestedValues)) {
                 $scopeQueryBuilder->orWhere($this->columnName, 'LIKE', '%'.$requestedValues.'%');
-
-                return;
-            }
-
-            foreach ($requestedValues as $value) {
-                $scopeQueryBuilder->orWhere($this->columnName, 'LIKE', '%'.$value.'%');
+            } elseif (is_array($requestedValues)) {
+                foreach ($requestedValues as $value) {
+                    $scopeQueryBuilder->orWhere($this->columnName, 'LIKE', '%'.$value.'%');
+                }
+            } else {
+                throw new InvalidColumnExpressionException('Only string and array are allowed for text column type.');
             }
         });
     }

--- a/packages/Webkul/DataGrid/src/Enums/ColumnTypeEnum.php
+++ b/packages/Webkul/DataGrid/src/Enums/ColumnTypeEnum.php
@@ -24,9 +24,9 @@ enum ColumnTypeEnum: string
     case INTEGER = 'integer';
 
     /**
-     * Float.
+     * Decimal.
      */
-    case FLOAT = 'float';
+    case DECIMAL = 'decimal';
 
     /**
      * Boolean.
@@ -56,7 +56,7 @@ enum ColumnTypeEnum: string
         return match ($type) {
             self::STRING->value    => Text::class,
             self::INTEGER->value   => Integer::class,
-            self::FLOAT->value     => Decimal::class,
+            self::DECIMAL->value   => Decimal::class,
             self::BOOLEAN->value   => Boolean::class,
             self::DATE->value      => Date::class,
             self::DATETIME->value  => Datetime::class,

--- a/packages/Webkul/DataGrid/src/Exceptions/InvalidColumnExpressionException.php
+++ b/packages/Webkul/DataGrid/src/Exceptions/InvalidColumnExpressionException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Webkul\DataGrid\Exceptions;
+
+use Exception;
+
+class InvalidColumnExpressionException extends Exception {}


### PR DESCRIPTION
# DataGrid Filtering: Decimal and Integer Columns

This guide explains how to use the enhanced filtering capabilities for Decimal and Integer column types in your data grid.

## Overview

The Decimal and Integer column types support various filtering operations, including:
- Exact match
- Greater than / Less than
- Greater than or equal to / Less than or equal to
- Range queries

## Supported Input Formats

### Decimal Columns

- Exact match: `"10.5"`
- Greater than: `">10.5"`
- Less than: `"<20.75"`
- Greater than or equal to: `">=15.0"`
- Less than or equal to: `"<=25.5"`
- Range: `"10.5-20.75"`

### Integer Columns

- Exact match: `"10"`
- Greater than: `">10"`
- Less than: `"<20"`
- Greater than or equal to: `">=15"`
- Less than or equal to: `"<=25"`
- Range: `"10-20"`
