### PR TITLE
Fix: Multi-select required attribute validation on product edit

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/catalog/products/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/products/edit.blade.php
@@ -216,7 +216,7 @@
                                             'product'   => $product,
                                         ])
 
-                                        <x-admin::form.control-group.error :control-name="$attribute->code . (in_array($attribute->type, ['multiselect', 'checkbox']) ? '[]' : '')" />
+                                        <x-admin::form.control-group.error :control-name="$attribute->code . ($attribute->type === 'checkbox' ? '[]' : '')" />
                                     </x-admin::form.control-group>
 
                                     {!! view_render_event("bagisto.admin.catalog.product.edit.form.{$group->code}.controls.after", ['product' => $product]) !!}

--- a/packages/Webkul/Admin/src/Resources/views/catalog/products/edit/controls.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/products/edit/controls.blade.php
@@ -104,20 +104,31 @@
         @break
     @case('multiselect')
         @php
-            $selectedOption = old($attribute->code) ?: explode(',', $product[$attribute->code]);
+            $selectedOption = old($attribute->code);
+
+            if (is_null($selectedOption)) {
+                $selectedOption = array_filter(explode(',', (string) $product[$attribute->code]));
+            }
+
+            if (! is_array($selectedOption)) {
+                $selectedOption = [$selectedOption];
+            }
+
+            $selectedOption = array_values(array_map('strval', $selectedOption));
         @endphp
 
         <x-admin::form.control-group.control
             type="multiselect"
             :id="$attribute->code . '[]'"
             :name="$attribute->code . '[]'"
+            ::value='{{ json_encode($selectedOption) }}'
             ::rules="{{ $attribute->validations }}"
             :label="$attribute->admin_name"
         >
             @foreach ($attribute->options()->orderBy('sort_order')->get() as $option)
                 <option
                     value="{{ $option->id }}"
-                    {{ in_array($option->id, $selectedOption) ? 'selected' : ''}}
+                    {{ in_array((string) $option->id, $selectedOption, true) ? 'selected' : ''}}
                     v-pre
                 >
                     {{ $option->admin_name }}

--- a/packages/Webkul/Admin/src/Resources/views/components/form/control-group/control.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/form/control-group/control.blade.php
@@ -191,15 +191,27 @@
         @break
 
     @case('multiselect')
+        @php
+            $validationName = str_ends_with($name, '[]')
+                ? substr($name, 0, -2)
+                : $name;
+        @endphp
+
         <v-field
-            as="select"
-            v-slot="{ value }"
-            :class="[errors && errors['{{ $name }}'] ? 'border !border-red-600 hover:border-red-600' : '']"
-            {{ $attributes->except([])->merge(['class' => 'flex w-full flex-col rounded-md border bg-white px-3 py-2.5 text-sm font-normal text-gray-600 transition-all hover:border-gray-400 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-gray-400']) }}
-            name="{{ $name }}"
-            multiple
+            v-slot="data"
+            {{ $attributes->only(['name', ':name', 'value', ':value', 'v-model', 'rules', ':rules', 'label', ':label']) }}
+            name="{{ $validationName }}"
         >
-            {{ $slot }}
+            <select
+                v-bind="data.field"
+                name="{{ $name }}"
+                v-model="data.value"
+                multiple
+                :class="[data.errors.length ? 'border !border-red-600 hover:border-red-600' : '']"
+                {{ $attributes->except(['value', ':value', 'v-model', 'rules', ':rules', 'label', ':label'])->merge(['class' => 'flex w-full flex-col rounded-md border bg-white px-3 py-2.5 text-sm font-normal text-gray-600 transition-all hover:border-gray-400 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-gray-400']) }}
+            >
+                {{ $slot }}
+            </select>
         </v-field>
 
         @break


### PR DESCRIPTION
## Issue Reference
#10963 
In Bagisto 2.3, required multi-select attribute values are not retained unless the user interacts with the select field again. This leads to incorrect validation errors when saving a product multiple times without modifying the field.

## Descriptoin
Resolved issue where required multi-select attributes were not persisted correctly unless user re-interacted with the field. This ensures previously selected values are retained and validation works correctly on repeated saves.

## Solution
This PR ensures that multi-select attribute values are properly initialized and retained during form submission, preventing unnecessary validation failures when the product is saved without further interaction.
