### PR TITLE
Fix Server-Side Template Injection (SSTI) in type Parameter of reporting  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This changelog consists of the bug & security fixes and new features being inclu
 
 - Refined the Blade tracer to track only view files, ensuring accurate view-level tracing.
 
-- Fixed SSTI vulnerability in type parameter handling — user input is now properly sanitized/validated to prevent server-side template injection
+- Fixed SSTI vulnerability in type parameter handling — user input is now properly sanitized/validated to prevent server-side template injection.
 
 * #11058 [fixed] - Fixed the speculation issue and resolved the revoke endpoint issue.
 

--- a/packages/Webkul/Admin/src/Http/Controllers/Reporting/Controller.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Reporting/Controller.php
@@ -66,13 +66,23 @@ class Controller extends BaseController
     }
 
     /**
+     * Validate if the requested type is valid.
+     *
+     * @return void
+     */
+    protected function validateRequestedType()
+    {
+        return ! array_key_exists(request()->query('type'), $this->typeFunctions);
+    }
+
+    /**
      * Resolve the requested type into a valid function name.
      *
      * @return string
      */
     protected function resolveTypeFunction()
     {
-        if (! array_key_exists(request()->query('type'), $this->typeFunctions)) {
+        if ($this->validateRequestedType()) {
             abort(404);
         }
 

--- a/packages/Webkul/Admin/src/Http/Controllers/Reporting/CustomerController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Reporting/CustomerController.php
@@ -38,7 +38,9 @@ class CustomerController extends Controller
      */
     public function view()
     {
-        $this->resolveTypeFunction();
+        if ($this->validateRequestedType()) {
+            abort(404);
+        }
 
         return view('admin::reporting.view')->with([
             'entity'    => 'customers',

--- a/packages/Webkul/Admin/src/Http/Controllers/Reporting/ProductController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Reporting/ProductController.php
@@ -40,7 +40,9 @@ class ProductController extends Controller
      */
     public function view()
     {
-        $this->resolveTypeFunction();
+        if ($this->validateRequestedType()) {
+            abort(404);
+        }
 
         return view('admin::reporting.view')->with([
             'entity'    => 'products',

--- a/packages/Webkul/Admin/src/Http/Controllers/Reporting/SaleController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Reporting/SaleController.php
@@ -41,7 +41,9 @@ class SaleController extends Controller
      */
     public function view()
     {
-        $this->resolveTypeFunction();
+        if ($this->validateRequestedType()) {
+            abort(404);
+        }
 
         return view('admin::reporting.view')->with([
             'entity'    => 'sales',


### PR DESCRIPTION
## Issue Reference
This PR fixes a Server-Side Template Injection (SSTI) vulnerability that was reported in Reporting section where the type parameter could be exploited to inject template expressions — potentially leading to remote code execution (RCE) if exploited.

##  Reference Advisory:
🔗 https://github.com/bagisto/bagisto/security/advisories/GHSA-9hvg-qw5q-wqwp