### PR TITLE
Moved hidden keys input to the edit blade it self from flied-type in …

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/configuration/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/configuration/edit.blade.php
@@ -119,6 +119,13 @@
 
         <div class="mt-6 grid grid-cols-[1fr_2fr] gap-10 max-xl:flex-wrap">
             @foreach ($activeConfiguration->getChildren() as $child)
+                
+                <input
+                    type="hidden"
+                    name="keys[]"
+                    value='@json($child)'
+                />
+
                 <div class="grid content-start gap-2.5">
                     <p class="text-base font-semibold text-gray-600 dark:text-gray-300">
                         {{ $child->getName() }}

--- a/packages/Webkul/Admin/src/Resources/views/configuration/field-type.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/configuration/field-type.blade.php
@@ -2,12 +2,6 @@
     $value = system_config()->getConfigData($field->getNameKey(), $currentChannel->code, $currentLocale->code);
 @endphp
 
-<input
-    type="hidden"
-    name="keys[]"
-    value="{{ json_encode($child) }}"
-/>
-
 <div class="mb-4 last:!mb-0">
     <v-configurable
         name="{{ $field->getNameField() }}"


### PR DESCRIPTION
…order to prevent duplicate keys entry

## Description
Due to having keys in field type blade of configurations when there are more then 1 field per child it creates same entry multiple times. Lets say 8 fields then there will be same entry 8 times making the request large with no reason.

Now the keys will be per child as it should be

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: 2.3