### PR TITLE
Customize Error Page to Replace the Default Index Page

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/errors/401.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/errors/401.blade.php
@@ -1,0 +1,70 @@
+<x-admin::layouts.anonymous>
+    <!-- Page Title -->
+    <x-slot:title>
+        @lang("admin::app.errors.{$errorCode}.title")
+    </x-slot>
+
+    <!-- Error page Information -->
+	<div class="flex h-[100vh] items-center justify-center bg-white dark:bg-gray-900">
+        <div class="flex max-w-[745px] items-center gap-5">
+            <div class="w-full">
+                @php
+                    $logoUrl = core()->getConfigData('general.design.admin_logo.logo_image') 
+                                ? Storage::url(core()->getConfigData('general.design.admin_logo.logo_image')) 
+                                : bagisto_asset('images/logo.svg');
+                @endphp
+
+                <img
+                    class="mb-6 h-10"
+                    src="{{ $logoUrl }}"
+                    id="logo-image"
+                    alt="{{ config('app.name') }}"
+                />
+
+				<div class="text-[38px] font-bold text-gray-800 dark:text-white">
+                    {{ $errorCode }}
+                </div>
+
+                <p class="mb-6 text-sm text-gray-800">
+                    @lang("admin::app.errors.{$errorCode}.description")
+                </p>
+
+                <div class="mb-6">
+                    <div class="flex items-center gap-2.5">
+                        <a
+                            onclick="history.back()"
+                            class="text-sm font-semibold text-blue-600 transition-all hover:underline"
+                        >
+                            @lang('admin::app.errors.go-back')
+                        </a>
+
+                        <span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="6" height="7" viewBox="0 0 6 7" fill="none">
+                                <circle cx="3" cy="3.5" r="3" fill="#9CA3AF"/>
+                            </svg>
+                        </span>
+
+                        <a
+                            href="{{ route('admin.dashboard.index') }}"
+                            class="text-sm font-semibold text-blue-600 transition-all hover:underline"
+                        >
+                            @lang('admin::app.errors.dashboard')
+                        </a>
+                    </div>
+                </div>
+
+                <p class="text-sm text-gray-800">
+                    @lang('admin::app.errors.support', [
+                        'link'  => 'mailto:support@example.com',
+                        'email' => 'support@example.com',
+                        'class' => 'font-semibold text-blue-600 transition-all hover:underline',
+                    ])
+                </p>
+            </div>
+
+            <div class="w-full">
+                <img src="{{ bagisto_asset('images/error.svg') }}" />
+            </div>
+        </div>
+	</div>
+</x-admin::layouts.anonymous>

