### PR TITLE
Use of APP_ADMIN_URL env variable in installer for admin URL

### DIFF
--- a/packages/Webkul/Installer/src/Console/Commands/Installer.php
+++ b/packages/Webkul/Installer/src/Console/Commands/Installer.php
@@ -423,7 +423,7 @@ class Installer extends Command
             $this->info('-----------------------------');
             $this->info('Congratulations!');
             $this->info('The installation has been finished and you can now use Bagisto.');
-            $this->info('Go to '.env('APP_URL').'/admin'.' and authenticate with:');
+            $this->info('Go to ' . env('APP_URL') . '/' . env('APP_ADMIN_URL', 'admin') . ' and authenticate with:');
             $this->info('Email: '.$adminEmail);
             $this->info('Password: '.$adminPassword);
             $this->info('Cheers!');


### PR DESCRIPTION
## PR Reference
[https://github.com/bagisto/bagisto/pull/10148](url)

## Description
In the installer file (packages\Webkul\Installer\src\Console\Commands\Installer.php), a static /admin url path is implemented despite the availability of environment variable APP_ADMIN_URL, which is not being used to show the admin url after installation.

## How To Test This?
![image](https://github.com/user-attachments/assets/32d0e98b-a5fa-4049-aff4-0dd054369ee2)

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [ ] Target Branch: 2.2 
