### PR TITLE
Multiple Parent ID support for Category carousel 

### DIFF
--- a/packages/Webkul/Admin/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en/app.php
@@ -3159,6 +3159,7 @@ return [
                 'new'                           => 'New',
                 'no'                            => 'No',
                 'parent-id'                     => 'Parent ID',
+                'parent-id-hint'                => 'You can enter multiple parent IDs as comma-separated values (e.g., 12,15,34)',
                 'category-id'                   => 'Category ID',
                 'preview'                       => 'Preview',
                 'product-carousel'              => 'Product Carousel',

--- a/packages/Webkul/Admin/src/Resources/views/settings/themes/edit/category-carousel.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/themes/edit/category-carousel.blade.php
@@ -246,6 +246,14 @@
                                         :label="trans('admin::app.settings.themes.edit.value-input')"
                                         :placeholder="trans('admin::app.settings.themes.edit.value-input')" 
                                     />
+                                   
+                                    <!-- Hint for parent_id -->
+                                    <p 
+                                        class="mt-1 text-xs text-gray-500" 
+                                        v-if="filters.applied.code === 'parent_id' || filters.applied.code === undefined"
+                                    >
+                                        @lang('admin::app.settings.themes.edit.parent-id-hint')
+                                    </p>
                                 </template>
 
                                 <x-admin::form.control-group.error control-name="value" />

--- a/packages/Webkul/Category/src/Repositories/CategoryRepository.php
+++ b/packages/Webkul/Category/src/Repositories/CategoryRepository.php
@@ -50,7 +50,13 @@ class CategoryRepository extends Repository
 
                     break;
                 case 'parent_id':
-                    $queryBuilder->where('categories.parent_id', $value);
+                    // Check if the value contains commas (multiple parent IDs)
+                    if (strpos($value, ',') !== false) {
+                        $parentIds = array_map('trim', explode(',', $value));
+                        $queryBuilder->whereIn('categories.parent_id', $parentIds);
+                    } else {
+                        $queryBuilder->where('categories.parent_id', $value);
+                    }                    
 
                     break;
                 case 'locale':


### PR DESCRIPTION
## Adding support for multiple parent category


### Description
Currently, when adding a category_carousel theme, we can set only a single parent id as Filter. But if I want to show categories from 2 or multiple parent, it's not supported.

This PR will add option to input multiple comma separated parent ids and will display items from all those parents.  

![CleanShot 2025-03-06 at 02 34 51@2x](https://github.com/user-attachments/assets/aed1d1c7-5bd4-446d-bac1-2c8f02d93281)

### How To Test This?

- Add a Category carousel block from **Settings > Themes > Create Theme** or edit a theme entry of ** image_carousel** type
- Add a filter with a single parent category ID
- Check if it's showing only categories from this parent
- Edit and add one/a few more parent_id with comma.
- Check if it's showing categories from all these parent IDs
