### PR TITLE
Add root category exclusion to sitemap generation

### DIFF
--- a/packages/Webkul/Sitemap/src/Models/Category.php
+++ b/packages/Webkul/Sitemap/src/Models/Category.php
@@ -9,7 +9,6 @@ use Webkul\Category\Models\Category as BaseCategory;
 
 class Category extends BaseCategory implements Sitemapable
 {
-
     /**
      * To get the sitemap tag for the category.
      */
@@ -27,7 +26,10 @@ class Category extends BaseCategory implements Sitemapable
             ->setLastModificationDate(Carbon::create($this->updated_at));
     }
 
-    protected function rootCategoryIds()
+    /**
+     * Get root category ids.
+     */
+    protected function rootCategoryIds(): array
     {
         return core()->getAllChannels()->pluck('root_category_id')->toArray();
     }


### PR DESCRIPTION
What's changed

Added cached rootCategoryIds() method (5min cache)
Root categories now excluded from sitemap generation
Prevents DB queries on each sitemap build

Why
Root categories are navigation containers, not content pages. Excluding them creates cleaner sitemaps and improves performance.