### PR TITLE
fix: prevent exception when reordering after customer deletion

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Sales/OrderController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Sales/OrderController.php
@@ -139,6 +139,12 @@ class OrderController extends Controller
     {
         $order = $this->orderRepository->findOrFail($id);
 
+        if (! $order->customer) {
+            session()->flash('error', trans('admin::app.sales.orders.view.reorder-customer-deleted'));
+
+            return redirect()->back();
+        }
+
         $cart = Cart::createCart([
             'customer' => $order->customer,
             'is_active' => false,

--- a/packages/Webkul/Admin/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en/app.php
@@ -392,6 +392,7 @@ return [
                 'cancel' => 'Cancel',
                 'cancel-msg' => 'Are your sure you want to cancel this order',
                 'cancel-success' => 'Order cancelled successfully',
+                'reorder-customer-deleted' => 'Cannot reorder because the customer account has been deleted.',
                 'canceled' => 'Canceled',
                 'channel' => 'Channel',
                 'closed' => 'Closed',


### PR DESCRIPTION
## Summary

Fixes #11242

When a customer places an order and the admin later deletes the customer account, attempting to reorder throws an exception: `Attempt to read property "addresses" on null`.

### Root Cause

In `OrderController::reorder()`, `$order->customer` returns `null` when the customer has been deleted (soft-deleted or hard-deleted). This null value is passed to `Cart::createCart()`, and downstream code tries to access `->addresses` on the null customer object.

### Fix

Added a null check for `$order->customer` at the start of the `reorder()` method. If the customer no longer exists, the admin is redirected back with an error flash message instead of proceeding with cart creation.

### Files Changed

- `packages/Webkul/Admin/src/Http/Controllers/Sales/OrderController.php` -- Guard clause in `reorder()` method
- `packages/Webkul/Admin/src/Resources/lang/en/app.php` -- Added `reorder-customer-deleted` translation key

## Test Plan

1. Create a customer and place an order
2. Cancel the order from admin panel
3. Delete the customer account
4. Click "Reorder" on the order -- should show error message instead of exception
