### PR TITLE
Use of APP_ADMIN_URL env variable in installer for admin URL

### DIFF
--- a/packages/Webkul/Installer/src/Console/Commands/Installer.php
+++ b/packages/Webkul/Installer/src/Console/Commands/Installer.php
@@ -424,7 +424,7 @@ class Installer extends Command
             $this->info('-----------------------------');
             $this->info('Congratulations!');
             $this->info('The installation has been finished and you can now use Bagisto.');
-            $this->info('Go to '.env('APP_URL').'/admin'.' and authenticate with:');
+            $this->info('Go to '.env('APP_URL').'/'.env('APP_ADMIN_URL', 'admin').' and authenticate with:');
             $this->info('Email: '.$adminEmail);
             $this->info('Password: '.$adminPassword);
             $this->info('Cheers!');


### PR DESCRIPTION
## Description
In the installer file (packages\Webkul\Installer\src\Console\Commands\Installer.php), a static **/admin** url path is implemented despite the availability of environment variable APP_ADMIN_URL, which is not being used to show the admin url after installation.

## How To Test This?
![image](https://github.com/user-attachments/assets/4b5df32b-335a-402c-b32b-255f90f4c653)


## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [ ] Target Branch: master 