### PR TITLE
Fix datagrid missing query when selecting predefined date range filter

### DIFF
--- a/packages/Webkul/DataGrid/src/ColumnTypes/Date.php
+++ b/packages/Webkul/DataGrid/src/ColumnTypes/Date.php
@@ -47,13 +47,20 @@ class Date extends Column
                 $rangeOption = collect($this->filterableOptions)->firstWhere('name', $requestedDates);
 
                 $requestedDates = ! $rangeOption
-                    ? [[$requestedDates, $requestedDates]]
-                    : [[$rangeOption['from'], $rangeOption['to']]];
+                ? [[$requestedDates, $requestedDates]]
+                : [[$rangeOption['from'], $rangeOption['to']]];
+
+                foreach ($requestedDates as $value) {
+                    $scopeQueryBuilder->whereBetween($this->columnName, [
+                        $value[0],
+                        $value[1],
+                    ]);
+                }
             } elseif (is_array($requestedDates)) {
                 foreach ($requestedDates as $value) {
                     $scopeQueryBuilder->whereBetween($this->columnName, [
-                        $value[0] ? (str_contains($value[0], ' ') ? $value[0] : $value[0].' 00:00:01') : '',
-                        $value[1] ? (str_contains($value[1], ' ') ? $value[1] : $value[1].' 23:59:59') : '',
+                        $value[0] ? (str_contains($value[0], ' ') ? $value[0] : $value[0] . ' 00:00:01') : '',
+                        $value[1] ? (str_contains($value[1], ' ') ? $value[1] : $value[1] . ' 23:59:59') : '',
                     ]);
                 }
             } else {

--- a/packages/Webkul/DataGrid/src/ColumnTypes/Datetime.php
+++ b/packages/Webkul/DataGrid/src/ColumnTypes/Datetime.php
@@ -47,8 +47,15 @@ class Datetime extends Column
                 $rangeOption = collect($this->filterableOptions)->firstWhere('name', $requestedDates);
 
                 $requestedDates = ! $rangeOption
-                    ? [[$requestedDates, $requestedDates]]
-                    : [[$rangeOption['from'], $rangeOption['to']]];
+                ? [[$requestedDates, $requestedDates]]
+                : [[$rangeOption['from'], $rangeOption['to']]];
+
+                foreach ($requestedDates as $value) {
+                    $scopeQueryBuilder->whereBetween($this->columnName, [
+                        $value[0],
+                        $value[1],
+                    ]);
+                }
             } elseif (is_array($requestedDates)) {
                 foreach ($requestedDates as $value) {
                     $scopeQueryBuilder->whereBetween($this->columnName, [$value[0] ?? '', $value[1] ?? '']);


### PR DESCRIPTION
## Description
<!--- Please describe your changes in detail. -->
- Fix datagrid not filtering as expected when user select predefined date range.

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: 2.3 
