### PR TITLE
Always use public disk for sitemap url

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Marketing/SearchSEO/SitemapDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Marketing/SearchSEO/SitemapDataGrid.php
@@ -61,7 +61,7 @@ class SitemapDataGrid extends DataGrid
             'label'      => trans('admin::app.marketing.search-seo.sitemaps.index.datagrid.link-for-google'),
             'type'       => 'string',
             'closure'    => function ($row) {
-                return Storage::url(clean_path($row->path.'/'.$row->file_name));
+                return Storage::disk('public')->url(clean_path($row->path.'/'.$row->file_name));
             },
         ]);
     }


### PR DESCRIPTION
Fix sitemap URLs when default storage disk differs from public
