### PR TITLE
attributes in category page and in search now are ordered

### DIFF
--- a/packages/Webkul/Attribute/src/Models/Attribute.php
+++ b/packages/Webkul/Attribute/src/Models/Attribute.php
@@ -61,7 +61,7 @@ class Attribute extends TranslatableModel implements AttributeContract
      */
     public function options(): HasMany
     {
-        return $this->hasMany(AttributeOptionProxy::modelClass());
+        return $this->hasMany(AttributeOptionProxy::modelClass())->orderBy('sort_order', 'asc');
     }
 
     /**


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->

## Description
<!--- Please describe your changes in detail. -->
When I created a few attributes and added their options with the correct sort order it doesn't get sorted correctly in the search page. Turns out it just needed to be sorted.
I kindly ask you to merge this because it is quite important, especially when we have filters that has to be sorted for example the age groups of clothing products.

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [ ] Target Branch: master 

## Pint
<!---  Please make sure all the pint tests are passed. -->

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->
