### PR TITLE
Fix incorrect subtotal calculation for bundle products with multiple …

### DIFF
--- a/packages/Webkul/Product/src/Type/Bundle.php
+++ b/packages/Webkul/Product/src/Type/Bundle.php
@@ -290,6 +290,8 @@ class Bundle extends AbstractType
 
         $products[0]['total_weight'] = $products[0]['base_total_weight'] = $products[0]['weight'] * $products[0]['quantity'];
 
+        $products[0]['total'] = $products[0]['base_total'] = $products[0]['base_total'] * $products[0]['quantity'];
+
         return $products;
     }
 


### PR DESCRIPTION
## Issue Reference
#10960 

In a specific scenario, when adding a **bundle product with quantity greater than 1**, the cart **subtotal was calculated only for a single quantity**, resulting in incorrect pricing.

## Description
- Updated the subtotal calculation logic to correctly account for **multiple quantities** of bundle products.
- Ensured price calculation aligns with expected cart and checkout totals.
- Verified behavior across cart, mini-cart, and checkout flows.

## How To Test This?
- Added bundle product with quantity > 1
- Verified subtotal, cart total, and checkout total
- Tested both fixed-price and dynamic bundle product configurations