### PR TITLE
Fix VAT validator: check fallback country exists before pattern lookup

### DIFF
--- a/packages/Webkul/Customer/src/Rules/VatValidator.php
+++ b/packages/Webkul/Customer/src/Rules/VatValidator.php
@@ -61,6 +61,13 @@ class VatValidator
                 return false;
             }
 
+            $formCountry = strtoupper($formCountry);
+
+            // Ensure the provided form country is supported before using it
+            if (! isset(self::$pattern_expression[$formCountry])) {
+                return false;
+            }
+
             $country = $formCountry;
             $number = $vatNumber;
         }


### PR DESCRIPTION
### Summary:

- Prevents PHP notice "Undefined array key 'XX'" in VatValidator when the VAT input starts with an unsupported country prefix or the provided form country is unsupported.

### Problem:

- VatValidator assumed the first two characters are always a valid country code and indexed into the internal pattern array without validating the fallback form country, which can produce an undefined array key notice and confusing validation results for users.

### Fix:

- Upper-case the fallback $formCountry and check that it exists in the pattern map before indexing it.
- Keep behavior unchanged otherwise (returns false for unsupported countries and invalid formats).

### How to reproduce the original problem:

- Submit a VAT number like "CD12345" or "12345" while formCountry is "CD" or empty (CD is not supported in the pattern list).
- Before this fix, PHP logs contained the error message "Undefined array key 'CD'."

### Notes:

- This is a minimal fix to prevent notices and keep behavior stable.
