### PR TITLE
Handled string exception when bundle product add to cart

### DIFF
--- a/packages/Webkul/Product/src/Type/Bundle.php
+++ b/packages/Webkul/Product/src/Type/Bundle.php
@@ -242,6 +242,10 @@ class Bundle extends AbstractType
 
         $products = parent::prepareForCart($data);
 
+        if (gettype($products) == "string") {
+            return($products);
+        }
+
         foreach ($this->getCartChildProducts($data) as $productId => $data) {
             $product = $this->productRepository->find($productId);
 

--- a/packages/Webkul/Product/src/Type/Bundle.php
+++ b/packages/Webkul/Product/src/Type/Bundle.php
@@ -243,7 +243,7 @@ class Bundle extends AbstractType
         $products = parent::prepareForCart($data);
 
         if (gettype($products) == "string") {
-            return($products);
+            return $products;
         }
 
         foreach ($this->getCartChildProducts($data) as $productId => $data) {


### PR DESCRIPTION
## Issue Reference
An exception occurs when a bundle product is added to the cart and exceeds the second child's inventory.

Create a bundle product with 2 children.
Set default quantities to 20 for both.
Set the first product inventory to 40 from the simple product edit page
Set the second product inventory to 20 from the simple product edit page
Add bundle product to cart.
Again, click the "Add to cart' button


array_merge(): Argument #1 must be of type array, string given
<img width="347" height="97" alt="Screenshot (17)" src="https://github.com/user-attachments/assets/76043d66-a437-4aba-a5f7-f4c5932f71a6" />
