### PR TITLE
fix: trim whitespace from form inputs before validation

### DIFF
--- a/packages/Webkul/Shop/src/Http/Requests/CartAddressRequest.php
+++ b/packages/Webkul/Shop/src/Http/Requests/CartAddressRequest.php
@@ -25,6 +25,30 @@ class CartAddressRequest extends FormRequest
     }
 
     /**
+     * Prepare the data for validation.
+     */
+    protected function prepareForValidation(): void
+    {
+        $trimFields = ['company_name', 'first_name', 'last_name', 'email', 'city', 'postcode', 'phone', 'vat_id'];
+
+        foreach (['billing', 'shipping'] as $addressType) {
+            if (! $this->has($addressType)) {
+                continue;
+            }
+
+            $addressData = $this->input($addressType, []);
+
+            foreach ($trimFields as $field) {
+                if (isset($addressData[$field]) && is_string($addressData[$field])) {
+                    $addressData[$field] = trim($addressData[$field]);
+                }
+            }
+
+            $this->merge([$addressType => $addressData]);
+        }
+    }
+
+    /**
      * Get the validation rules that apply to the request.
      */
     public function rules(): array

--- a/packages/Webkul/Shop/src/Http/Requests/Customer/AddressRequest.php
+++ b/packages/Webkul/Shop/src/Http/Requests/Customer/AddressRequest.php
@@ -20,6 +20,28 @@ class AddressRequest extends FormRequest
     }
 
     /**
+     * Prepare the data for validation.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $trimFields = ['company_name', 'first_name', 'last_name', 'city', 'postcode', 'phone', 'email', 'vat_id'];
+
+        $data = [];
+
+        foreach ($trimFields as $field) {
+            if ($this->has($field)) {
+                $data[$field] = is_string($this->input($field)) ? trim($this->input($field)) : $this->input($field);
+            }
+        }
+
+        if (! empty($data)) {
+            $this->merge($data);
+        }
+    }
+
+    /**
      * Get the validation rules that apply to the request.
      *
      * @return array

--- a/packages/Webkul/Shop/src/Http/Requests/Customer/ProfileRequest.php
+++ b/packages/Webkul/Shop/src/Http/Requests/Customer/ProfileRequest.php
@@ -18,6 +18,28 @@ class ProfileRequest extends FormRequest
     }
 
     /**
+     * Prepare the data for validation.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $trimFields = ['first_name', 'last_name', 'email', 'phone'];
+
+        $data = [];
+
+        foreach ($trimFields as $field) {
+            if ($this->has($field)) {
+                $data[$field] = trim($this->input($field));
+            }
+        }
+
+        if (! empty($data)) {
+            $this->merge($data);
+        }
+    }
+
+    /**
      * Get the validation rules that apply to the request.
      *
      * @return array


### PR DESCRIPTION
Adds prepareForValidation() to customer-facing form requests to automatically trim leading/trailing whitespace from text input fields before validation rules are applied.

Affected files:
- ProfileRequest - trims first_name, last_name, email, phone
- AddressRequest - trims company_name, first_name, last_name, city, postcode, phone, email, vat_id
- CartAddressRequest - trims the same fields for both billing and shipping address

Problem: When users enter valid values with leading or trailing spaces (e.g. " user@example.com "), validation fails unnecessarily.

Solution: Using Laravel built-in prepareForValidation() hook to trim string fields before validation runs.

Fixes #10973