### PR TITLE
fix: hide appointment time ranges shorter than slot duration

### DIFF
--- a/packages/Webkul/BookingProduct/src/Helpers/Booking.php
+++ b/packages/Webkul/BookingProduct/src/Helpers/Booking.php
@@ -103,6 +103,17 @@ class Booking
                 $slots = $bookingProductSlot->same_slot_all_days ? ($bookingProductSlot->slots ?? []) : ($bookingProductSlot->slots[$index] ?? []);
             }
 
+            if (! empty($bookingProductSlot->duration) && ! empty($slots)) {
+                $slots = array_values(array_filter($slots, function ($slot) use ($bookingProductSlot) {
+                    $fromChunks = explode(':', $slot['from']);
+                    $toChunks = explode(':', $slot['to']);
+
+                    $rangeInMinutes = ($toChunks[0] * 60 + $toChunks[1]) - ($fromChunks[0] * 60 + $fromChunks[1]);
+
+                    return $rangeInMinutes >= $bookingProductSlot->duration;
+                }));
+            }
+
             $slotsByDays[] = [
                 'name' => trans($this->daysOfWeek[$index]),
                 'slots' => isset($availableDays[$index]) ? $this->convert24To12Hours($slots) : [],


### PR DESCRIPTION
### Terms

- [x] Before opening this PR, I have checked if a similar PR has already been submitted.

### Issue

Fixes #10902

### Problem

When the admin sets an appointment duration (e.g. 45 minutes) but configures a time range shorter than that duration (e.g. a 30-minute window from 9:00 to 9:30), the storefront still displays that time range in:
- The **weekly availability** (`See Details` section)
- **Today's availability** summary

No appointment can actually be booked in that range because the `slotsCalculation()` method correctly rejects slots that don't fit. This creates a misleading UX where customers see a time range listed as available but cannot book it.

### Root Cause

`getWeekSlotDurations()` returns the raw configured time ranges without checking whether each range is long enough to accommodate at least one booking of the configured duration. The computation-level `slotsCalculation()` method already handles this correctly, but the display-level method does not.

### Solution

Added a duration filter in `getWeekSlotDurations()` that excludes any configured time range whose span (in minutes) is shorter than `bookingProductSlot->duration`. The filter:

- Only activates when the booking product has a `duration` property (appointment, table, default types)
- Parses the same `HH:MM` format used throughout the slot system
- Uses `array_values(array_filter(...))` to maintain clean indexing

### Changes

| File | Change |
|------|--------|
| `packages/Webkul/BookingProduct/src/Helpers/Booking.php` | Filter time ranges shorter than slot duration in `getWeekSlotDurations()` |

### How to Verify

1. Create an appointment booking product with a 45-minute duration.
2. Configure a time slot shorter than 45 minutes (e.g., 9:00 -- 9:30).
3. Also configure a valid slot (e.g., 10:00 -- 11:00).
4. View the product on the storefront.
5. **Before fix**: Both 9:00-9:30 and 10:00-11:00 appear in the weekly availability.
6. **After fix**: Only 10:00-11:00 appears (the 30-minute range is hidden since no 45-min appointment fits).