### PR TITLE
Fix/10899 data transfer csv validation

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Sales/OrderDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Sales/OrderDataGrid.php
@@ -143,7 +143,7 @@ class OrderDataGrid extends DataGrid
             'type'       => 'string',
             'closure'    => function ($row) {
                 return collect(explode('|', $row->method))
-                    ->map(fn ($method) => core()->getConfigData('sales.payment_methods.' . $method . '.title'))
+                    ->map(fn ($method) => core()->getConfigData('sales.payment_methods.'.$method.'.title'))
                     ->filter()
                     ->unique()
                     ->join(', ');

--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/ImportController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/ImportController.php
@@ -70,7 +70,7 @@ class ImportController extends Controller
             'validation_strategy' => 'required:in:stop-on-errors,skip-errors',
             'allowed_errors'      => 'required|integer|min:0',
             'field_separator'     => 'required',
-            'file'                => 'required|extensions:'.$supportedFormats.'|mimes:'.$supportedFormats,
+            'file'                => 'required|extensions:'.$supportedFormats.'|mimetypes:text/plain,text/csv,application/csv,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
         ]);
 
         Event::dispatch('data_transfer.imports.create.before');
@@ -148,7 +148,7 @@ class ImportController extends Controller
             'validation_strategy' => 'required:in:stop-on-errors,skip-errors',
             'allowed_errors'      => 'required|integer|min:0',
             'field_separator'     => 'required',
-            'file'                => 'extensions:'.$supportedFormats.'|mimes:'.$supportedFormats,
+            'file'                => 'extensions:'.$supportedFormats.'|mimetypes:text/plain,text/csv,application/csv,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
         ]);
 
         Event::dispatch('data_transfer.imports.update.before');

--- a/packages/Webkul/Admin/src/Resources/lang/ca/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ca/app.php
@@ -1298,7 +1298,7 @@ return [
                         'validations' => [
                             'type-mismatch'      => 'El tipus de reserva no es pot canviar.',
                             'time-validation'    => "L'hora d'inici ha de ser menor que l'hora de finalització.",
-                            'overlap-validation' => "La franja horària se solapa amb una franja existent.",
+                            'overlap-validation' => 'La franja horària se solapa amb una franja existent.',
                         ],
                     ],
 

--- a/packages/Webkul/Admin/src/Resources/lang/fr/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/fr/app.php
@@ -1298,7 +1298,7 @@ return [
                         'validations' => [
                             'type-mismatch'      => 'Le type de réservation ne peut pas être modifié.',
                             'time-validation'    => "L'heure de début doit être inférieure à l'heure de fin.",
-                            'overlap-validation' => "Le créneau horaire chevauche un créneau existant.",
+                            'overlap-validation' => 'Le créneau horaire chevauche un créneau existant.',
                         ],
                     ],
 

