### PR TITLE
fix: prevent multiple default addresses by moving logic to controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This changelog consists of the bug & security fixes and new features being inclu
 
 * Added missing event dispatches to ensure proper event flow and handling.
 
+* Removed default address handling from the repository and moved it to the controllers to prevent side effects across customer addresses in the admin panel, shop front, and checkout pages.
+
 ## **v2.2.8 (29th of May 2025)** - *Release*
 
 * Resolved the filter issue for date and datetime types in the DataGrid.

--- a/packages/Webkul/Admin/src/Http/Controllers/Customers/AddressController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Customers/AddressController.php
@@ -71,6 +71,12 @@ class AddressController extends Controller
 
         Event::dispatch('customer.addresses.create.before');
 
+        if (! empty($data['default_address'])) {
+            $this->customerAddressRepository->where('customer_id', $data['customer_id'])
+                ->where('default_address', 1)
+                ->update(['default_address' => 0]);
+        }
+
         $address = $this->customerAddressRepository->create(array_merge($data, [
             'customer_id' => $id,
         ]));
@@ -119,6 +125,12 @@ class AddressController extends Controller
         ]);
 
         Event::dispatch('customer.addresses.update.before', $id);
+
+        if (! empty($data['default_address'])) {
+            $this->customerAddressRepository->where('customer_id', $data['customer_id'])
+                ->where('default_address', 1)
+                ->update(['default_address' => 0]);
+        }
 
         $address = $this->customerAddressRepository->update($data, $id);
 

--- a/packages/Webkul/Customer/src/Repositories/CustomerAddressRepository.php
+++ b/packages/Webkul/Customer/src/Repositories/CustomerAddressRepository.php
@@ -8,24 +8,10 @@ use Webkul\Customer\Contracts\CustomerAddress;
 class CustomerAddressRepository extends Repository
 {
     /**
-     * Specify Model class name.
+     * Specify model class name.
      */
     public function model(): string
     {
         return CustomerAddress::class;
-    }
-
-    /**
-     * Create a new customer address.
-     */
-    public function create(array $data)
-    {
-        if (! empty($data['default_address'])) {
-            $this->model->where('customer_id', $data['customer_id'])
-                ->where('default_address', 1)
-                ->update(['default_address' => 0]);
-        }
-
-        return $this->model->create($data);
     }
 }

--- a/packages/Webkul/Shop/src/Http/Controllers/API/AddressController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/API/AddressController.php
@@ -54,6 +54,12 @@ class AddressController extends APIController
             'address'     => implode(PHP_EOL, array_filter($request->input('address'))),
         ]);
 
+        if (! empty($data['default_address'])) {
+            $this->customerAddressRepository->where('customer_id', $data['customer_id'])
+                ->where('default_address', 1)
+                ->update(['default_address' => 0]);
+        }
+
         $customerAddress = $this->customerAddressRepository->create($data);
 
         Event::dispatch('customer.addresses.create.after', $customerAddress);

--- a/packages/Webkul/Shop/src/Http/Controllers/Customer/Account/AddressController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/Customer/Account/AddressController.php
@@ -65,6 +65,12 @@ class AddressController extends Controller
             'address'     => implode(PHP_EOL, array_filter($request->input('address'))),
         ]);
 
+        if (! empty($data['default_address'])) {
+            $this->customerAddressRepository->where('customer_id', $data['customer_id'])
+                ->where('default_address', 1)
+                ->update(['default_address' => 0]);
+        }
+
         $customerAddress = $this->customerAddressRepository->create($data);
 
         Event::dispatch('customer.addresses.create.after', $customerAddress);


### PR DESCRIPTION
## Info
Removed default address handling from the repository and moved it to the controllers to prevent side effects across customer addresses in the admin panel, shop front, and checkout pages.