### PR TITLE
fix: fixed date validation error #10682

### DIFF
--- a/packages/Webkul/Shop/src/Resources/views/products/view/types/booking/rental.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/products/view/types/booking/rental.blade.php
@@ -211,6 +211,7 @@
                             type="date"
                             name="booking[date_from]"
                             rules="required"
+                            v-model="booking.date_from"
                             :label="trans('shop::app.products.view.type.booking.rental.from')"
                             :placeholder="trans('shop::app.products.view.type.booking.rental.from')"
                             data-min-date="today"
@@ -229,7 +230,8 @@
                         <x-shop::form.control-group.control
                             type="date"
                             name="booking[date_to]"
-                            rules="required"
+                            ::rules="'required|after:' + booking.date_from"
+                            v-model="booking.date_to"
                             :label="trans('shop::app.products.view.type.booking.rental.to')"
                             :placeholder="trans('shop::app.products.view.type.booking.rental.to')"
                             data-min-date="today"
@@ -244,6 +246,14 @@
     </script>
 
     <script type="module">
+        defineRule('after', (value, [target]) => {
+            if (! value || ! target) {
+                return false;
+            }
+
+            return new Date(value) > new Date(target);
+        });
+
         app.component('v-rental-slots', {
             template: '#v-rental-slots-template',
 
@@ -258,6 +268,12 @@
                     slots: [],
 
                     selected_slot: '',
+
+                    booking: {
+                        date_from: '',
+                        
+                        date_to: '',
+                    },
                 }
             },
 


### PR DESCRIPTION
## Issue Reference
#10682

## Description
Fixes validation where date_to must be greater than date_from and showing error message.
https://webkul.chatwhizz.com/share/view-recording/68ac3c06b7af9f05d39ae5e9

## How To Test This?
Go to the product detail page.
Select a From Date.
Select a To Date earlier than the From Date.
Validation should now trigger an error message instead of breaking with JS error.
Selecting a valid To Date (greater than From Date) should pass the validation successfully.


