### PR TITLE
feat: laravel sail support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,116 @@
+services:
+    laravel.test:
+        build:
+            context: ./vendor/laravel/sail/runtimes/8.3
+            dockerfile: Dockerfile
+            args:
+                WWWGROUP: '${WWWGROUP}'
+        image: sail-8.3/app
+        extra_hosts:
+            - 'host.docker.internal:host-gateway'
+        ports:
+            - '${APP_PORT:-80}:80'
+            - '${VITE_PORT:-5173}:${VITE_PORT:-5173}'
+        environment:
+            WWWUSER: '${WWWUSER}'
+            LARAVEL_SAIL: 1
+            XDEBUG_MODE: '${SAIL_XDEBUG_MODE:-off}'
+            XDEBUG_CONFIG: '${SAIL_XDEBUG_CONFIG:-client_host=host.docker.internal}'
+            IGNITION_LOCAL_SITES_PATH: '${PWD}'
+        volumes:
+            - '.:/var/www/html'
+        networks:
+            - sail
+        depends_on:
+            - mysql
+            - redis
+            - elasticsearch
+            - kibana
+            - mailpit
+    mysql:
+        image: 'mysql/mysql-server:8.0'
+        ports:
+            - '${FORWARD_DB_PORT:-3306}:3306'
+        environment:
+            MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
+            MYSQL_ROOT_HOST: '%'
+            MYSQL_DATABASE: '${DB_DATABASE}'
+            MYSQL_USER: '${DB_USERNAME}'
+            MYSQL_PASSWORD: '${DB_PASSWORD}'
+            MYSQL_ALLOW_EMPTY_PASSWORD: 1
+        volumes:
+            - 'sail-mysql:/var/lib/mysql'
+            - './vendor/laravel/sail/database/mysql/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'
+        networks:
+            - sail
+        healthcheck:
+            test:
+                - CMD
+                - mysqladmin
+                - ping
+                - '-p${DB_PASSWORD}'
+            retries: 3
+            timeout: 5s
+    redis:
+        image: 'redis:alpine'
+        ports:
+            - '${FORWARD_REDIS_PORT:-6379}:6379'
+        volumes:
+            - 'sail-redis:/data'
+        networks:
+            - sail
+        healthcheck:
+            test:
+                - CMD
+                - redis-cli
+                - ping
+            retries: 3
+            timeout: 5s
+    elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.17.0
+        ports:
+            - '9200:9200'
+            - '9300:9300'
+        environment:
+            - xpack.security.enabled=false
+            - discovery.type=single-node
+            - bootstrap.memory_lock=true
+            - "ES_JAVA_OPTS=-Xms256m -Xmx256m"
+        ulimits:
+            memlock:
+                soft: -1
+                hard: -1
+            nofile:
+                soft: 65536
+                hard: 65536
+        volumes:
+            - 'sail-elasticsearch:/var/lib/elasticsearch/data'
+        networks:
+            - sail
+    kibana:
+        image: docker.elastic.co/kibana/kibana:7.17.0
+        ports:
+            - 5601:5601
+        environment:
+            ELASTICSEARCH_HOSTS: 'http://elasticsearch:9200'
+        networks:
+            - sail
+        depends_on:
+            - elasticsearch
+    mailpit:
+        image: 'axllent/mailpit:latest'
+        ports:
+            - '${FORWARD_MAILPIT_PORT:-1025}:1025'
+            - '${FORWARD_MAILPIT_DASHBOARD_PORT:-8025}:8025'
+        networks:
+            - sail
+networks:
+    sail:
+        driver: bridge
+volumes:
+    sail-mysql:
+        driver: local
+    sail-redis:
+        driver: local
+    sail-elasticsearch:
+        driver: local


### PR DESCRIPTION
# Setting Up Bagisto with Laravel Sail
Link: https://github.com/bagisto/bagisto/issues/9962

This guide walks you through the process of setting up Bagisto using Laravel Sail.

## Installing Dependencies

To install Composer dependencies on a fresh clone of your project, the default PHP version is 8.3. However, you may switch to a Bagisto-supported PHP version by using one of the following:

- `laravelsail/php81-composer:latest`
- `laravelsail/php82-composer:latest`
- `laravelsail/php83-composer:latest`

When changing the PHP version, remember to update the Dockerfile context in the `docker-compose` file accordingly. For more details, refer to the [Laravel Sail documentation on PHP versions](https://laravel.com/docs/11.x/sail#sail-php-versions).

```bash
docker run --rm \
    -u "$(id -u):$(id -g)" \
    -v "$(pwd):/var/www/html" \
    -w /var/www/html \
    laravelsail/php83-composer:latest \
    composer require laravel/sail --dev --ignore-platform-reqs
```

If you are working on an existing project with a dependency manager installed, you can easily set up Laravel Sail by running the following command:

```bash
composer require laravel/sail --dev
```

## Available Services

The docker-compose file includes the following services for Bagisto:
- Laravel
- MySQL
- Redis
- Elasticsearch
- Kibana
- MailPit

For detailed information about these services, please refer to the [Laravel Sail Documentation](https://laravel.com/docs/11.x/sail#introduction).

## Environment Configuration

Before starting Bagisto, you'll need to configure the following services in your `.env` file:

### MySQL Configuration
These credentials will be used to create the database when the container starts for the first time:
```env
DB_CONNECTION=mysql
DB_HOST=mysql
DB_PORT=3306
DB_DATABASE=bagisto
DB_USERNAME=sail
DB_PASSWORD=password
DB_PREFIX=
```

### Redis Configuration
```env
REDIS_HOST=redis
REDIS_PASSWORD=null
REDIS_PORT=6379
```

### MailPit Configuration
```env
MAIL_MAILER=smtp
MAIL_HOST=mailpit
MAIL_PORT=1025
MAIL_USERNAME=
MAIL_PASSWORD=
MAIL_ENCRYPTION=tls
```

### Elasticsearch Configuration
```env
ELASTICSEARCH_HOST=http://elasticsearch:9200
```

## Building and Running Containers

1. Build the container (use `--no-cache` for a fresh build):
```bash
vendor/bin/sail build --no-cache
```

2. Start the containers in detached mode:
```bash
vendor/bin/sail up -d
```

## Installing Bagisto

If this is your first time running the container, you'll need to install Bagisto:
```bash
vendor/bin/sail artisan bagisto:install
```

During the installation process, you'll be prompted for various credentials. The system will suggest default values based on your `.env` file configurations. For consistency, it's recommended to use the same credentials you specified in your `.env` file, even though this may seem redundant. Because some environment variables are used to create services (like MySQL), and we are now reconnecting with the following credentials.