### PR TITLE
Fix pricing on Cart mobile view.

### DIFF
--- a/packages/Webkul/Shop/src/Resources/views/checkout/cart/index.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/checkout/cart/index.blade.php
@@ -269,7 +269,23 @@
 
                                             <div class="md:hidden">
                                                 <p class="text-lg font-semibold max-md:text-sm">
-                                                    @{{ item.formatted_total }}
+                                                    <template v-if="displayTax.prices == 'including_tax'">
+                                                            @{{ item.formatted_total_incl_tax }}
+                                                    </template>
+
+                                                    <template v-else-if="displayTax.prices == 'both'">
+
+                                                        @{{ item.formatted_total_incl_tax }}
+                                                        <span class="text-xs font-normal">
+                                                            @lang('shopTheme::app.checkout.cart.index.excl-tax')
+                                                            <span class="font-medium">@{{ item.formatted_total }}</span>
+                                                        </span>
+
+                                                    </template>
+
+                                                    <template v-else>
+                                                            @{{ item.formatted_total }}
+                                                    </template>
                                                 </p>
                                                 
                                                 <span


### PR DESCRIPTION
## Description
In desktop and tablet view, the prices are shown as selected in the admin, but in the mobile, the prices were just shown without taxes. In this PR I fix that problem.

## How To Test This?
Check in mobile that the prices don't react to the admin, display, with / without /both taxes. It only shows one version.
In tablet / desktop, this problem does not exist.

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [ ] Target Branch: master 
- [ ] Also on 2.2

