### PR TITLE
bagisto/bagisto#10739 fix booking info display

### DIFF
--- a/packages/Webkul/Product/src/Repositories/ProductRepository.php
+++ b/packages/Webkul/Product/src/Repositories/ProductRepository.php
@@ -69,6 +69,10 @@ class ProductRepository extends Repository
     {
         $product = $this->findOrFail($id);
 
+        if ($data['booking']['booking_type'] == 'one') {
+            $data['booking']['default_slot']['duration'] = null;
+            $data['booking']['default_slot']['break_time'] = null;
+        }
         $product = $product->getTypeInstance()->update($data, $id, $attributes);
 
         $product->refresh();

--- a/packages/Webkul/Shop/src/Resources/views/products/view/types/booking/default.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/products/view/types/booking/default.blade.php
@@ -1,5 +1,5 @@
 <div class="grid grid-cols-1 gap-6">
-    @if ($bookingProduct['default_slot']['duration'])
+    @if ($bookingProduct['default_slot']['duration'] && $bookingProduct['default_slot']['booking_type'] != 'one')
         <div class="flex gap-3">
             <span class="icon-calendar text-2xl"></span>
 


### PR DESCRIPTION
## Issue Reference
#10739 

## Description
**Root cause**: When the admin sets the "Many booking for many days" option to "One booking for one day," the duration and break_time fields don't update.

**Details**:
1. When the admin sets "One booking for many days" option, it stores the `duration` and `break_time` in the `booking_product_default_slots` table as Null.

2. When the admin sets "Many booking for one days" option, it sets 2 columns `duration` and `break_time` as the required fields with the user input values.

3. When the admin sets the "Many booking for many days" option to "One booking for one day," the duration and break_time fields don't update. That is the root cause.

4. In the [default blade template](https://github.com/bagisto/bagisto/blob/2.3/packages/Webkul/Shop/src/Resources/views/products/view/types/booking/default.blade.php#L2), it checks the `duration` field as not null. But the `duration` field is null.

**Possible Solution**:
1. We can update with the expected values [in product repository](https://github.com/bagisto/bagisto/blob/2.3/packages/Webkul/Product/src/Repositories/ProductRepository.php#L72) mentioned in the root cause details 1.
2. We can set an additional filter while rendering the default blade template. e.g `$bookingProduct['default_slot']['booking_type'] != 'one'` mentioned in root cause details 4.


## How To Test This?
It has to be tested manually, similar to the shared video in the issue description.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: 2.3 
