### PR TITLE
update validation mapping rule that can handle text and number field

### DIFF
--- a/packages/Webkul/Core/src/SystemConfig/ItemField.php
+++ b/packages/Webkul/Core/src/SystemConfig/ItemField.php
@@ -12,8 +12,14 @@ class ItemField
      * @var array
      */
     protected $veeValidateMappings = [
-        'max' => 'max_value',
-        'min' => 'min_value',
+        'max' => [
+            'text' => 'max',
+            'number' => 'max_value',
+        ],
+        'min' => [
+            'text' => 'min',
+            'number' => 'min_value',
+        ]
     ];
 
     /**
@@ -94,8 +100,12 @@ class ItemField
             return '';
         }
 
-        foreach ($this->veeValidateMappings as $laravelRule => $veeValidateRule) {
-            $this->validation = str_replace($laravelRule, $veeValidateRule, $this->validation);
+        foreach ($this->veeValidateMappings as $laravelRule => $veeValidateRule) {            
+            if (! array_key_exists($this->getType(), $veeValidateRule)) {
+                continue;
+            }
+            
+            $this->validation = str_replace($laravelRule, $veeValidateRule[$this->getType()], $this->validation);
         }
 
         return $this->validation;


### PR DESCRIPTION
## Issue Reference
#10410 

## Description
The current validation mapping rule is not working with `text` input type. `min_value` validation determine the input value must be a numeric value and not be greater than boundary value. As docs saying,

[min](https://vee-validate.logaretm.com/v4/guide/global-validators#min) - The field under validation length should not be less than the specified length.
[min_value](https://vee-validate.logaretm.com/v4/guide/global-validators#min_value) - The field under validation must be a numeric value and must not be less than the specified value.