### PR TITLE
Fixed Category Datagrid 

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Catalog/CategoryDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Catalog/CategoryDataGrid.php
@@ -30,7 +30,10 @@ class CategoryDataGrid extends DataGrid
                 'category_translations.locale',
             )
             ->addSelect(DB::raw('COUNT(DISTINCT '.DB::getTablePrefix().'product_categories.product_id) as count'))
-            ->leftJoin('category_translations', 'categories.id', '=', 'category_translations.category_id')
+            ->leftJoin('category_translations', function ($join) {
+                $join->on('categories.id', '=', 'category_translations.category_id')
+                    ->where('category_translations.locale', '=', app()->getLocale());
+            })
             ->leftJoin('product_categories', 'categories.id', '=', 'product_categories.category_id')
             ->groupBy('categories.id');
 


### PR DESCRIPTION
## Issue Reference
Fixed Category Datagrid 

## Description
When we add a category in multiple locales data doesn't show locale-wise in the data grid 

## How To Test This?
Go to the category section in the admin
Add a category in multiple locales
Check the data grid