--- a/packages/Webkul/Admin/src/Resources/views/errors/403.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/errors/403.blade.php
@@ -1,0 +1,70 @@
+<x-admin::layouts.anonymous>
+    <!-- Page Title -->
+    <x-slot:title>
+        @lang("admin::app.errors.{$errorCode}.title")
+    </x-slot>
+
+    <!-- Error page Information -->
+	<div class="flex h-[100vh] items-center justify-center bg-white dark:bg-gray-900">
+        <div class="flex max-w-[745px] items-center gap-5">
+            <div class="w-full">
+                @php
+                    $logoUrl = core()->getConfigData('general.design.admin_logo.logo_image') 
+                                ? Storage::url(core()->getConfigData('general.design.admin_logo.logo_image')) 
+                                : bagisto_asset('images/logo.svg');
+                @endphp
+
+                <img
+                    class="mb-6 h-10"
+                    src="{{ $logoUrl }}"
+                    id="logo-image"
+                    alt="{{ config('app.name') }}"
+                />
+
+				<div class="text-[38px] font-bold text-gray-800 dark:text-white">
+                    {{ $errorCode }}
+                </div>
+
+                <p class="mb-6 text-sm text-gray-800">
+                    @lang("admin::app.errors.{$errorCode}.description")
+                </p>
+
+                <div class="mb-6">
+                    <div class="flex items-center gap-2.5">
+                        <a
+                            onclick="history.back()"
+                            class="text-sm font-semibold text-blue-600 transition-all hover:underline"
+                        >
+                            @lang('admin::app.errors.go-back')
+                        </a>
+
+                        <span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="6" height="7" viewBox="0 0 6 7" fill="none">
+                                <circle cx="3" cy="3.5" r="3" fill="#9CA3AF"/>
+                            </svg>
+                        </span>
+
+                        <a
+                            href="{{ route('admin.dashboard.index') }}"
+                            class="text-sm font-semibold text-blue-600 transition-all hover:underline"
+                        >
+                            @lang('admin::app.errors.dashboard')
+                        </a>
+                    </div>
+                </div>
+
+                <p class="text-sm text-gray-800">
+                    @lang('admin::app.errors.support', [
+                        'link'  => 'mailto:support@example.com',
+                        'email' => 'support@example.com',
+                        'class' => 'font-semibold text-blue-600 transition-all hover:underline',
+                    ])
+                </p>
+            </div>
+
+            <div class="w-full">
+                <img src="{{ bagisto_asset('images/error.svg') }}" />
+            </div>
+        </div>
+	</div>
+</x-admin::layouts.anonymous>

--- a/packages/Webkul/Admin/src/Resources/views/errors/404.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/errors/404.blade.php
@@ -1,0 +1,70 @@
+<x-admin::layouts.anonymous>
+    <!-- Page Title -->
+    <x-slot:title>
+        @lang("admin::app.errors.{$errorCode}.title")
+    </x-slot>
+
+    <!-- Error page Information -->
+	<div class="flex h-[100vh] items-center justify-center bg-white dark:bg-gray-900">
+        <div class="flex max-w-[745px] items-center gap-5">
+            <div class="w-full">
+                @php
+                    $logoUrl = core()->getConfigData('general.design.admin_logo.logo_image') 
+                                ? Storage::url(core()->getConfigData('general.design.admin_logo.logo_image')) 
+                                : bagisto_asset('images/logo.svg');
+                @endphp
+
+                <img
+                    class="mb-6 h-10"
+                    src="{{ $logoUrl }}"
+                    id="logo-image"
+                    alt="{{ config('app.name') }}"
+                />
+
+				<div class="text-[38px] font-bold text-gray-800 dark:text-white">
+                    {{ $errorCode }}
+                </div>
+
+                <p class="mb-6 text-sm text-gray-800">
+                    @lang("admin::app.errors.{$errorCode}.description")
+                </p>
+
+                <div class="mb-6">
+                    <div class="flex items-center gap-2.5">
+                        <a
+                            onclick="history.back()"
+                            class="text-sm font-semibold text-blue-600 transition-all hover:underline"
+                        >
+                            @lang('admin::app.errors.go-back')
+                        </a>
+
+                        <span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="6" height="7" viewBox="0 0 6 7" fill="none">
+                                <circle cx="3" cy="3.5" r="3" fill="#9CA3AF"/>
+                            </svg>
+                        </span>
+
+                        <a
+                            href="{{ route('admin.dashboard.index') }}"
+                            class="text-sm font-semibold text-blue-600 transition-all hover:underline"
+                        >
+                            @lang('admin::app.errors.dashboard')
+                        </a>
+                    </div>
+                </div>
+
+                <p class="text-sm text-gray-800">
+                    @lang('admin::app.errors.support', [
+                        'link'  => 'mailto:support@example.com',
+                        'email' => 'support@example.com',
+                        'class' => 'font-semibold text-blue-600 transition-all hover:underline',
+                    ])
+                </p>
+            </div>
+
+            <div class="w-full">
+                <img src="{{ bagisto_asset('images/error.svg') }}" />
+            </div>
+        </div>
+	</div>
+</x-admin::layouts.anonymous>

