### PR TITLE
Trim leading and trailing whitespace before frontend validation

### DIFF
--- a/packages/Webkul/Shop/src/Resources/views/components/form/control-group/control.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/components/form/control-group/control.blade.php
@@ -72,7 +72,7 @@
             </textarea>
 
             @if ($attributes->get('tinymce', false) || $attributes->get(':tinymce', false))
-                <x-shop::tinymce
+                <x-shop::tinymce 
                     :selector="'textarea#' . $attributes->get('id')"
                     :prompt="stripcslashes($attributes->get('prompt', ''))"
                     ::field="field"


### PR DESCRIPTION
## Issue Reference
fix #10973 

## Description
Trims leading and trailing whitespace from text-based inputs in shop forms when the user moves focus away from the input field. This prevents validation errors caused by extra spaces in otherwise valid values.

## How To Test This?
1. Go to My Account → Edit Profile.
2. Enter values with leading or trailing spaces (e.g., " user@example.com ").
3. Click anywhere outside the input field.
4. The value should be trimmed automatically.
5. No validation error should appear if the trimmed value is valid.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [x] Target Branch: 2.3

## Tailwind Reordering
All Tailwind classes are properly ordered.