### PR TITLE
Fix quantity calculation in ProductDataGrid

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Catalog/ProductDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Catalog/ProductDataGrid.php
@@ -63,7 +63,7 @@ class ProductDataGrid extends DataGrid
                 'product_flat.visible_individually',
                 'af.name as attribute_family',
             )
-            ->addSelect(DB::raw('SUM(DISTINCT '.$tablePrefix.'product_inventories.qty) as quantity'))
+            ->addSelect(DB::raw('SUM('.$tablePrefix.'product_inventories.qty) as quantity'))
             ->addSelect(DB::raw('COUNT(DISTINCT '.$tablePrefix.'product_images.id) as images_count'))
             ->where('product_flat.locale', app()->getLocale())
             ->groupBy('product_flat.product_id');


### PR DESCRIPTION
## Description
If we have multiple inventories with the same quantities for example:
Inventory 1 -> quantity 2
Inventory 2 -> quantity 2

In products index page the available quantity will be 2, which is wrong
the correct number should be 4 (2+2)

no need to use DISTINCT on product quantities