### PR TITLE
fix: Undefined array key channels error when saving CMS page without selecting a channel

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/CMS/PageController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/CMS/PageController.php
@@ -53,6 +53,7 @@ class PageController extends Controller
             'url_key'      => ['required', 'unique:cms_page_translations,url_key', new \Webkul\Core\Rules\Slug],
             'page_title'   => 'required',
             'html_content' => 'required',
+            'channels'     => 'required|array|min:1',
         ]);
 
         Event::dispatch('cms.page.create.before');
@@ -103,6 +104,7 @@ class PageController extends Controller
             }],
             $locale.'.page_title'     => 'required',
             $locale.'.html_content'   => 'required',
+            'channels'                => 'required|array|min:1',
         ]);
 
         Event::dispatch('cms.page.update.before', $id);

--- a/packages/Webkul/Admin/src/Resources/views/cms/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/cms/create.blade.php
@@ -196,7 +196,7 @@
                         </x-admin::form.control-group>
 
                         <!-- Select Channels -->
-                        <x-admin::form.control-group.label>
+                        <x-admin::form.control-group.label class="required">
                             @lang('admin::app.cms.create.channels')
                         </x-admin::form.control-group.label>
 
@@ -206,6 +206,7 @@
                                     type="checkbox"
                                     :id="'channels_' . $channel->id"
                                     name="channels[]"
+                                    rules="required"
                                     :value="$channel->id"
                                     :for="'channels_' . $channel->id"
                                     :label="trans('admin::app.cms.create.channels')"

--- a/packages/Webkul/Admin/src/Resources/views/cms/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/cms/edit.blade.php
@@ -252,7 +252,7 @@
                         </x-admin::form.control-group>
 
                         <!-- Select Channels -->
-                        <x-admin::form.control-group.label>
+                        <x-admin::form.control-group.label class="required">
                             @lang('admin::app.cms.create.channels')
                         </x-admin::form.control-group.label>
 
@@ -262,6 +262,7 @@
                                     type="checkbox"
                                     :id="'channels_' . $channel->id"
                                     name="channels[]"
+                                    rules="required"
                                     :value="$channel->id"
                                     :for="'channels_' . $channel->id"
                                     :label="trans('admin::app.cms.create.channels')"

--- a/packages/Webkul/Admin/tests/Feature/Cms/CmsTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Cms/CmsTest.php
@@ -52,6 +52,7 @@ it('should fail the validation with errors when certain inputs are not provided 
         ->assertJsonValidationErrorFor('url_key')
         ->assertJsonValidationErrorFor('page_title')
         ->assertJsonValidationErrorFor('html_content')
+        ->assertJsonValidationErrorFor('channels')
         ->assertUnprocessable();
 });
 
@@ -117,6 +118,7 @@ it('should fail the validation with errors when certain inputs are not provided 
         ->assertJsonValidationErrorFor($localeCode.'.url_key')
         ->assertJsonValidationErrorFor($localeCode.'.page_title')
         ->assertJsonValidationErrorFor($localeCode.'.html_content')
+        ->assertJsonValidationErrorFor('channels')
         ->assertUnprocessable();
 });
 


### PR DESCRIPTION
## Issue Reference
#11035 

## Description
Added `required` attributes on both create and edit blade form and make sure the order of controller validation in both `store` and `update` method. Also, updated Test file to include JSON error for the channel field.

## How To Test This?
- Login as Admin
- Go to CMS > Pages > Create Page
- Fill out the required fields and left uncheck Channel
- Save

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: 2.3 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->
