### PR TITLE
Fix tax calculation to use discounted price instead of original price

### DIFF
--- a/packages/Webkul/Checkout/src/Cart.php
+++ b/packages/Webkul/Checkout/src/Cart.php
@@ -1073,9 +1073,13 @@ class Cart
 
                     $item->base_price = $item->base_total / $item->quantity;
                 } else {
-                    $item->tax_amount = round(($item->total * $rate->tax_rate) / 100, 4);
+                    $taxBase = max(0, $item->total - $item->discount_amount);
 
-                    $item->base_tax_amount = round(($item->base_total * $rate->tax_rate) / 100, 4);
+                    $baseTaxBase = max(0, $item->base_total - $item->base_discount_amount);
+
+                    $item->tax_amount = round(($taxBase * $rate->tax_rate) / 100, 4);
+
+                    $item->base_tax_amount = round(($baseTaxBase * $rate->tax_rate) / 100, 4);
 
                     $item->total_incl_tax = $item->total + $item->tax_amount;
 


### PR DESCRIPTION
## Issue Reference

<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->

Fixes #<ISSUE_ID>

---

## Description

This pull request fixes a critical tax calculation issue where tax is calculated from the original item price instead of the **discounted price**.

### ❌ Current Behavior

Tax is calculated using:

```php
$item->total
```

Even when a discount is applied, which results in **overcharged tax**.

### ✅ New Behavior

Tax is now calculated from the **discounted base amount**:

```php
$taxBase = max(0, $item->total - $item->discount_amount);
$baseTaxBase = max(0, $item->base_total - $item->base_discount_amount);
```

This ensures that:

* Tax is calculated **after discount**
* Totals comply with VAT regulations
* Prevents tax overcharging in all discount scenarios (coupons, cart rules, promotions, etc.)

---

## How To Test This?

1. Create a product:

   * Price: `1000`
   * Tax category: `20% VAT`
2. Set configuration:

   * Catalog prices: **Excluding tax**
3. Create a cart rule or coupon:

   * Discount: `5%`
4. Add product to cart
5. Apply the coupon
6. Go to cart or checkout page

### ✅ Expected result:

* Discount: `50`
* Tax base: `950`
* Tax: `190`
* Total: `1140`

### ❌ Before fix:

* Tax was: `200`
* Total was: `1150` (overcharged)

---

## Documentation

* [ ] My pull request requires an update on the documentation repository.

*No documentation change required. This is a bugfix.*

---

## Branch Selection

* [x] Target Branch: `master`

---

## Tailwind Reordering

* [x] Not applicable (No UI changes)