### PR TITLE
Fix HTTP response status code in exception handler

### DIFF
--- a/packages/Webkul/Core/src/Exceptions/Handler.php
+++ b/packages/Webkul/Core/src/Exceptions/Handler.php
@@ -74,7 +74,7 @@ class Handler extends BaseHandler
                 $viewPath = "{$namespace}::errors.index";
             }
 
-            return response()->view($viewPath, compact('errorCode'));
+            return response()->view($viewPath, compact('errorCode'), $errorCode);
         });
     }
 
@@ -111,7 +111,7 @@ class Handler extends BaseHandler
                 $viewPath = "{$namespace}::errors.index";
             }
 
-            return response()->view($viewPath, compact('errorCode'));
+            return response()->view($viewPath, compact('errorCode'), $errorCode);
         });
     }
 }


### PR DESCRIPTION
Exception handler was returning HTTP 200 status code for all error responses instead of the actual exception status code while app is not debug (production) (404, 500, etc.).

SEO issues (404 pages returned as 200 OK)
Incorrect status codes for API responses
Monitoring tools unable to detect actual error states

Solution: Added proper HTTP status code to both JSON and view responses using the exception's actual status code.
