### PR TITLE
Update Tax.php

### DIFF
--- a/packages/Webkul/Tax/src/Tax.php
+++ b/packages/Webkul/Tax/src/Tax.php
@@ -151,7 +151,7 @@ class Tax
         // dump($address);
         foreach ($taxRates as $rate) {
             if (
-                ! in_array($rate->state, ['*', ''])
+                ! in_array(trim($rate->state), ['*', ''])
                 && $rate->state != $address->state
             ) {
                 continue;

--- a/packages/Webkul/Tax/src/Tax.php
+++ b/packages/Webkul/Tax/src/Tax.php
@@ -151,7 +151,7 @@ class Tax
         // dump($address);
         foreach ($taxRates as $rate) {
             if (
-                $address->state != '*'
+                ! in_array($rate->state, ['*', ''])
                 && $rate->state != $address->state
             ) {
                 continue;


### PR DESCRIPTION
Correction of the Tax Claculation during the checkout process

## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->

## Description
During the checkout process, if the tax is configured, when you press the "Proceed" button (1) then the tax amount (2) is reset.
![image](https://github.com/user-attachments/assets/3cc94134-4381-4d5c-8584-e6d27bdeed85)


## How To Test This?
To test this, a tax category and a tax rate must be first configured.
The taxes "Configure" tab must then be configured as following:
![image](https://github.com/user-attachments/assets/32faed60-1b48-488d-9cdc-350be29a5c2c)
