### PR TITLE
Improve the module development

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -122,6 +122,13 @@
             ]
         }
     },
+    "repositories": [{
+        "type": "path",
+        "url": "packages/*/*",
+        "options": {
+            "symlink": true
+        }
+    }],
     "config": {
         "optimize-autoloader": true,
         "preferred-install": "dist",


### PR DESCRIPTION
The installation of a module doesn't need anymore to update manually the root config/app.php file.

## Description
Imagine we want to create a module Vendor/Package. We then had to add the file PackageServiceProvider in the config/app.php.
Now, we don't have do do it anymore.

## How To Test This?

- Create a package with the command: php artisan package:make VendorName/PackageName for example. Then you will get in your packages folder:
![image](https://github.com/user-attachments/assets/a630d361-1390-436c-87d5-6ae95a1ce8ff)
- Now, create a composer.json file in your package (packages/VendorName/PackageName/composer.json) as following:
![image](https://github.com/user-attachments/assets/61add83c-1ea6-40e5-bb1f-2bae8cf2a668)
You can then install the package with the command: composer require vendorname/packagename
Or uninstall it with the command: composer remove vendorname/packagename
