### PR TITLE
add proper validation rule

### DIFF
--- a/packages/Webkul/Admin/src/Config/system.php
+++ b/packages/Webkul/Admin/src/Config/system.php
@@ -2014,7 +2014,7 @@ return [
                 'name'          => 'invoice_number_length',
                 'title'         => 'admin::app.configuration.index.sales.invoice-settings.invoice-number.length',
                 'type'          => 'text',
-                'validation'    => 'numeric',
+                'validation'    => 'numeric|min:0|max:10',
                 'channel_based' => true,
                 'locale_based'  => true,
             ], [


### PR DESCRIPTION
## Issue Reference
#10370 

## Description
There is only `numeric` validation rule applied on the invoice number length in configuration file. So, I added general extra rules to prevent user from entering unexpected length. I checked the `generate` method that is used `sprintf` function to specify zero padding with user provided length. The `sprintf` function thrown **ValueError** exception if the length is less than zero or bigger than [PHP_INT_MAX](https://www.php.net/manual/en/reserved.constants.php#constant.php-int-max). https://github.com/bagisto/bagisto/blob/28ed27ed72a629c51027a289ecf58e00a56c4f52/packages/Webkul/Sales/src/Generators/Sequencer.php#L109-L115