### PR TITLE
fix(admin): ensure TinyMCE editors are reinitialized correctly after theme change

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/components/tinymce/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/tinymce/index.blade.php
@@ -245,7 +245,7 @@
                 this.init();
 
                 this.$emitter.on('change-theme', (theme) => {
-                    tinymce.activeEditor.destroy();
+                    tinymce.get(0).destroy();
 
                     this.currentSkin = theme === 'dark' ? 'oxide-dark' : 'oxide';
                     this.currentContentCSS = theme === 'dark' ? 'dark' : 'default';


### PR DESCRIPTION

## Issue Reference
#10982 

## Description
- Destroy the correct editor before reinitializing the tinymce editor
- Now after changing theme when multiple tinymce editors are present on the same page the editors will still work as editors instead of reverting to plain textarea input.