### PR TITLE
Change phone validation rule to 'required|phone'

### DIFF
--- a/packages/Webkul/Shop/src/Resources/views/checkout/onepage/address/form.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/checkout/onepage/address/form.blade.php
@@ -283,7 +283,7 @@
                     type="text"
                     ::name="controlName + '.phone'"
                     ::value="address.phone"
-                    rules="required|numeric"
+                    rules="required|phone"
                     :label="trans('shop::app.checkout.onepage.address.telephone')"
                     :placeholder="trans('shop::app.checkout.onepage.address.telephone')"
                 />


### PR DESCRIPTION
## Description
Phone number validation should allow "+" sign at the beginning. There is already custom "phone" rule - why we don't use it?

## Branch Selection
- [x] Target Branch: 2.3 
