### PR TITLE
Fixed issue #11239

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Sales/BookingDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Sales/BookingDataGrid.php
@@ -71,7 +71,7 @@ class BookingDataGrid extends DataGrid
             'filterable' => true,
             'filterable_type' => 'datetime_range',
             'closure' => function ($value) {
-                return Carbon::createFromTimestamp($value->from)->format('d M, Y H:iA');
+                return Carbon::createFromTimestamp($value->from)->format('d M, Y h:i A');
             },
         ]);
 
@@ -84,7 +84,7 @@ class BookingDataGrid extends DataGrid
             'filterable' => true,
             'filterable_type' => 'datetime_range',
             'closure' => function ($value) {
-                return Carbon::createFromTimestamp($value->to)->format('d M, Y H:iA');
+                return Carbon::createFromTimestamp($value->to)->format('d M, Y h:i A');
             },
         ]);
 

--- a/packages/Webkul/Admin/src/Http/Controllers/Sales/BookingController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Sales/BookingController.php
@@ -53,9 +53,13 @@ class BookingController extends Controller
 
         $bookings = $this->bookingRepository->getBookings([Carbon::parse($startDate)->timestamp, Carbon::parse($endDate)->timestamp])
             ->map(function ($booking) {
-                $booking['start'] = Carbon::createFromTimestamp($booking->start)->format('Y-m-d h:i A');
+                $booking['start'] = Carbon::createFromTimestampUTC($booking->start)
+                    ->setTimezone(config('app.timezone'))
+                    ->format('Y-m-d h:i A');
 
-                $booking['end'] = Carbon::createFromTimestamp($booking->end)->format('Y-m-d h:i A');
+                $booking['end'] = Carbon::createFromTimestampUTC($booking->end)
+                    ->setTimezone(config('app.timezone'))
+                    ->format('Y-m-d h:i A');
 
                 $booking->total = core()->formatBasePrice($booking->total);
 

--- a/packages/Webkul/BookingProduct/src/Helpers/Booking.php
+++ b/packages/Webkul/BookingProduct/src/Helpers/Booking.php
@@ -631,11 +631,15 @@ class Booking
             [
                 'attribute_name' => trans('shop::app.products.booking.cart.booking-from'),
                 'option_id' => 0,
-                'option_label' => Carbon::createFromTimestamp($timestamps[0])->isoFormat('Do MMM, YYYY h:mm A'),
+                'option_label' => Carbon::createFromTimestampUTC((int) $timestamps[0])
+                    ->setTimezone(config('app.timezone'))
+                    ->isoFormat('Do MMM, YYYY h:mm A'),
             ], [
                 'attribute_name' => trans('shop::app.products.booking.cart.booking-till'),
                 'option_id' => 0,
-                'option_label' => Carbon::createFromTimestamp($timestamps[1])->isoFormat('Do MMM, YYYY h:mm A'),
+                'option_label' => Carbon::createFromTimestampUTC((int) $timestamps[1])
+                    ->setTimezone(config('app.timezone'))
+                    ->isoFormat('Do MMM, YYYY h:mm A'),
             ],
         ];
 
@@ -661,11 +665,15 @@ class Booking
             [
                 'attribute_name' => trans('shop::app.products.booking.cart.booking-from'),
                 'option_id' => 0,
-                'option_label' => Carbon::createFromTimestamp($timestamps[0])->format('d F, Y h:i A'),
+                'option_label' => Carbon::createFromTimestampUTC((int) $timestamps[0])
+                    ->setTimezone(config('app.timezone'))
+                    ->format('d F, Y h:i A'),
             ], [
                 'attribute_name' => trans('shop::app.products.booking.cart.booking-till'),
                 'option_id' => 0,
-                'option_label' => Carbon::createFromTimestamp($timestamps[1])->format('d F, Y h:i A'),
+                'option_label' => Carbon::createFromTimestampUTC((int) $timestamps[1])
+                    ->setTimezone(config('app.timezone'))
+                    ->format('d F, Y h:i A'),
             ],
         ];
     }

--- a/packages/Webkul/BookingProduct/src/Repositories/BookingRepository.php
+++ b/packages/Webkul/BookingProduct/src/Repositories/BookingRepository.php
@@ -55,6 +55,9 @@ class BookingRepository extends Repository
                 $to = Carbon::createFromTimeString($bookingItem['date_to'].' 23:59:59')->getTimestamp();
             }
 
+            $from = is_numeric($from) ? (int) $from : null;
+            $to = is_numeric($to) ? (int) $to : null;
+
             $booking = parent::create([
                 'qty' => $item->qty_ordered,
                 'from' => $from,


### PR DESCRIPTION
##Issue Reference
Fixed Issue => 11239

$$Description
This change ensures default booking orders show the exact slot time selected by the customer during checkout. Instead of rebuilding the displayed time only from stored timestamps, the selected slot from and to values are now passed from the storefront and used while saving booking order attributes.

$$How To Test This?
Create or edit a default booking product with slots.
On the storefront, select a date and slot.
Place an order.
Check the order in customer account and admin.
Verify Booking From and Booking Till match the selected slot exactly.