### PR TITLE
Format dates with translations

### DIFF
--- a/packages/Webkul/Core/src/Core.php
+++ b/packages/Webkul/Core/src/Core.php
@@ -653,7 +653,7 @@ class Core
 
         $date->setTimezone($channel->timezone);
 
-        return $date->format($format);
+        return $date->translatedFormat($format);
     }
 
     /**


### PR DESCRIPTION
## Description
We use "d M Y" date format in multiple places, but the month ("M") was always displayed in English. This PR fixes the issue by using Carbon's translatedFormat method.

## Branch Selection
- [x] Target Branch: 2.2 

