### PR TITLE
$columns variable passed down to findByField()

### DIFF
--- a/packages/Webkul/Core/src/Eloquent/Repository.php
+++ b/packages/Webkul/Core/src/Eloquent/Repository.php
@@ -78,7 +78,7 @@ abstract class Repository extends BaseRepository implements CacheableInterface
      */
     public function findOneByField($field, $value = null, $columns = ['*'])
     {
-        $model = $this->findByField($field, $value, $columns = ['*']);
+        $model = $this->findByField($field, $value, $columns);
 
         return $model->first();
     }


### PR DESCRIPTION
## Issue Reference
#10027 

## Description
Parameter usage fixed

## How To Test This?

Use any findOneByField() method on any repository and provide $columns param.

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [ ] Target Branch: master 
