### PR TITLE
Fixed issue #10902

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This changelog consists of the bug & security fixes and new features being inclu
 
 - #11235 [fixed] - Fixed an issue causing incorrect slot visibility based on selected day and date in appointment booking.
 
+- #10902 [fixed] - Updated appointment booking products to display only available time slots.
+
 ## **v2.3.17 (13th of April 2026)** - *Release*
 
 * Added support for Romanian language.

--- a/packages/Webkul/BookingProduct/src/Helpers/Booking.php
+++ b/packages/Webkul/BookingProduct/src/Helpers/Booking.php
@@ -92,20 +92,40 @@ class Booking
     {
         $slotsByDays = [];
 
-        $bookingProductSlot = $this->typeRepositories[$bookingProduct->type]->findOneByField('booking_product_id', $bookingProduct->id);
+        $bookingProductSlot = $this->typeRepositories[$bookingProduct->type]
+            ->findOneByField('booking_product_id', $bookingProduct->id);
 
         $availableDays = $this->getAvailableWeekDays($bookingProduct);
+
+        $minDuration = $bookingProduct->appointment_slot->duration;
 
         foreach ($this->daysOfWeek as $index => $isOpen) {
             $slots = [];
 
             if ($isOpen) {
-                $slots = $bookingProductSlot->same_slot_all_days ? ($bookingProductSlot->slots ?? []) : ($bookingProductSlot->slots[$index] ?? []);
+                $slots = $bookingProductSlot->same_slot_all_days
+                    ? ($bookingProductSlot->slots ?? [])
+                    : ($bookingProductSlot->slots[$index] ?? []);
             }
+
+            $convertedSlots = isset($availableDays[$index])
+                ? $this->convert24To12Hours($slots)
+                : [];
+
+            $filteredSlots = array_values(array_filter($convertedSlots, function ($slot) use ($minDuration) {
+                if (empty($slot['from']) || empty($slot['to'])) {
+                    return false;
+                }
+
+                $from = strtotime($slot['from']);
+                $to = strtotime($slot['to']);
+
+                return ($to - $from) >= ($minDuration * 60);
+            }));
 
             $slotsByDays[] = [
                 'name' => trans($this->daysOfWeek[$index]),
-                'slots' => in_array($this->daysOfWeek[$index], $availableDays) ? $this->convert24To12Hours($slots) : [],
+                'slots' => $filteredSlots,
             ];
         }
 


### PR DESCRIPTION
## Issue Reference

Fixed #10902 

## Description

Refactored `getWeekSlotDurations` for better readability and cleaner structure by extracting helper methods. No functional changes.

## How To Test This?

* Verify weekly slots display correctly
* Ensure short/invalid slots are filtered
* Confirm behavior remains unchanged
