### PR TITLE
Bug Fix - Grand total and shipping amount for free delivery cart coupon is broken

### DIFF
--- a/packages/Webkul/Checkout/src/Cart.php
+++ b/packages/Webkul/Checkout/src/Cart.php
@@ -824,6 +824,8 @@ class Cart
 
         Event::dispatch('checkout.cart.collect.totals.before', $this->cart);
 
+        $this->refreshCart();
+
         $this->calculateItemsTax();
 
         $this->calculateShippingTax();


### PR DESCRIPTION
## Issue description
Grand total and shipping - wrong values:
1. Add Tax settings
2. Set shipping price to be set with tax
3. Add "free delivery" cart coupon.
4. Test it out. It will zero "incl. tax" shipping amount, but not "excl. tax", because after coupon code is applied the cart is reloaded in the CartRule object, but not in the Checkout\Cart object.

## How To Test This?
After refreshing the cart it works fine.

## Branch Selection
- [x] Target Branch: 2.3

