### PR TITLE
fix: prevent ISE when adding duplicate customer group discount on product

### DIFF
--- a/packages/Webkul/Product/src/Repositories/ProductCustomerGroupPriceRepository.php
+++ b/packages/Webkul/Product/src/Repositories/ProductCustomerGroupPriceRepository.php
@@ -25,6 +25,8 @@ class ProductCustomerGroupPriceRepository extends Repository
         $previousCustomerGroupPriceIds = $product->customer_group_prices()->pluck('id');
 
         if (isset($data['customer_group_prices'])) {
+            $processedUniqueIds = [];
+
             foreach ($data['customer_group_prices'] as $customerGroupPriceId => $row) {
                 $row['customer_group_id'] = $row['customer_group_id'] == '' ? null : $row['customer_group_id'];
 
@@ -33,6 +35,12 @@ class ProductCustomerGroupPriceRepository extends Repository
                     $product->id,
                     $row['customer_group_id'],
                 ]));
+
+                if (in_array($row['unique_id'], $processedUniqueIds)) {
+                    continue;
+                }
+
+                $processedUniqueIds[] = $row['unique_id'];
 
                 if (Str::contains($customerGroupPriceId, 'price_')) {
                     $this->create(array_merge([


### PR DESCRIPTION
## Summary

Fixes #10976

When applying the same customer group discount twice on a product, the system throws an Internal Server Error (500 ISE) due to a unique constraint violation on the `unique_id` column in the `product_customer_group_prices` table.

### Root Cause

The `saveCustomerGroupPrices` method in `ProductCustomerGroupPriceRepository` builds a `unique_id` from `qty|product_id|customer_group_id` and inserts it directly. When a user adds duplicate discounts for the same customer group with the same quantity, the database rejects the duplicate `unique_id`, causing an unhandled exception.

### Fix

Added a `$processedUniqueIds` array to track which combinations have already been processed during the save loop. Duplicate entries are silently skipped with `continue`, preventing the unique constraint violation from ever reaching the database layer.

### Files Changed

- `packages/Webkul/Product/src/Repositories/ProductCustomerGroupPriceRepository.php` -- duplicate detection in `saveCustomerGroupPrices()`

## Test Plan

1. Go to Catalog > Products > Edit any product
2. Navigate to "Customer Group Price" section
3. Add a discount for "Guest" customer group
4. Add another discount for the same "Guest" customer group with the same quantity
5. Click Save Product
6. Verify no 500 error -- the duplicate entry is silently ignored
