### PR TITLE
fix: initialize multiselect form value from pre-selected options

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/catalog/products/edit/controls.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/products/edit/controls.blade.php
@@ -135,6 +135,7 @@
             :id="$attribute->code . '[]'"
             :name="$attribute->code . '[]'"
             ::rules="{{ $attribute->validations }}"
+            :value="json_encode(array_map('strval', array_filter($selectedOption)))"
             :label="$attribute->admin_name"
         >
             @foreach ($attribute->options()->orderBy('sort_order')->get() as $option)


### PR DESCRIPTION
## Summary

Fixes #10963

The multiselect attribute on the product edit page did not pass its pre-selected values to VeeValidate's `v-field` component. When saving the product without interacting with the multiselect, the form treated it as empty and triggered required validation.

## Root Cause

The `v-field` component requires a `:value` prop to initialize its internal form state. The `select` type already passes this, but the `multiselect` case in `controls.blade.php` relied solely on `<option selected>` attributes, which VeeValidate ignores when managing form state.

## Fix

Pass the pre-selected option IDs as a JSON array via `:value` to the multiselect component. `array_filter` removes empty strings from the `explode` when no values exist, and `array_map('strval', ...)` ensures IDs are strings to match `<option>` values.

## Steps to Verify

1. Create a multiselect attribute with 'required' enabled and assign to a product
2. Edit a product, select multiselect options, and save
3. Re-open the same product edit page
4. Save again **without** interacting with the multiselect
5. The product should save without a required validation error