### PR TITLE
[Bug] Locales intalled but not activated can be accessible in the front

### DIFF
--- a/packages/Webkul/Shop/src/Http/Middleware/Locale.php
+++ b/packages/Webkul/Shop/src/Http/Middleware/Locale.php
@@ -22,20 +22,19 @@ class Locale
      */
     public function handle($request, Closure $next)
     {
-        if ($localeCode = core()->getRequestedLocaleCode('locale', false)) {
-            if ($this->localeRepository->findOneByField('code', $localeCode)) {
-                app()->setLocale($localeCode);
+        $locales = core()->getCurrentChannel()->locales->pluck('code')->toArray();
+        $localeCode = core()->getRequestedLocaleCode('locale', false);
 
-                session()->put('locale', $localeCode);
-            }
-        } else {
-            if ($localeCode = session()->get('locale')) {
-                app()->setLocale($localeCode);
-            } else {
-                app()->setLocale(core()->getDefaultLocaleCodeFromDefaultChannel());
-            }
+        if (! $localeCode || ! in_array($localeCode, $locales)) {
+            $localeCode = session()->get('locale');
         }
 
+        if (! $localeCode || ! in_array($localeCode, $locales)) {
+            $localeCode = core()->getCurrentChannel()->default_locale->code;
+        }
+
+        app()->setLocale($localeCode);
+        session()->put('locale', $localeCode);
         unset($request['locale']);
 
         return $next($request);


### PR DESCRIPTION
## Description
When a locale is installed but not activated on a channel (as Polish for example), the locale is even accessible in the frontend with the url: url/?locale=pl where url have to be replaced by your current url

## How To Test This?

- To test this, you have to edit the channel you want to test (Settings > Channels and then edit it). You must have at least 2 locales installed (on the picture we have installed five)
- Deactivate one locale as on the picture below (here we have deactivated Polish => pl)

![image](https://github.com/user-attachments/assets/638181c0-5833-40f9-a241-27cac62ed239)

- Once this is done, go on your frontend and add /?locale=pl at the end of the url as below
![image](https://github.com/user-attachments/assets/4cfe44bc-2921-4c6b-a54b-8d9d0c10bd90)

The locale has to remain unchanged instead of being in polish
