### PR TITLE
adding return to recursive call

### DIFF
--- a/packages/Webkul/Sales/src/Repositories/OrderRepository.php
+++ b/packages/Webkul/Sales/src/Repositories/OrderRepository.php
@@ -87,7 +87,7 @@ class OrderRepository extends Repository
             );
 
             /* recalling */
-            $this->createOrderIfNotThenRetry($data);
+            return $this->createOrderIfNotThenRetry($data);
         } finally {
             /* commit in each case */
             DB::commit();


### PR DESCRIPTION
## Description
This issue happens when Bagisto is retrying to create orders. The rolled-back order is still being returned **after** the latest created order because lacking of a return for `createOrderIfNotThenRetry` recalling. Instead, the application should return the latest created order and exist the recursive call.

## How To Reproduce Issue
Issue can be reproduced by making a fail order creation query, then on the retry, make it success. 

## How To Test This?
We can test this by placing an order as usual.

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [ ] Target Branch: master 
