### PR TITLE
fix: exclude pending invoices from Total Paid calculation

### DIFF
--- a/packages/Webkul/Sales/src/Repositories/OrderRepository.php
+++ b/packages/Webkul/Sales/src/Repositories/OrderRepository.php
@@ -351,6 +351,10 @@ class OrderRepository extends Repository
         $order->discount_invoiced = $order->base_discount_invoiced = 0;
 
         foreach ($order->invoices as $invoice) {
+            if ($invoice->state === 'pending') {
+                continue;
+            }
+
             $order->sub_total_invoiced += $invoice->sub_total;
             $order->base_sub_total_invoiced += $invoice->base_sub_total;
 


### PR DESCRIPTION
## Description

Fixes #10778

When "Automatically generate the invoice after placing an order" is enabled with invoice state set to "Pending", the order's "Total Paid" incorrectly shows the full order amount instead of 0.

## Root Cause

`OrderRepository::collectTotals()` sums all invoices into `grand_total_invoiced` regardless of their state. Since the admin and shop views both display `grand_total_invoiced` as "Total Paid", pending invoices inflate this total even though no payment has been received.

## Fix

Skip invoices with `state === 'pending'` in the `collectTotals()` loop. Only paid invoices contribute to the invoiced totals. When the invoice transitions from pending to paid, `collectTotals()` will be called again and the paid invoice will then be included.

## Steps to Verify

1. Enable "Automatically generate invoice after placing an order" in admin settings
2. Set invoice state to "Pending" and order status to "Pending Payment" for Money Transfer
3. Place an order using Money Transfer payment
4. Check order details -- "Total Paid" should show 0.00
5. Manually mark the invoice as paid
6. Check order details -- "Total Paid" should now show the full amount
