### PR TITLE
Bug fix of products filtering

### DIFF
--- a/packages/Webkul/Shop/src/Resources/views/categories/toolbar.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/categories/toolbar.blade.php
@@ -184,7 +184,7 @@
                         if (this.filters.applied[key] != this.filters.default[key]) {
                             filters[key] = this.filters.applied[key];
                         } else {
-                            filters= this.filters.default;
+                            filters[key] = this.filters.default[key];
                         }
                     }
 


### PR DESCRIPTION
## Description
Depending on the order in which filters were applied, previously set filters were sometimes reset to their default values.

## How To Test This?

1. Set the default sorting order and display mode (grid/list) in the admin panel.
2. Go to the shop and change either the display mode OR the sort order of the products - test them one at a time. 
3. One of the settings will not work as expected — it will always revert to the default value.
4. If you're unable to reproduce the issue, check the pull request commit for more details — the bug is quite obvious, and reviewing the changes should help you understand how to replicate it.

## Branch Selection
- [x] Target Branch: 2.2

