### PR TITLE
Fixed issue #10697

### DIFF
--- a/packages/Webkul/BookingProduct/src/Helpers/Booking.php
+++ b/packages/Webkul/BookingProduct/src/Helpers/Booking.php
@@ -145,6 +145,25 @@ class Booking
     }
 
     /**
+     * Returns the booking-specific slot availability error message.
+     */
+    public function getSlotAvailabilityErrorMessage(array $cartProducts): string
+    {
+        foreach ($cartProducts as $cartProduct) {
+            if ($this->isSlotExpired($cartProduct)) {
+                return trans('shop::app.products.view.type.booking.slots.no-slots-available');
+            }
+
+            if (! $this->isItemHaveQuantity($cartProduct)) {
+                return trans('shop::app.products.booking.cart.integrity.inventory_warning');
+            }
+        }
+
+        return trans('shop::app.products.booking.cart.integrity.inventory_warning');
+    }
+
+
+    /**
      * Returns slots for a particular day.
      *
      * @param  BookingProduct  $bookingProduct

--- a/packages/Webkul/Product/src/Type/Booking.php
+++ b/packages/Webkul/Product/src/Type/Booking.php
@@ -217,7 +217,7 @@ class Booking extends AbstractType
         $typeHelper = app($this->bookingHelper->getTypeHelper($bookingProduct->type));
 
         if (! $typeHelper->isSlotAvailable($products)) {
-            throw new InsufficientProductInventoryException(trans('shop::app.products.booking.cart.integrity.inventory_warning'));
+            throw new InsufficientProductInventoryException($typeHelper->getSlotAvailabilityErrorMessage($products));
         }
 
         $products = $typeHelper->addAdditionalPrices($products);


### PR DESCRIPTION
##Issue Reference

Fixes Issue #10697

##Description

Fixed issue where incorrect or missing alert message was shown when rental product is unavailable. Now displays the correct availability alert.

## How To Test This?
Open a rental product with no availability
Verify correct alert message is displayed
