### PR TITLE
Fixes #11106 - enhance template rendering with additional params support

### DIFF
--- a/packages/Webkul/Theme/src/ViewRenderEventManager.php
+++ b/packages/Webkul/Theme/src/ViewRenderEventManager.php
@@ -90,6 +90,7 @@ class ViewRenderEventManager
     public function addTemplate($template, $params = [])
     {
         array_push($this->templates, $template);
+        
         $this->params = array_merge($this->params, $params);
     }
 


### PR DESCRIPTION
## Issue Reference
Issue #11106 - [2.3] ViewRenderEventManager::addTemplate does not accept data parameters as documented 

## Description
Add the ability to pass additional parameters to the `addTemplate` method in the `ViewRenderEventManager`. Enhance flexibility by merging these parameters into existing ones, allowing more dynamic data handling when rendering templates. This change supports more customizable template rendering scenarios by using specific data relevant to each template instance. 

The [View Render Events](https://devdocs.bagisto.com/advanced/view-render-events.html) in official documentation states that it is possible to pass an array of optional data to a template when using the addTemplate method.

But it was not working.

## How To Test This?
```php
Event::listen('bagisto.shop.checkout.payment.after', function($viewRenderEventManager) {
    $viewRenderEventManager->addTemplate('rma::shop.checkout.return-policy', [
        'policyUrl' => config('rma.return_policy_url'),
        'returnDays' => config('rma.default_return_days', 30)
    ]);
});
```
