### PR TITLE
Fix sitemap generation for non-public default disk

### DIFF
--- a/packages/Webkul/Sitemap/src/Jobs/ProcessSitemap.php
+++ b/packages/Webkul/Sitemap/src/Jobs/ProcessSitemap.php
@@ -151,7 +151,7 @@ class ProcessSitemap implements ShouldQueue
         $sitemap = SitemapIndex::create();
 
         foreach ($this->generatedSitemaps as $generatedSitemap) {
-            $sitemap->add(Storage::url($generatedSitemap));
+            $sitemap->add(Storage::disk('public')->url($generatedSitemap));
         }
 
         $sitemap->writeToDisk('public', $this->sitemap->index_file_name);


### PR DESCRIPTION
Use Storage::disk('public')->url() to ensure correct URL generation  when default filesystem disk is not 'public'
