### PR TITLE
Fix security issue in customer order reorder

### DIFF
--- a/packages/Webkul/Shop/src/Http/Controllers/Customer/Account/OrderController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/Customer/Account/OrderController.php
@@ -62,7 +62,12 @@ class OrderController extends Controller
      */
     public function reorder(int $id)
     {
-        $order = $this->orderRepository->findOrFail($id);
+        $order = $this->orderRepository->findOneWhere([
+            'customer_id' => auth()->guard('customer')->id(),
+            'id'          => $id,
+        ]);
+
+        abort_if(! $order, 404);
 
         foreach ($order->items as $item) {
             try {


### PR DESCRIPTION
## Issue Reference
Security fix for customer order reorder

## Description
This PR fixes a security issue in the customer order reorder functionality.

Previously, the reorder action did not verify whether the requested order belonged to the authenticated customer. This allowed an authenticated customer to reorder items from another customer's order by manipulating the order ID.

The fix ensures proper ownership validation before allowing reorder actions.

### Reference
- Security Advisory: GHSA-x5rw-qvvp-5cgm
