### PR TITLE
Add item level render event in admin order items list

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/sales/orders/view.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/sales/orders/view.blade.php
@@ -128,11 +128,9 @@
 
                     <!-- Order items -->
                     <div class="grid">
-
                         {!! view_render_event('bagisto.admin.sales.order.list.before', ['order' => $order]) !!}
 
                         @foreach ($order->items as $item)
-
                             {!! view_render_event('bagisto.admin.sales.order.list.item.before', ['order' => $order, 'item' => $item]) !!}
 
                             <div class="flex justify-between gap-2.5 border-b border-slate-300 px-4 py-6 dark:border-gray-800">
@@ -274,11 +272,9 @@
                             </div>
 
                             {!! view_render_event('bagisto.admin.sales.order.list.item.after', ['order' => $order, 'item' => $item]) !!}
-
                         @endforeach
 
                         {!! view_render_event('bagisto.admin.sales.order.list.after', ['order' => $order]) !!}
-
                     </div>
 
                     <div class="mt-4 flex flex-auto justify-end p-4">


### PR DESCRIPTION
## Description
This PR improves the render events in the admin order items list view.

Currently the event:
bagisto.admin.sales.order.list.before

is placed inside the foreach loop that iterates over order items.

This PR:
- Moves `bagisto.admin.sales.order.list.before` outside the foreach loop
- Introduces a new render event: `bagisto.admin.sales.order.list.item.before`

which allows developers to inject content for each order item.

## Reason
This provides more flexibility for extensions that need to interact with individual order items in the admin order view.


## Version
Tested on Bagisto 2.3.x