### PR TITLE
[Bug] Currencies intalled but not activated can be accessible in the …

### DIFF
--- a/packages/Webkul/Shop/src/Http/Middleware/Currency.php
+++ b/packages/Webkul/Shop/src/Http/Middleware/Currency.php
@@ -22,20 +22,19 @@ class Currency
      */
     public function handle($request, Closure $next)
     {
-        if ($currencyCode = request()->get('currency')) {
-            if ($this->currencyRepository->findOneByField('code', $currencyCode)) {
-                core()->setCurrentCurrency($currencyCode);
+        $currencies = core()->getCurrentChannel()->currencies->pluck('code')->toArray();
+        $currencyCode = core()->getRequestedLocaleCode('currency', false);
 
-                session()->put('currency', $currencyCode);
-            }
-        } else {
-            if ($currencyCode = session()->get('currency')) {
-                core()->setCurrentCurrency($currencyCode);
-            } else {
-                core()->setCurrentCurrency(core()->getChannelBaseCurrencyCode());
-            }
+        if (! $currencyCode || ! in_array($currencyCode, $currencies)) {
+            $currencyCode = session()->get('currency');
         }
 
+        if (! $currencyCode || ! in_array($currencyCode, $currencies)) {
+            $currencyCode = core()->getCurrentChannel()->default_currency->code;
+        }
+
+        core()->setCurrentCurrency($currencyCode);
+        session()->put('currency', $currencyCode);
         unset($request['currency']);
 
         return $next($request);

--- a/packages/Webkul/Shop/src/Http/Middleware/Currency.php
+++ b/packages/Webkul/Shop/src/Http/Middleware/Currency.php
@@ -30,7 +30,7 @@ class Currency
         }
 
         if (! $currencyCode || ! in_array($currencyCode, $currencies)) {
-            $currencyCode = core()->getCurrentChannel()->default_currency->code;
+            $currencyCode = core()->getCurrentChannel()->base_currency->code;
         }
 
         core()->setCurrentCurrency($currencyCode);


### PR DESCRIPTION
## Description
When a currency (or more) is installed but not activated on a channel (as PLN for example), the currency is even accessible in the frontend with the url: url/?currency=PLN where url have to be replaced by your current url

## How To Test This?

- To test this, you have to edit the channel you want to test (Settings > Channels and then edit it). You must have at least 2 currencies installed (on the picture we have 3 installed)

- Deactivate one currency as on the picture below (here we have deactivated Polish Zloty => PLN)
![image](https://github.com/user-attachments/assets/59a14c51-fbfe-4009-af9a-c7a58710708f)

- Once this is done, go on your frontend and add /?currency=PLN at the end of the url as below
![image](https://github.com/user-attachments/assets/b357b7e7-6e4a-4c3a-bda6-9fc00ec622ee)

The currency of the website has to remain unchanged