### PR TITLE
fix: skip 404 in CLI so artisan route:list works (#10883)

### DIFF
--- a/packages/Webkul/Admin/src/Resources/lang/ca/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ca/app.php
@@ -1298,7 +1298,7 @@ return [
                         'validations' => [
                             'type-mismatch'      => 'El tipus de reserva no es pot canviar.',
                             'time-validation'    => "L'hora d'inici ha de ser menor que l'hora de finalització.",
-                            'overlap-validation' => "La franja horària se solapa amb una franja existent.",
+                            'overlap-validation' => 'La franja horària se solapa amb una franja existent.',
                         ],
                     ],
 

--- a/packages/Webkul/Admin/src/Resources/lang/fr/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/fr/app.php
@@ -1298,7 +1298,7 @@ return [
                         'validations' => [
                             'type-mismatch'      => 'Le type de réservation ne peut pas être modifié.',
                             'time-validation'    => "L'heure de début doit être inférieure à l'heure de fin.",
-                            'overlap-validation' => "Le créneau horaire chevauche un créneau existant.",
+                            'overlap-validation' => 'Le créneau horaire chevauche un créneau existant.',
                         ],
                     ],
 

--- a/packages/Webkul/BookingProduct/src/Helpers/Booking.php
+++ b/packages/Webkul/BookingProduct/src/Helpers/Booking.php
@@ -341,7 +341,7 @@ class Booking
     public function slotsCalculation(object $bookingProduct, object $requestedDate, object $bookingProductSlot): array
     {
         $slots = [];
-            
+
         if ($bookingProduct->type == 'default') {
             [$availableFrom, $availableTo, $timeDurations] = $this->getDefaultSlotDetails($bookingProduct, $bookingProductSlot, $requestedDate);
 
@@ -349,40 +349,40 @@ class Booking
                 return [];
             }
 
-            if ( 
-                isset($timeDurations[0]['status']) 
+            if (
+                isset($timeDurations[0]['status'])
                 && $timeDurations[0]['status'] == 0
             ) {
                 $start = $requestedDate->copy()->startOfDay();
-                  
+
                 $end = $requestedDate->copy()->endOfDay();
 
-                $currentTime  = clone $start;
+                $currentTime = clone $start;
 
                 while ($currentTime < $end) {
                     $to = (clone $currentTime)->addMinutes($bookingProductSlot->duration);
 
                     $isClosed = false;
-                    
+
                     foreach ($timeDurations as $slot) {
                         if (! ($slot['status'] ?? 1)) {
                             $closedFrom = Carbon::parse($requestedDate->format('Y-m-d').' '.$slot['from']);
-                            
-                            $closedTo   = Carbon::parse($requestedDate->format('Y-m-d').' '.$slot['to']);
-                            
+
+                            $closedTo = Carbon::parse($requestedDate->format('Y-m-d').' '.$slot['to']);
+
                             if (
-                                $currentTime < $closedTo 
+                                $currentTime < $closedTo
                                 && $to > $closedFrom
                             ) {
                                 $isClosed = true;
-                                
+
                                 break;
                             }
                         }
                     }
 
                     if (
-                        ! $isClosed 
+                        ! $isClosed
                         && Carbon::now() <= $currentTime
                     ) {
                         $slots[] = [
@@ -475,7 +475,7 @@ class Booking
                                 'qty'       => $qty,
                             ];
 
-                            usort($slots, fn($first, $second) => strtotime($first['from']) <=> strtotime($second['from']));
+                            usort($slots, fn ($first, $second) => strtotime($first['from']) <=> strtotime($second['from']));
                         }
                     }
                 } else {

--- a/packages/Webkul/Shop/src/Http/Controllers/Customer/GDPRController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/Customer/GDPRController.php
@@ -22,10 +22,11 @@ class GDPRController extends Controller
         protected OrderRepository $orderRepository,
         protected CustomerAddressRepository $customerAddressRepository
     ) {
-        if (
-            ! core()->getConfigData('general.gdpr.settings.enabled')
-            && ! app()->runningInConsole()
-        ) {
+        if (app()->runningInConsole()) {
+            return;
+        }
+
+        if (! core()->getConfigData('general.gdpr.settings.enabled')) {
             abort(404);
         }
 

--- a/packages/Webkul/Shop/src/Http/Controllers/Customer/GDPRController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/Customer/GDPRController.php
@@ -22,9 +22,13 @@ class GDPRController extends Controller
         protected OrderRepository $orderRepository,
         protected CustomerAddressRepository $customerAddressRepository
     ) {
-        if (! core()->getConfigData('general.gdpr.settings.enabled')) {
+        if (
+            ! core()->getConfigData('general.gdpr.settings.enabled')
+            && ! app()->runningInConsole()
+        ) {
             abort(404);
         }
+
     }
 
     /**

--- a/packages/Webkul/Shop/src/Http/Controllers/Customer/RegistrationController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/Customer/RegistrationController.php
@@ -72,8 +72,8 @@ class RegistrationController extends Controller
             $this->subscriptionRepository->update([
                 'customer_id' => $customer->id,
             ], $subscription->id);
-        } 
-        
+        }
+
         if (
             ! empty($data['is_subscribed'])
             && ! $subscription

--- a/packages/Webkul/Shop/src/Http/Controllers/SubscriptionController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/SubscriptionController.php
@@ -28,7 +28,7 @@ class SubscriptionController extends Controller
         $email = request()->input('email');
 
         $subscription = $this->subscriptionRepository->findOneByField('email', $email);
-        
+
         Event::dispatch('customer.subscription.before');
 
         if ($subscription) {


### PR DESCRIPTION
## Issue Reference
Fixes #10883

## Description
`php artisan route:list` was failing because `GDPRController` called `abort(404)` in its constructor when GDPR is disabled. 
Artisan instantiates controllers while resolving routes, so the HTTP abort surfaced in the CLI.

**Change (minimal):**
Skip the abort when running in console:
```php
if (! core()->getConfigData('general.gdpr.settings.enabled') && ! app()->runningInConsole()) {
    abort(404);
}
