### PR TITLE
fix: use mb_substr and mb_strlen for UTF-8 safe reviewer name censoring

### DIFF
--- a/packages/Webkul/Shop/src/Http/Controllers/API/ReviewController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/API/ReviewController.php
@@ -144,7 +144,7 @@ class ReviewController extends APIController
     private function censorReviewerName(string $name): string
     {
         return collect(explode(' ', $name))
-            ->map(fn ($part) => substr($part, 0, 1).str_repeat('*', max(strlen($part) - 1, 0)))
+            ->map(fn ($part) => mb_substr($part, 0, 1).str_repeat('*', max(mb_strlen($part) - 1, 0)))
             ->join(' ');
     }
 }


### PR DESCRIPTION
## Issue Reference

Fixes malformed UTF-8 characters error in product reviews API when reviewer names contain multi-byte characters (e.g., Turkish: Ö, Ş, İ, Ç, Ü).

## Description

The `censorReviewerName` method in `ReviewController` was using `substr()` and `strlen()` functions which operate on bytes rather than characters. This caused issues with UTF-8 encoded names containing multi-byte characters.

**Problem:**
- `substr($str, 0, 1)` takes only the first byte of a multi-byte character
- For example, "Özlem" (Turkish Ö = 0xC396) becomes broken when only 0xC3 is taken
- This results in `InvalidArgumentException: Malformed UTF-8 characters, possibly incorrectly encoded` when JSON encoding the response

**Solution:**
- Changed `substr()` to `mb_substr()` for proper character extraction
- Changed `strlen()` to `mb_strlen()` for proper character counting

**Before:**
```php
return collect(explode(' ', $name))
    ->map(fn ($part) => substr($part, 0, 1).str_repeat('*', max(strlen($part) - 1, 0)))
    ->join(' ');
```

**After:**
```php
return collect(explode(' ', $name))
    ->map(fn ($part) => mb_substr($part, 0, 1).str_repeat('*', max(mb_strlen($part) - 1, 0)))
    ->join(' ');
```

## How To Test This?

1. Create a product review with a reviewer name starting with a multi-byte UTF-8 character (e.g., "Özlem", "Şenay", "Ümit" with Turkish characters)
2. Set the review status to "approved"
3. Enable "Censoring Reviewer Name" option in admin panel (Catalog > Products > Review > Censoring Reviewer Name)
4. Visit the product page and click on "Reviews" tab
5. Check browser console - should no longer show 500 Internal Server Error
6. Reviews should load successfully with censored names like "O****" instead of broken characters

**Test Script:**
```php
// Before fix: JSON encoding fails
$name = "Özlem K."; // Turkish O
$broken = substr($name, 0, 1); // Takes only 0xC3 byte - BROKEN
json_encode($broken); // Throws InvalidArgumentException

// After fix: JSON encoding works
$fixed = mb_substr($name, 0, 1); // Takes full character 0xC396 - OK
json_encode($fixed); // Works correctly
```

## Documentation

- [ ] My pull request requires an update on the documentation repository.

No documentation changes required.

## Branch Selection

- [x] Target Branch: 2.3

## Tailwind Reordering

Not applicable - PHP code changes only.

---

**File Changed:**
`packages/Webkul/Shop/src/Http/Controllers/API/ReviewController.php`

**Lines Changed:** 146-147

---

**Console Log:**
```js
frame_ant.js:2  GET http://laravel.test/api/product/79/reviews 500 (Internal Server Error)
r.send @ frame_ant.js:2
(anonymous) @ vendor-jY-xvwzp.js:3
xhr @ vendor-jY-xvwzp.js:3
Me @ vendor-jY-xvwzp.js:5
_request @ vendor-jY-xvwzp.js:6
request @ vendor-jY-xvwzp.js:5
j.<computed> @ vendor-jY-xvwzp.js:6
(anonymous) @ vendor-jY-xvwzp.js:1
get @ yemek-masasi-seti-79:2354
(anonymous) @ yemek-masasi-seti-79:2333
(anonymous) @ yemek-masasi-seti-79:2331
```

---

**SS:**

<img width="1592" height="1106" alt="image" src="https://github.com/user-attachments/assets/47cfef58-7353-49da-b0b4-64d384fe2f97" />