--- a/packages/Webkul/BookingProduct/src/Helpers/Booking.php
+++ b/packages/Webkul/BookingProduct/src/Helpers/Booking.php
@@ -341,7 +341,7 @@ class Booking
     public function slotsCalculation(object $bookingProduct, object $requestedDate, object $bookingProductSlot): array
     {
         $slots = [];
-            
+
         if ($bookingProduct->type == 'default') {
             [$availableFrom, $availableTo, $timeDurations] = $this->getDefaultSlotDetails($bookingProduct, $bookingProductSlot, $requestedDate);
 
@@ -349,40 +349,40 @@ class Booking
                 return [];
             }
 
-            if ( 
-                isset($timeDurations[0]['status']) 
+            if (
+                isset($timeDurations[0]['status'])
                 && $timeDurations[0]['status'] == 0
             ) {
                 $start = $requestedDate->copy()->startOfDay();
-                  
+
                 $end = $requestedDate->copy()->endOfDay();
 
-                $currentTime  = clone $start;
+                $currentTime = clone $start;
 
                 while ($currentTime < $end) {
                     $to = (clone $currentTime)->addMinutes($bookingProductSlot->duration);
 
                     $isClosed = false;
-                    
+
                     foreach ($timeDurations as $slot) {
                         if (! ($slot['status'] ?? 1)) {
                             $closedFrom = Carbon::parse($requestedDate->format('Y-m-d').' '.$slot['from']);
-                            
-                            $closedTo   = Carbon::parse($requestedDate->format('Y-m-d').' '.$slot['to']);
-                            
+
+                            $closedTo = Carbon::parse($requestedDate->format('Y-m-d').' '.$slot['to']);
+
                             if (
-                                $currentTime < $closedTo 
+                                $currentTime < $closedTo
                                 && $to > $closedFrom
                             ) {
                                 $isClosed = true;
-                                
+
                                 break;
                             }
                         }
                     }
 
                     if (
-                        ! $isClosed 
+                        ! $isClosed
                         && Carbon::now() <= $currentTime
                     ) {
                         $slots[] = [
@@ -475,7 +475,7 @@ class Booking
                                 'qty'       => $qty,
                             ];
 
-                            usort($slots, fn($first, $second) => strtotime($first['from']) <=> strtotime($second['from']));
+                            usort($slots, fn ($first, $second) => strtotime($first['from']) <=> strtotime($second['from']));
                         }
                     }
                 } else {

--- a/packages/Webkul/Shop/src/Http/Controllers/Customer/GDPRController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/Customer/GDPRController.php
@@ -22,10 +22,11 @@ class GDPRController extends Controller
         protected OrderRepository $orderRepository,
         protected CustomerAddressRepository $customerAddressRepository
     ) {
-        if (
-            ! core()->getConfigData('general.gdpr.settings.enabled')
-            && ! app()->runningInConsole()
-        ) {
+        if (app()->runningInConsole()) {
+            return;
+        }
+
+        if (! core()->getConfigData('general.gdpr.settings.enabled')) {
             abort(404);
         }
 

--- a/packages/Webkul/Shop/src/Http/Controllers/Customer/GDPRController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/Customer/GDPRController.php
@@ -22,9 +22,13 @@ class GDPRController extends Controller
         protected OrderRepository $orderRepository,
         protected CustomerAddressRepository $customerAddressRepository
     ) {
-        if (! core()->getConfigData('general.gdpr.settings.enabled')) {
+        if (
+            ! core()->getConfigData('general.gdpr.settings.enabled')
+            && ! app()->runningInConsole()
+        ) {
             abort(404);
         }
+
     }
 
     /**

--- a/packages/Webkul/Shop/src/Http/Controllers/Customer/RegistrationController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/Customer/RegistrationController.php
@@ -72,8 +72,8 @@ class RegistrationController extends Controller
             $this->subscriptionRepository->update([
                 'customer_id' => $customer->id,
             ], $subscription->id);
-        } 
-        
+        }
+
         if (
             ! empty($data['is_subscribed'])
             && ! $subscription

--- a/packages/Webkul/Shop/src/Http/Controllers/SubscriptionController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/SubscriptionController.php
@@ -28,7 +28,7 @@ class SubscriptionController extends Controller
         $email = request()->input('email');
 
         $subscription = $this->subscriptionRepository->findOneByField('email', $email);
-        
+
         Event::dispatch('customer.subscription.before');
 
         if ($subscription) {


### PR DESCRIPTION
=## Issue Reference
Fixes #10899

## Description
Relax file validation for Data Transfer imports so sample CSV/XLS/XLSX files downloaded from the Admin UI no longer fail validation in v2.3.

**What changed**
- Updated `ImportController` validation to keep `extensions:` check and add a flexible `mimetypes:` list that accepts common CSV/XLS/XLSX MIME types (including `text/plain` which PHP sometimes returns for CSV).
- This preserves security (we still check extensions) while avoiding false rejections caused by inconsistent MIME detection across PHP/platforms.

Files changed:
- `packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/ImportController.php`

## How To Test This?
1. Checkout the branch and ensure the app is running.
2. Login to Admin panel.
3. Go to **Settings → Data Transfer → Import**.
4. Click **Download sample** and save the CSV file.
5. Use the exact downloaded sample CSV file to import (choose the sample file you downloaded).
6. Expected: the file validates successfully and the import proceeds. No "file validation" error should appear.
7. (Optional) Test with `.xls` and `.xlsx` sample files to confirm they also validate.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
  - _No documentation update required_ (this is an internal validation change that does not alter user-facing functionality or settings).

## Branch Selection
- [x] Target Branch: 2.3
  - This is a bugfix for the 2.3 release stream.


