### PR TITLE
Fixing Blade File Syntax Error

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/settings/data-transfer/imports/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/data-transfer/imports/edit.blade.php
@@ -85,7 +85,8 @@
                                     <div class="grid gap-2.5 max-md:my-0">
                                         @foreach ($supportedFormats as $format)
                                             <a
-                                                :href="'{{ route('admin.settings.data_transfer.imports.download_sample', ['type' => ':type:', 'format' => ':format:']) }}'.replace(':type:', $refs['importType']?.value).replace(':format:', '{{ $format }}')"
+                                                href="'{{ route('admin.settings.data_transfer.imports.download_sample', 
+                                                ['type' => ':type:', 'format' => ':format:']) }}'.replace(':type:', $refs['importType']?.value).replace(':format:', '{{ $format }}')"
                                                 target="_blank"
                                                 id="source-sample-link"
                                                 class="cursor-pointer text-sm text-blue-600 transition-all hover:underline"


### PR DESCRIPTION
**Description**

Resolved a Blade syntax error that was causing rendering issues or preventing proper compilation. This fix ensures the Blade view renders as expected.

**How To Test This?**
Open the affected Blade file in a browser via your Laravel app.

Confirm that the page loads without syntax errors.

Check that all dynamic data is rendering correctly.

Run php artisan view:clear if needed to refresh compiled views.

**Documentation**

My pull request requires an update on the documentation repository.
No documentation changes needed for this syntax fix.

**Branch Selection**
 Target Branch: base2.3