--- a/packages/Webkul/Admin/src/Resources/views/errors/503.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/errors/503.blade.php
@@ -1,0 +1,70 @@
+<x-admin::layouts.anonymous>
+    <!-- Page Title -->
+    <x-slot:title>
+        @lang("admin::app.errors.{$errorCode}.title")
+    </x-slot>
+
+    <!-- Error page Information -->
+	<div class="flex h-[100vh] items-center justify-center bg-white dark:bg-gray-900">
+        <div class="flex max-w-[745px] items-center gap-5">
+            <div class="w-full">
+                @php
+                    $logoUrl = core()->getConfigData('general.design.admin_logo.logo_image') 
+                                ? Storage::url(core()->getConfigData('general.design.admin_logo.logo_image')) 
+                                : bagisto_asset('images/logo.svg');
+                @endphp
+
+                <img
+                    class="mb-6 h-10"
+                    src="{{ $logoUrl }}"
+                    id="logo-image"
+                    alt="{{ config('app.name') }}"
+                />
+
+				<div class="text-[38px] font-bold text-gray-800 dark:text-white">
+                    {{ $errorCode }}
+                </div>
+
+                <p class="mb-6 text-sm text-gray-800">
+                    @lang("admin::app.errors.{$errorCode}.description")
+                </p>
+
+                <div class="mb-6">
+                    <div class="flex items-center gap-2.5">
+                        <a
+                            onclick="history.back()"
+                            class="text-sm font-semibold text-blue-600 transition-all hover:underline"
+                        >
+                            @lang('admin::app.errors.go-back')
+                        </a>
+
+                        <span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="6" height="7" viewBox="0 0 6 7" fill="none">
+                                <circle cx="3" cy="3.5" r="3" fill="#9CA3AF"/>
+                            </svg>
+                        </span>
+
+                        <a
+                            href="{{ route('admin.dashboard.index') }}"
+                            class="text-sm font-semibold text-blue-600 transition-all hover:underline"
+                        >
+                            @lang('admin::app.errors.dashboard')
+                        </a>
+                    </div>
+                </div>
+
+                <p class="text-sm text-gray-800">
+                    @lang('admin::app.errors.support', [
+                        'link'  => 'mailto:support@example.com',
+                        'email' => 'support@example.com',
+                        'class' => 'font-semibold text-blue-600 transition-all hover:underline',
+                    ])
+                </p>
+            </div>
+
+            <div class="w-full">
+                <img src="{{ bagisto_asset('images/error.svg') }}" />
+            </div>
+        </div>
+	</div>
+</x-admin::layouts.anonymous>

--- a/packages/Webkul/Core/src/Exceptions/Handler.php
+++ b/packages/Webkul/Core/src/Exceptions/Handler.php
@@ -68,7 +68,12 @@ class Handler extends BaseHandler
                 ], $errorCode);
             }
 
-            return response()->view("{$path}::errors.index", compact('errorCode'));
+            $viewPath = "{$path}::errors.{$errorCode}";
+            if (!view()->exists($viewPath)) {
+                $viewPath = "{$path}::errors.index";
+            }
+
+            return response()->view($viewPath, compact('errorCode'));
         });
     }
 

