### PR TITLE
add permissions array validation rule on store method

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/RoleController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/RoleController.php
@@ -56,6 +56,7 @@ class RoleController extends Controller
             'name'            => 'required',
             'permission_type' => 'required',
             'description'     => 'required',
+            'permissions'     => 'required_unless:permission_type,all',
         ]);
 
         Event::dispatch('user.role.create.before');

--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/RoleController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/RoleController.php
@@ -56,7 +56,7 @@ class RoleController extends Controller
             'name'            => 'required',
             'permission_type' => 'required',
             'description'     => 'required',
-            'permissions'     => 'required_unless:permission_type,all',
+            'permissions'     => 'required',
         ]);
 
         Event::dispatch('user.role.create.before');

--- a/packages/Webkul/Admin/src/Resources/views/settings/roles/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/roles/create.blade.php
@@ -161,7 +161,7 @@
                         </option>
                     </x-admin::form.control-group.control>
 
-                    <x-admin::form.control-group.error control-name="permission_type" />
+                    <x-admin::form.control-group.error control-name="permissions" />
                 </x-admin::form.control-group>
 
                 <div v-if="permission_type == 'custom'">

--- a/packages/Webkul/Admin/src/Resources/views/settings/roles/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/roles/create.blade.php
@@ -161,10 +161,12 @@
                         </option>
                     </x-admin::form.control-group.control>
 
-                    <x-admin::form.control-group.error control-name="permissions" />
+                    <x-admin::form.control-group.error control-name="permission_type" />
                 </x-admin::form.control-group>
 
                 <div v-if="permission_type == 'custom'">
+                    <x-admin::form.control-group.error control-name="permissions" />
+
                     <x-admin::tree.view
                         input-type="checkbox"
                         value-field="key"


### PR DESCRIPTION
## Issue Reference
#10388 

## Description
There is no validation for permissions value on store method. So, I added appropriate rules to validate the field. Also, it would be better to use Form Request validation to customize error message when the permissions are not selected and then submit the form.

https://github.com/user-attachments/assets/b178a7dc-b40b-49c5-8255-2476ddebcdac