### PR TITLE
fix: use Storage::url() for theme carousel image path

### DIFF
--- a/packages/Webkul/Theme/src/Repositories/ThemeCustomizationRepository.php
+++ b/packages/Webkul/Theme/src/Repositories/ThemeCustomizationRepository.php
@@ -114,7 +114,7 @@ class ThemeCustomizationRepository extends Repository
                 }
 
                 $options['images'][] = [
-                    'image' => 'storage/'.$path,
+                    'image' => Storage::url($path),
                     'link' => $image['link'],
                     'title' => $image['title'],
                 ];


### PR DESCRIPTION
## Summary

Fixes #10816

The theme carousel image path is hardcoded as `'storage/'.$path` which breaks when using non-local filesystem disks like S3.

### Root Cause

In `ThemeCustomizationRepository`, the carousel image path is constructed by prefixing `'storage/'` to the path string (line 117). This only works for the local disk. When S3 or other cloud storage is configured, the URL format is completely different.

### Fix

Replaced `'storage/'.$path` with `Storage::url($path)` which resolves the correct URL regardless of the configured filesystem disk. This is consistent with how `static_content` images are already handled in the same method (line 113).

### Files Changed

- `packages/Webkul/Theme/src/Repositories/ThemeCustomizationRepository.php` -- 1 line change

## Test Plan

1. Configure S3 disk storage
2. Go to Admin > Settings > Themes > Edit carousel
3. Add a carousel image and save
4. Verify the image URL uses the correct storage path (S3 URL, not `storage/...`)
5. Verify carousel images display correctly on the storefront
