### PR TITLE
fix: reset state field when country changes during checkout

### DIFF
--- a/packages/Webkul/Shop/src/Resources/views/checkout/onepage/address/form.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/checkout/onepage/address/form.blade.php
@@ -340,6 +340,14 @@
                 },
             },
 
+            watch: {
+                selectedCountry(newCountry, oldCountry) {
+                    if (newCountry !== oldCountry) {
+                        this.address.state = '';
+                    }
+                },
+            },
+
             mounted() {
                 this.getCountries();
 


### PR DESCRIPTION
Fixes #10842

## Problem

When a customer fills the shipping/billing address during checkout, selects a country (e.g. United States) and state (e.g. California), then changes the country to another (e.g. India), the previously selected state value (CA) is preserved in the form data. This allows the order to be placed with a mismatched state/country combination, causing data inconsistency in order records.

## Root Cause

The `v-checkout-address-form` Vue component binds `selectedCountry` via `v-model` but has no watcher to reset `address.state` when the country changes. While the state dropdown options update correctly (showing states for the new country), the underlying `address.state` value from the previous selection persists.

## Fix

Added a `watch` block on `selectedCountry` that clears `address.state` to an empty string whenever the country selection changes. This forces the customer to select a valid state for the new country before proceeding.

## Files Changed

- `packages/Webkul/Shop/src/Resources/views/checkout/onepage/address/form.blade.php` -- added 8 lines (watcher)

## Testing

1. Go to checkout
2. Select country (e.g. United States), select state (e.g. California)
3. Change country to India
4. Verify state field is cleared and must be re-selected
5. Verify the order can only be placed with a valid state for the selected country

Made with [Cursor](https://cursor.com)