### PR TITLE
Fixed date filter issues with predefined date ranges

### DIFF
--- a/packages/Webkul/DataGrid/src/ColumnTypes/Date.php
+++ b/packages/Webkul/DataGrid/src/ColumnTypes/Date.php
@@ -52,8 +52,8 @@ class Date extends Column
 
             foreach ($requestedDates as $value) {
                 $scopeQueryBuilder->whereBetween($this->columnName, [
-                    ($value[0] ?? '').' 00:00:01',
-                    ($value[1] ?? '').' 23:59:59',
+                    $value[0] ? (str_contains($value[0], ' ') ? $value[0] : $value[0] . ' 00:00:01') : '',
+                    $value[1] ? (str_contains($value[1], ' ') ? $value[1] : $value[1] . ' 23:59:59') : '',
                 ]);
             }
         });


### PR DESCRIPTION
## Issue Reference
Date range queries of DataGrid are generating not-right date strings for pre-defined date ranges.
![CleanShot 2025-02-22 at 00 14 21@2x](https://github.com/user-attachments/assets/91c7a57b-cc03-4c25-b5c4-c7d8ed4e0b68)

## Description

Predefined ranges are defined in `packages/Webkul/DataGrid/src/Enums/DateRangeOptionEnum.php`. In it's `options()` method, the default date format is 'Y-m-d H:i:s'.  So it's generating a string like '2025-02-01 00:00:00'. 
Then again, in `packages/Webkul/DataGrid/src/ColumnTypes/Date.php`, the `processFilter()` method is adding ' 00:00:01' and ' 23:59:59' for all from-to dates. As a result, it's becoming something like `(`date` between '2025-02-01 00:00:00 00:00:01' and '2025-02-28 23:59:59 23:59:59')`.

## Fix proposed

Checking if the date string has time fragment (by checking space). Adding time fragment only if it's not present. 
Actually, time fragment is not there if custom date range is used.

## Branch Selection
- [ ] Target Branch: 2.2 

