### PR TITLE
Refactor cart address handling in CartController::estimateShippingMet…

### DIFF
--- a/packages/Webkul/Shop/src/Resources/views/checkout/cart/summary/estimate-shipping.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/checkout/cart/summary/estimate-shipping.blade.php
@@ -133,25 +133,13 @@
                             class="relative select-none border-b border-zinc-200 last:border-b-0 max-md:max-w-full max-md:flex-auto"
                             v-for="rate in method.rates"
                         >
-                            <div class="absolute top-5 ltr:left-4 rtl:right-4">
-                                <x-shop::form.control-group.control
-                                    type="radio"
-                                    name="shipping_method"
-                                    ::for="rate.method"
-                                    ::id="rate.method"
-                                    ::value="rate.method"
-                                    ::label="rate.method"
-                                />
-                            </div>
-
-                            <label 
-                                class="block cursor-pointer p-4 pl-12"
-                                :for="rate.method"
+                            <label
+                                class="block p-4"
                             >
                                 <p class="text-2xl font-semibold max-md:text-lg">
                                     @{{ rate.base_formatted_price }}
                                 </p>
-                                
+
                                 <p class="mt-2.5 text-xs font-medium max-md:mt-0">
                                     <span class="font-medium">@{{ rate.method_title }}</span> - @{{ rate.method_description }}
                                 </p>


### PR DESCRIPTION
## Description
The old code was buggy because before calculating shipping rates, it called Cart::collectTotals. This method, in turn, calls refreshCart.
Let’s assume I added an item to the cart and went straight to the cart view. There, I would like to estimate the shipping costs. The old code temporarily set the address (without saving it to the database), calculated taxes, and then reloaded the cart from the database (where shipping_address was null). If a shipping method used code that depended on $cart->shipping_address->country or similar, it failed.

Moreover, the new code now saves the country and state, so you don’t need to fill them in again on the checkout form.

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: 2.3