--- a/packages/Webkul/Shop/src/Resources/views/errors/401.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/errors/401.blade.php
@@ -1,0 +1,42 @@
+<x-shop::layouts
+    :has-header="false"
+    :has-feature="false"
+    :has-footer="false"
+>
+    <!-- Page Title -->
+    <x-slot:title>
+        @lang("admin::app.errors.{$errorCode}.title")
+    </x-slot>
+
+    <!-- Error page Information -->
+	<div class="container absolute left-1/2 top-0 -translate-x-1/2 px-[60px] max-lg:px-8 max-sm:px-4">
+		<div class="grid h-[100vh] w-full">
+			<div class="wrapper-404 max-868:!text-[294px] max-md:!text-[140px]">
+				<div class="glow-404">
+                    {{ $errorCode }}
+                </div>
+
+				<div class="glow-shadow-404">
+                    {{ $errorCode }}
+                </div>
+			</div>
+
+            <div class="absolute left-1/2 top-[74%] mt-10 -translate-x-1/2 -translate-y-1/2 text-center max-868:w-full max-md:top-[60%]">
+                <h1 class="text-3xl font-semibold max-md:text-xl">
+                    @lang("admin::app.errors.{$errorCode}.title")
+                </h1>
+
+                <p class="mt-4 text-lg text-zinc-500 max-md:text-sm">
+                    @lang("admin::app.errors.{$errorCode}.description")
+                </p>
+
+                <a 
+                    href="{{ route('shop.home.index') }}"
+                    class="m-auto mt-8 block w-max cursor-pointer rounded-[45px] bg-navyBlue px-10 py-4 text-center text-base font-medium text-white max-sm:mb-10 max-sm:px-6 max-sm:text-sm"
+                >
+                    @lang('shop::app.errors.go-to-home') 
+                </a>
+            </div>
+		</div>
+	</div>
+</x-shop::layouts>

--- a/packages/Webkul/Shop/src/Resources/views/errors/403.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/errors/403.blade.php
@@ -1,0 +1,42 @@
+<x-shop::layouts
+    :has-header="false"
+    :has-feature="false"
+    :has-footer="false"
+>
+    <!-- Page Title -->
+    <x-slot:title>
+        @lang("admin::app.errors.{$errorCode}.title")
+    </x-slot>
+
+    <!-- Error page Information -->
+	<div class="container absolute left-1/2 top-0 -translate-x-1/2 px-[60px] max-lg:px-8 max-sm:px-4">
+		<div class="grid h-[100vh] w-full">
+			<div class="wrapper-404 max-868:!text-[294px] max-md:!text-[140px]">
+				<div class="glow-404">
+                    {{ $errorCode }}
+                </div>
+
+				<div class="glow-shadow-404">
+                    {{ $errorCode }}
+                </div>
+			</div>
+
+            <div class="absolute left-1/2 top-[74%] mt-10 -translate-x-1/2 -translate-y-1/2 text-center max-868:w-full max-md:top-[60%]">
+                <h1 class="text-3xl font-semibold max-md:text-xl">
+                    @lang("admin::app.errors.{$errorCode}.title")
+                </h1>
+
+                <p class="mt-4 text-lg text-zinc-500 max-md:text-sm">
+                    @lang("admin::app.errors.{$errorCode}.description")
+                </p>
+
+                <a 
+                    href="{{ route('shop.home.index') }}"
+                    class="m-auto mt-8 block w-max cursor-pointer rounded-[45px] bg-navyBlue px-10 py-4 text-center text-base font-medium text-white max-sm:mb-10 max-sm:px-6 max-sm:text-sm"
+                >
+                    @lang('shop::app.errors.go-to-home') 
+                </a>
+            </div>
+		</div>
+	</div>
+</x-shop::layouts>

