### PR TITLE
Fix click event binding in accordion component

### DIFF
--- a/packages/Webkul/Shop/src/Resources/views/components/accordion/index.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/components/accordion/index.blade.php
@@ -13,7 +13,7 @@
                     {{ $header->attributes->merge(['class' => 'flex cursor-pointer select-none items-center justify-between p-4']) }}
                     role="button"
                     tabindex="0"
-                    @click="toggle"
+                    v-on:click="toggle"
                 >
                     {{ $header }}
 


### PR DESCRIPTION
# Firefox Latest

The toggle accordion doesn't open in Firefox.

It works normally in Chrome.

The line was changed and now it works in both Chrome and Firefox.

## Without correction
<img width="877" height="260" alt="image" src="https://github.com/user-attachments/assets/b33c760e-34f2-41f7-8755-d3b372ad9a60" />


## With the correction
<img width="909" height="668" alt="image" src="https://github.com/user-attachments/assets/4b43e62a-6d5d-4371-b7e6-f57b5f7f66b5" />
