### PR TITLE
fix: prevent cart quantity from exceeding max purchase limit for event bookings

### DIFF
--- a/packages/Webkul/Checkout/src/Cart.php
+++ b/packages/Webkul/Checkout/src/Cart.php
@@ -361,9 +361,19 @@ class Cart
                 throw new \Exception(trans('shop::app.checkout.cart.illegal'));
             }
 
+            $maxPurchaseQty = $item->getTypeInstance()->getMaximumPurchaseQuantity();
+
+            if ($maxPurchaseQty > 0 && $quantity > $maxPurchaseQty) {
+                throw new \Exception(trans('shop::app.checkout.cart.inventory-warning'));
+            }
+
+            $previousQuantity = $item->quantity;
+
             $item->quantity = $quantity;
 
             if (! $this->isItemHaveQuantity($item)) {
+                $item->quantity = $previousQuantity;
+
                 throw new \Exception(trans('shop::app.checkout.cart.inventory-warning'));
             }
 

--- a/packages/Webkul/Product/src/Type/AbstractType.php
+++ b/packages/Webkul/Product/src/Type/AbstractType.php
@@ -830,6 +830,30 @@ abstract class AbstractType
     }
 
     /**
+     * Maximum units of this product allowed per cart line. Zero means no catalog limit.
+     *
+     * Resolved from product attributes when present in the attribute family (e.g. max_purchase_qty).
+     */
+    public function getMaximumPurchaseQuantity(): int
+    {
+        foreach (['max_purchase_qty', 'max_sale_qty'] as $code) {
+            $value = $this->product->{$code} ?? null;
+
+            if ($value === null || $value === '') {
+                continue;
+            }
+
+            $max = (int) $value;
+
+            if ($max > 0) {
+                return $max;
+            }
+        }
+
+        return 0;
+    }
+
+    /**
      * Get request quantity.
      *
      * @param  array  $data

--- a/packages/Webkul/Product/src/Type/Booking.php
+++ b/packages/Webkul/Product/src/Type/Booking.php
@@ -131,6 +131,12 @@ class Booking extends AbstractType
 
     public function haveSufficientQuantity(int $qty): bool
     {
+        $maxPurchaseQty = $this->getMaximumPurchaseQuantity();
+
+        if ($maxPurchaseQty > 0 && $qty > $maxPurchaseQty) {
+            return false;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
## Problem

When updating cart quantity for event booking products, the UI could show an error while the line quantity was still advanced past the catalog max purchase limit. Checkout later corrected the value, which was confusing.

## Root cause

- Cart updates applied the new quantity on the cart item before all checks completed, and booking types did not consistently enforce catalog max purchase quantity the way stock limits do for simple products.
- \Booking::haveSufficientQuantity()\ always returned \	rue\, so product-level purchase caps were not considered in those code paths.

## Solution

- Add \AbstractType::getMaximumPurchaseQuantity()\ to read max purchase from product attributes (\max_purchase_qty\, then \max_sale_qty\) when set on the product attribute family.
- In \Cart::updateItems()\, reject updates above that limit **before** persisting, using the same user-facing message as other quantity failures.
- If ticket availability validation fails, restore the previous in-memory quantity so the cart item model stays consistent.
- Align \Booking::haveSufficientQuantity()\ with the same max-purchase rule.

Closes #10708.

Made with [Cursor](https://cursor.com)