### PR TITLE
fix: show correct alert when booking slot is unavailable

### DIFF
--- a/packages/Webkul/Product/src/Type/Booking.php
+++ b/packages/Webkul/Product/src/Type/Booking.php
@@ -216,6 +216,14 @@ class Booking extends AbstractType
 
         $typeHelper = app($this->bookingHelper->getTypeHelper($bookingProduct->type));
 
+        if ($bookingProduct->type !== 'event') {
+            foreach ($products as $product) {
+                if ($typeHelper->isSlotExpired($product)) {
+                    throw new InsufficientProductInventoryException(trans('shop::app.products.booking.cart.integrity.slot_unavailable'));
+                }
+            }
+        }
+
         if (! $typeHelper->isSlotAvailable($products)) {
             throw new InsufficientProductInventoryException(trans('shop::app.products.booking.cart.integrity.inventory_warning'));
         }

--- a/packages/Webkul/Shop/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Shop/src/Resources/lang/en/app.php
@@ -913,6 +913,7 @@ return [
                     'missing_options' => 'Options are missing for this product.',
                     'inventory_warning' => 'The requested quantity is not available, please try again later.',
                     'select_hourly_duration' => 'Select a slot duration of one hour.',
+                    'slot_unavailable' => 'The selected slot is not available. Please choose a different date or time.',
                 ],
 
                 'rent-from' => 'Rent From',


### PR DESCRIPTION
### Terms

- [x] Before opening this PR, I have checked if a similar PR has already been submitted.

### Issue

Fixes #10697

### Problem

When a rental booking product's selected date range falls outside the available period, the system shows a misleading **quantity** alert (`The requested quantity is not available, please try again later.`) instead of a slot/availability alert. This confuses customers into thinking the product is out of stock when the real problem is the selected dates are outside the rental window.

### Root Cause

`Booking::isItemHaveQuantity()` combines both quantity checking and slot-expiry checking into a single boolean return. The caller in `prepareForCart()` only shows the generic `inventory_warning` message regardless of which condition failed.

### Solution

Added a **separate slot-expiry check** before the existing quantity/availability check in `Booking (Type)::prepareForCart()`. This surfaces a dedicated `slot_unavailable` translation message when the selected date/time is outside the available window. The existing quantity check remains unchanged for actual stock-depletion scenarios.

- Event bookings are excluded from this new check since they already have their own expiry handling.
- Added `slot_unavailable` translation key to the English language file.

### Changes

| File | Change |
|------|--------|
| `packages/Webkul/Product/src/Type/Booking.php` | Added slot-expiry check before `isSlotAvailable` in `prepareForCart()` |
| `packages/Webkul/Shop/src/Resources/lang/en/app.php` | Added `slot_unavailable` translation key |

### How to Verify

1. Create a rental booking product with a limited availability window (e.g., only next week).
2. On the storefront, select rental dates **outside** the available range.
3. Attempt to add to cart.
4. **Before fix**: Shows `The requested quantity is not available`.
5. **After fix**: Shows `The selected slot is not available. Please choose a different date or time.`