### PR TITLE
Fix: missing backslash in address validation regex for Hiragana

### DIFF
--- a/packages/Webkul/Core/src/Rules/Address.php
+++ b/packages/Webkul/Core/src/Rules/Address.php
@@ -12,7 +12,7 @@ class Address implements ValidationRule
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        if (! preg_match("/^[a-zA-Z0-9\s'\p{Arabic}\p{Bengali}\p{Hebrew}\p{Latin}\p{Sinhala}\p{Cyrillic}\p{Devanagari}p{Hiragana}\p{Katakana}\p{Han}\-,\(\)]{1,60}$/iu", $value)) {
+        if (! preg_match("/^[a-zA-Z0-9\s'\p{Arabic}\p{Bengali}\p{Hebrew}\p{Latin}\p{Sinhala}\p{Cyrillic}\p{Devanagari}\p{Hiragana}\p{Katakana}\p{Han}\-,\(\)]{1,60}$/iu", $value)) {
             $fail('core::validation.address')->translate();
         }
     }


### PR DESCRIPTION
## Issue Reference
Found a typo in the address validation logic while developing with Bagisto v2.3.11.

## Description
Fixed a syntax error in the address validation regular expression. A backslash (\) was missing before p{Hiragana}, which caused the regex to treat the letter 'p' as a literal character instead of a Unicode property escape for Japanese Hiragana characters.

Changes:

- Corrected p{Hiragana} to \p{Hiragana} in the address validation rule.

## How To Test This?

1. Go to the address creation/edit page (Customer Address or Checkout).
2. Try to save an address containing Japanese Hiragana characters (e.g., あいうえお).
3. Before the fix, the validation might fail or behave unexpectedly because the regex was malformed.
4. After the fix, Japanese Hiragana characters should be correctly validated as part of the allowed character set.

## Documentation
- [x] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: master 

## Tailwind Reordering
- [x] Not applicable (No CSS/Tailwind changes).
<!--- Please make sure all the Tailwind classes are reordered. -->
