### PR TITLE
Fixed issue #10739

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/catalog/products/edit/types/booking/default.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/products/edit/types/booking/default.blade.php
@@ -631,9 +631,14 @@
 
                 slotType() {
                     if (this.default_booking.booking_type == 'one') {
-                        this.slots['one'] = [];
-                    } else {
                         this.slots['many'] = [[], [], [], [], [], [], []];
+
+                        this.selectedStatus = [];
+
+                        this.default_booking.duration = null;
+                        this.default_booking.break_time = null;
+                    } else {
+                        this.slots['one'] = [];
                     }
 
                     this.optionRowCount = 0;

--- a/packages/Webkul/BookingProduct/src/Repositories/BookingProductRepository.php
+++ b/packages/Webkul/BookingProduct/src/Repositories/BookingProductRepository.php
@@ -51,6 +51,8 @@ class BookingProductRepository extends Repository
      */
     public function create(array $data)
     {
+        $data = $this->sanitizeTypeSpecificData($data);
+
         if (isset($data['slots'])) {
             $data['slots'] = $this->validateSlots($data);
         }
@@ -75,6 +77,8 @@ class BookingProductRepository extends Repository
      */
     public function update(array $data, $id, $attribute = 'id')
     {
+        $data = $this->sanitizeTypeSpecificData($data);
+
         if (isset($data['slots'])) {
             $data['slots'] = $this->skipOverLappingSlots($data['slots']);
         }
@@ -108,6 +112,24 @@ class BookingProductRepository extends Repository
                 $this->typeRepositories[$data['type']]->update($data, $bookingProductTypeSlot->id);
             }
         }
+    }
+
+    /**
+     * Normalize type-specific fields so stale values do not survive mode switches.
+     */
+    protected function sanitizeTypeSpecificData(array $data): array
+    {
+        if (
+            ($data['type'] ?? null) !== 'default'
+            || ($data['booking_type'] ?? null) !== 'one'
+        ) {
+            return $data;
+        }
+
+        $data['duration'] = null;
+        $data['break_time'] = null;
+
+        return $data;
     }
 
     /**

--- a/packages/Webkul/Shop/src/Resources/views/products/view/types/booking/default.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/products/view/types/booking/default.blade.php
@@ -1,5 +1,8 @@
 <div class="grid grid-cols-1 gap-6">
-    @if ($bookingProduct['default_slot']['duration'])
+    @if (
+        ($bookingProduct['default_slot']['booking_type'] ?? null) === 'many'
+        && $bookingProduct['default_slot']['duration']
+    )
         <div class="flex gap-3">
             <span class="icon-calendar text-2xl"></span>
 


### PR DESCRIPTION
## Issue Reference

Fixed #10739

## Description

Fixed issue where old "many booking" data was not cleared when switching to "one booking", causing incorrect display on product view page.

## How To Test This?

Switch booking type (many → one) and save
Verify old slot/duration data is removed and display is correct.