### PR TITLE
fix: use Storage::url() for carousel image path

### DIFF
--- a/packages/Webkul/Theme/src/Repositories/ThemeCustomizationRepository.php
+++ b/packages/Webkul/Theme/src/Repositories/ThemeCustomizationRepository.php
@@ -114,7 +114,7 @@ class ThemeCustomizationRepository extends Repository
                 }
 
                 $options['images'][] = [
-                    'image' => 'storage/'.$path,
+                    'image' => Storage::url($path),
                     'link' => $image['link'],
                     'title' => $image['title'],
                 ];


### PR DESCRIPTION
## Summary

- Replace hardcoded `'storage/'` prefix with `Storage::url()` for carousel image paths in `ThemeCustomizationRepository`  
- This ensures correct URLs when using non-local filesystem disks (S3, GCS, etc.)

Fixes #10816

## Changes

`packages/Webkul/Theme/src/Repositories/ThemeCustomizationRepository.php` (line 117):

```diff
- 'image' => 'storage/'.\,
+ 'image' => Storage::url(\),
```

The `static_content` branch (line 113) already uses `Storage::url()` correctly. This aligns carousel image handling with the same pattern.