### PR TITLE
Fix/users image deleted on update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ This changelog consists of the bug & security fixes and new features being inclu
 
 ## Unreleased
 
-* #10898 - Added asterisk symbol to all the required fields in configurable product variants.
+* #10971 - Fixed an issue where updating a field without changing the image caused the image to break or not display correctly.
+
+* #10898 - Added an asterisk (*) to indicate all required fields in configurable product variants.
 
 ## **v2.3.7 (24th of September 2025)** - *Release*
 

--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/UserController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/UserController.php
@@ -112,6 +112,14 @@ class UserController extends Controller
 
         Event::dispatch('user.admin.update.before', $id);
 
+        /**
+         * If the request has image.image, it means the request doesn't upload a new image.
+         * So we need to remove it from the data to prevent the image from being overwritten.
+         */
+        if(request()->has('image.image')) {
+            unset($data['image']);
+        }
+
         $admin = $this->adminRepository->update($data, $id);
 
         if (request()->hasFile('image')) {

--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/UserController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/UserController.php
@@ -116,7 +116,7 @@ class UserController extends Controller
          * If the request has image.image, it means the request doesn't upload a new image.
          * So we need to remove it from the data to prevent the image from being overwritten.
          */
-        if(request()->has('image.image')) {
+        if (request()->has('image.image')) {
             unset($data['image']);
         }
 

--- a/packages/Webkul/Admin/tests/Feature/Settings/UsersTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Settings/UsersTest.php
@@ -174,7 +174,7 @@ it('should fails the validation error with tempered avatar provided when update 
         ->assertUnprocessable();
 });
 
-it('should can update users without new image', function () {
+it('can update the users without new image', function () {
     // Arrange.
     $admin = Admin::factory()->create();
     $admin->update([

--- a/packages/Webkul/Admin/tests/Feature/Settings/UsersTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Settings/UsersTest.php
@@ -199,7 +199,7 @@ it('can update the users without new image', function () {
         ->assertOk();
 
     $this->assertDatabaseHas('admins', [
-        'id' => $admin->id,
+        'id'    => $admin->id,
         'image' => $admin->image,
     ]);
 });

--- a/packages/Webkul/Admin/tests/Feature/Settings/UsersTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Settings/UsersTest.php
@@ -174,6 +174,36 @@ it('should fails the validation error with tempered avatar provided when update 
         ->assertUnprocessable();
 });
 
+it('should can update users without new image', function () {
+    // Arrange.
+    $admin = Admin::factory()->create();
+    $admin->update([
+        'image' => 'avatar.jpg',
+    ]);
+    $admin->refresh();
+
+    // Act and Assert.
+    $this->loginAsAdmin($admin);
+
+    putJson(route('admin.settings.users.update'), [
+        'id'                    => $admin->id,
+        'name'                  => $admin->name,
+        'image'                 => [
+            'image' => '',
+        ],
+        'role_id'               => 1,
+        'email'                 => fake()->email(),
+        'password'              => $password = fake()->password(),
+        'password_confirmation' => $password,
+    ])
+        ->assertOk();
+
+    $this->assertDatabaseHas('admins', [
+        'id' => $admin->id,
+        'image' => $admin->image,
+    ]);
+});
+
 it('should delete the existing admin', function () {
     // Arrange.
     $admin = Admin::factory()->create();


### PR DESCRIPTION
## Issue Reference
#10971 

## Description
Prevent overwriting users image when no new image uploaded.

## How To Test This?
Using UI
1. Go to Admin -> Settings -> user.
2. Click on the edit button.
3. Add an image and save.
4. Again, click on the same edit button.
5. Save without changing.
6. See the image still and not disappear.

Using Pest
`./vendor/bin/pest packages/Webkul/Admin/tests/Feature/Settings/UsersTest.php  `

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [x] Target Branch: master 

## Tailwind Reordering
- No UI Update
