### PR TITLE
Fix VAT validator: check fallback country exists before pattern lookup

### DIFF
--- a/packages/Webkul/Customer/src/Rules/VatValidator.php
+++ b/packages/Webkul/Customer/src/Rules/VatValidator.php
@@ -61,7 +61,6 @@ class VatValidator
                 return false;
             }
 
-            // Ensure the provided form country is supported before using it
             if (! isset(self::$pattern_expression[$formCountry])) {
                 return false;
             }


### PR DESCRIPTION
### Summary:
- Prevents PHP notice "Undefined array key 'XX'" in VatValidator when the VAT input starts with an unsupported country prefix or the provided form country is unsupported.

### Problem:
- VatValidator assumed the first two characters are always a valid country code and indexed into the internal pattern array without validating the fallback form country, which can produce an undefined array key notice and confusing validation results for users.
### Fix:
- Check that $formCountry exists in the pattern map before indexing it.

- Keep behavior unchanged otherwise (returns false for unsupported countries and invalid formats).
### How to reproduce the original problem:
1. Navigate to Admin Panel →  Sales → Orders → Create Order
2. Search for the customer by name and select (If not, create a new customer)
3. Click Add Product -> Search for the product by name and add to cart (if not, create a new product)
4. Click Add Address -> fill required fields with incorrect VAT format and hit save 

- Submit a VAT number like "BD12345" or "12345" while formCountry is "BD" or empty (BD is not supported in the pattern list).
- Before this fix, PHP logs contained the error message "Undefined array key 'BD'."
### Notes:
- This is a minimal fix to prevent notices and keep behavior stable.

### Screenshot
<img width="1280" height="663" alt="Screenshot 2025-11-06 at 3 37 26 PM" src="https://github.com/user-attachments/assets/621d8e12-e07d-4122-9f83-1fd31a5c27de" />
