### PR TITLE
fix: fixed inventories group attribute condition error #10701

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/catalog/products/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/products/edit.blade.php
@@ -155,6 +155,10 @@
                     @foreach ($groups as $group)
                         @php $customAttributes = $product->getEditableAttributes($group); @endphp
 
+                        @if ($group->code === 'inventories' && $product->getTypeInstance()->isComposite())
+                            @continue
+                        @endif
+
                         @if ($customAttributes->isNotEmpty())
                             {!! view_render_event("bagisto.admin.catalog.product.edit.form.{$group->code}.before", ['product' => $product]) !!}
 


### PR DESCRIPTION
## Issue Reference
#10701

## Description
This PR fixes the problem where the group attribute condition in configurable products’ inventory rules was not applying to new attributes. The logic has been updated to correctly handle both existing and newly created product attributes when evaluating inventory conditions.

## How To Test This?

Create a new product attribute.
Add it to a configurable product.
Verify that the condition now correctly affects the configurable product’s inventory.