--- a/packages/Webkul/Shop/src/Resources/views/errors/404.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/errors/404.blade.php
@@ -1,0 +1,42 @@
+<x-shop::layouts
+    :has-header="false"
+    :has-feature="false"
+    :has-footer="false"
+>
+    <!-- Page Title -->
+    <x-slot:title>
+        @lang("admin::app.errors.{$errorCode}.title")
+    </x-slot>
+
+    <!-- Error page Information -->
+	<div class="container absolute left-1/2 top-0 -translate-x-1/2 px-[60px] max-lg:px-8 max-sm:px-4">
+		<div class="grid h-[100vh] w-full">
+			<div class="wrapper-404 max-868:!text-[294px] max-md:!text-[140px]">
+				<div class="glow-404">
+                    {{ $errorCode }}
+                </div>
+
+				<div class="glow-shadow-404">
+                    {{ $errorCode }}
+                </div>
+			</div>
+
+            <div class="absolute left-1/2 top-[74%] mt-10 -translate-x-1/2 -translate-y-1/2 text-center max-868:w-full max-md:top-[60%]">
+                <h1 class="text-3xl font-semibold max-md:text-xl">
+                    @lang("admin::app.errors.{$errorCode}.title")
+                </h1>
+
+                <p class="mt-4 text-lg text-zinc-500 max-md:text-sm">
+                    @lang("admin::app.errors.{$errorCode}.description")
+                </p>
+
+                <a 
+                    href="{{ route('shop.home.index') }}"
+                    class="m-auto mt-8 block w-max cursor-pointer rounded-[45px] bg-navyBlue px-10 py-4 text-center text-base font-medium text-white max-sm:mb-10 max-sm:px-6 max-sm:text-sm"
+                >
+                    @lang('shop::app.errors.go-to-home') 
+                </a>
+            </div>
+		</div>
+	</div>
+</x-shop::layouts>

--- a/packages/Webkul/Shop/src/Resources/views/errors/503.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/errors/503.blade.php
@@ -1,0 +1,45 @@
+<x-shop::layouts
+    :has-header="false"
+    :has-feature="false"
+    :has-footer="false"
+>
+    <!-- Page Title -->
+    <x-slot:title>
+        @lang("admin::app.errors.{$errorCode}.title")
+    </x-slot>
+
+    <!-- Error page Information -->
+	<div class="container absolute left-1/2 top-0 -translate-x-1/2 px-[60px] max-lg:px-8 max-sm:px-4">
+		<div class="grid h-[100vh] w-full">
+			<div class="wrapper-404 max-868:!text-[294px] max-md:!text-[140px]">
+				<div class="glow-404">
+                    {{ $errorCode }}
+                </div>
+
+				<div class="glow-shadow-404">
+                    {{ $errorCode }}
+                </div>
+			</div>
+
+            <div class="absolute left-1/2 top-[74%] mt-10 -translate-x-1/2 -translate-y-1/2 text-center max-868:w-full max-md:top-[60%]">
+                <h1 class="text-3xl font-semibold max-md:text-xl">
+                    @lang("admin::app.errors.{$errorCode}.title")
+                </h1>
+
+                <p class="mt-4 text-lg text-zinc-500 max-md:text-sm">
+                    {{ 
+                        core()->getCurrentChannel()->maintenance_mode_text != ""
+                        ? core()->getCurrentChannel()->maintenance_mode_text : trans("admin::app.errors.{$errorCode}.description")
+                    }}
+                </p>
+
+                <a 
+                    href="{{ route('shop.home.index') }}"
+                    class="m-auto mt-8 block w-max cursor-pointer rounded-[45px] bg-navyBlue px-10 py-4 text-center text-base font-medium text-white max-sm:mb-10 max-sm:px-6 max-sm:text-sm"
+                >
+                    @lang('shop::app.errors.go-to-home') 
+                </a>
+            </div>
+		</div>
+	</div>
+</x-shop::layouts>


### PR DESCRIPTION
## Issue Reference
#10610 

## Description

- Implemented separate Blade files for error pages (401.blade.php, 403.blade.php, 404.blade.php, 503.blade.php), instead of using a single index.blade.php.

- Updated Handler.php to check for individual error views and fallback to index if the specific error page doesn't exist.

- Maintained the existing structure and styling, ensuring that each error page extends the common layout.

## How To Test This?

- Trigger different error pages by navigating to URLs that return 401, 403 or 404 status codes.

- Verify the correct error page loads for each case instead of falling back to index.blade.php.

- Check the design consistency by comparing the new pages with the previous generic error page.

- Ensure maintenance mode shows the custom 503 page by running:


## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [ ] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->
