### PR TITLE
Bug fix - Admin ProductDataGrid.php

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Catalog/ProductDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Catalog/ProductDataGrid.php
@@ -317,8 +317,12 @@ class ProductDataGrid extends DataGrid
         $ids = collect($results['hits']['hits'])->pluck('_id')->toArray();
 
         $this->queryBuilder
-            ->whereIn('product_flat.product_id', $ids)
-            ->orderBy(DB::raw('FIELD('.DB::getTablePrefix().'product_flat.product_id, '.implode(',', $ids).')'));
+            ->whereIn('product_flat.product_id', $ids);
+
+        if($ids) {
+            $this->queryBuilder
+                ->orderBy(DB::raw('FIELD('.DB::getTablePrefix().'product_flat.product_id, '.implode(',', $ids).')'));
+        }
 
         $total = $results['hits']['total']['value'];
 

--- a/packages/Webkul/Admin/src/DataGrids/Catalog/ProductDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Catalog/ProductDataGrid.php
@@ -319,7 +319,7 @@ class ProductDataGrid extends DataGrid
         $this->queryBuilder
             ->whereIn('product_flat.product_id', $ids);
 
-        if($ids) {
+        if ($ids) {
             $this->queryBuilder
                 ->orderBy(DB::raw('FIELD('.DB::getTablePrefix().'product_flat.product_id, '.implode(',', $ids).')'));
         }


### PR DESCRIPTION
## Description
Empty search results caused SQL error related to sort by an empty array:
```
.... order by FIELD(product_flat.product_id, ) asc)
```

Full error:
```
Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ') asc ' at line 1 (Connection: mysql, SQL: select distinct `product_flat`.`locale`, `product_flat`.`channel`, `product_images`.`path` as `base_image`, `pc`.`category_id`, `ct`.`name` as `category_name`, `product_flat`.`product_id`, `product_flat`.`sku`, `product_flat`.`name`, `product_flat`.`type`, `product_flat`.`status`, `product_flat`.`price`, `product_flat`.`url_key`, `product_flat`.`visible_individually`, `af`.`name` as `attribute_family`, SUM(DISTINCT product_inventories.qty) as quantity, COUNT(DISTINCT product_images.id) as images_count from `product_flat` left join `attribute_families` as `af` on `product_flat`.`attribute_family_id` = `af`.`id` left join `product_inventories` on `product_flat`.`product_id` = `product_inventories`.`product_id` left join `product_images` on `product_flat`.`product_id` = `product_images`.`product_id` left join `product_categories` as `pc` on `product_flat`.`product_id` = `pc`.`product_id` left join `category_translations` as `ct` on `pc`.`category_id` = `ct`.`category_id` and `ct`.`locale` = pl where `product_flat`.`locale` = pl and 0 = 1 group by `product_flat`.`product_id` order by FIELD(product_flat.product_id, ) asc) {"exception":"[obj ect] (Illuminate\\Database\\QueryException(code: 42000): SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax t o use near ') asc' at line 1 (Connection: mysql, SQL: select distinct `product_flat`.`locale`, `product_flat`.`channel`, `product_images`.`path` as `base_image`, `pc`.`category_id`, `ct`.`name` as `category_name`, `product_flat`.`product_ id`, `product_flat`.`sku`, `product_flat`.`name`, `product_flat`.`type`, `product_flat`.`status`, `product_flat`.`price`, `product_flat`.`url_key`, `product_flat`.`visible_individually`, `af`.`name` as `attribute_family`, SUM(DISTINCT pro duct_inventories.qty) as quantity, COUNT(DISTINCT product_images.id) as images_count from `product_flat` left join `attribute_families` as `af` on `product_flat`.`attribute_family_id` = `af`.`id` left join `product_inventories` on `produc t_flat`.`product_id` = `product_inventories`.`product_id` left join `product_images` on `product_flat`.`product_id` = `product_images`.`product_id` left join `product_categories` as `pc` on `product_flat`.`product_id` = `pc`.`product_id` left join `category_translations` as `ct` on `pc`.`category_id` = `ct`.`category_id` and `ct`.`locale` = pl where `product_flat`.`locale` = pl and 0 = 1 group by `product_flat`.`product_id` order by FIELD(product_flat.product_id, ) asc)
```
## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: 2.2
