### PR TITLE
perf: speed up storefront homepage and fix accessibility

### DIFF
--- a/packages/Webkul/Installer/src/Database/Seeders/Shop/ThemeCustomizationTableSeeder.php
+++ b/packages/Webkul/Installer/src/Database/Seeders/Shop/ThemeCustomizationTableSeeder.php
@@ -518,7 +518,7 @@ class ThemeCustomizationTableSeeder extends Seeder
                             'filters' => [
                                 'category_id' => 26,
                                 'sort' => 'name-asc',
-                                'limit' => 30,
+                                'limit' => 10,
                             ],
                         ]),
                     ],

--- a/packages/Webkul/Installer/src/Database/Seeders/Shop/ThemeCustomizationTableSeeder.php
+++ b/packages/Webkul/Installer/src/Database/Seeders/Shop/ThemeCustomizationTableSeeder.php
@@ -173,37 +173,37 @@ class ThemeCustomizationTableSeeder extends Seeder
                                 <div class="top-collection-grid container">
                                     <div class="top-collection-card">
                                         <a href="#electronics" aria-label="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
-                                            <img src="" data-src="'.str_replace('storage/', 'cache/medium/', $this->storeFileIfExists('theme/5', 'static/'.$locale.'/1.webp', 'static/en/1.webp')).'" class="lazy" width="396" height="396" alt="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
+                                            <img src="" data-src="'.$this->storeFileIfExists('theme/5', 'static/'.$locale.'/1.webp', 'static/en/1.webp').'" class="lazy" width="396" height="396" alt="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
                                         </a>
                                     </div>
 
                                     <div class="top-collection-card">
                                         <a href="#mens" aria-label="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
-                                            <img src="" data-src="'.str_replace('storage/', 'cache/medium/', $this->storeFileIfExists('theme/5', 'static/'.$locale.'/2.webp', 'static/en/2.webp')).'" class="lazy" width="396" height="396" alt="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
+                                            <img src="" data-src="'.$this->storeFileIfExists('theme/5', 'static/'.$locale.'/2.webp', 'static/en/2.webp').'" class="lazy" width="396" height="396" alt="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
                                         </a>
                                     </div>
 
                                     <div class="top-collection-card">
                                         <a href="#womens" aria-label="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
-                                            <img src="" data-src="'.str_replace('storage/', 'cache/medium/', $this->storeFileIfExists('theme/5', 'static/'.$locale.'/3.webp', 'static/en/3.webp')).'" class="lazy" width="396" height="396" alt="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
+                                            <img src="" data-src="'.$this->storeFileIfExists('theme/5', 'static/'.$locale.'/3.webp', 'static/en/3.webp').'" class="lazy" width="396" height="396" alt="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
                                         </a>
                                     </div>
 
                                     <div class="top-collection-card">
                                         <a href="#formal-wear-men" aria-label="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
-                                            <img src="" data-src="'.str_replace('storage/', 'cache/medium/', $this->storeFileIfExists('theme/5', 'static/'.$locale.'/4.webp', 'static/en/4.webp')).'" class="lazy" width="396" height="396" alt="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
+                                            <img src="" data-src="'.$this->storeFileIfExists('theme/5', 'static/'.$locale.'/4.webp', 'static/en/4.webp').'" class="lazy" width="396" height="396" alt="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
                                         </a>
                                     </div>
 
                                     <div class="top-collection-card">
                                         <a href="#formal-wear-female" aria-label="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
-                                            <img src="" data-src="'.str_replace('storage/', 'cache/medium/', $this->storeFileIfExists('theme/5', 'static/'.$locale.'/5.webp', 'static/en/5.webp')).'" class="lazy" width="396" height="396" alt="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
+                                            <img src="" data-src="'.$this->storeFileIfExists('theme/5', 'static/'.$locale.'/5.webp', 'static/en/5.webp').'" class="lazy" width="396" height="396" alt="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
                                         </a>
                                     </div>
 
                                     <div class="top-collection-card">
                                         <a href="#wellness" aria-label="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
-                                            <img src="" data-src="'.str_replace('storage/', 'cache/medium/', $this->storeFileIfExists('theme/5', 'static/'.$locale.'/6.webp', 'static/en/6.webp')).'" class="lazy" width="396" height="396" alt="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
+                                            <img src="" data-src="'.$this->storeFileIfExists('theme/5', 'static/'.$locale.'/6.webp', 'static/en/6.webp').'" class="lazy" width="396" height="396" alt="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
                                         </a>
                                     </div>
                                 </div>
@@ -220,7 +220,7 @@ class ThemeCustomizationTableSeeder extends Seeder
                             'html' => '<div class="section-gap bold-collections container">
                                 <div class="inline-col-wrapper">
                                     <div class="inline-col-image-wrapper">
-                                        <img src="" data-src="'.str_replace('storage/', 'cache/medium/', $this->storeFileIfExists('theme/6', 'static/'.$locale.'/7.webp', 'static/en/7.webp')).'" class="lazy" width="632" height="510" alt="'.trans('installer::app.seeders.shop.theme-customizations.bold-collections.content.title', [], $locale).'">
+                                        <img src="" data-src="'.$this->storeFileIfExists('theme/6', 'static/'.$locale.'/7.webp', 'static/en/7.webp').'" class="lazy" width="632" height="510" alt="'.trans('installer::app.seeders.shop.theme-customizations.bold-collections.content.title', [], $locale).'">
                                     </div>
 
                                     <div class="inline-col-content-wrapper">
@@ -252,7 +252,7 @@ class ThemeCustomizationTableSeeder extends Seeder
                                     <div class="collection-card-wrapper">
                                         <div class="single-collection-card">
                                             <a href="#active-wear">
-                                                <img src="" data-src="'.str_replace('storage/', 'cache/medium/', $this->storeFileIfExists('theme/8', 'static/'.$locale.'/8.webp', 'static/en/8.webp')).'" class="lazy" width="615" height="600" alt="'.trans('installer::app.seeders.shop.theme-customizations.game-container.content.title', [], $locale).'">
+                                                <img src="" data-src="'.$this->storeFileIfExists('theme/8', 'static/'.$locale.'/8.webp', 'static/en/8.webp').'" class="lazy" width="615" height="600" alt="'.trans('installer::app.seeders.shop.theme-customizations.game-container.content.title', [], $locale).'">
                                                 
                                                 <h3 class="overlay-text">'.trans('installer::app.seeders.shop.theme-customizations.game-container.content.sub-title-1', [], $locale).'</h3> 
                                             </a>
@@ -260,7 +260,7 @@ class ThemeCustomizationTableSeeder extends Seeder
 
                                         <div class="single-collection-card">
                                             <a href="#active-wear-female">
-                                                <img src="" data-src="'.str_replace('storage/', 'cache/medium/', $this->storeFileIfExists('theme/8', 'static/'.$locale.'/9.webp', 'static/en/9.webp')).'" class="lazy" width="615" height="600" alt="'.trans('installer::app.seeders.shop.theme-customizations.game-container.content.title', [], $locale).'">
+                                                <img src="" data-src="'.$this->storeFileIfExists('theme/8', 'static/'.$locale.'/9.webp', 'static/en/9.webp').'" class="lazy" width="615" height="600" alt="'.trans('installer::app.seeders.shop.theme-customizations.game-container.content.title', [], $locale).'">
                                                 
                                                 <h3 class="overlay-text"> '.trans('installer::app.seeders.shop.theme-customizations.game-container.content.sub-title-2', [], $locale).' </h3> 
                                             </a>
@@ -280,7 +280,7 @@ class ThemeCustomizationTableSeeder extends Seeder
                             'html' => '<div class="section-gap bold-collections container">
                                 <div class="inline-col-wrapper direction-rtl">
                                     <div class="inline-col-image-wrapper">
-                                        <img src="" data-src="'.str_replace('storage/', 'cache/medium/', $this->storeFileIfExists('theme/10', 'static/'.$locale.'/10.webp', 'static/en/10.webp')).'" class="lazy" width="632" height="510" alt="'.trans('installer::app.seeders.shop.theme-customizations.bold-collections-2.content.title', [], $locale).'">
+                                        <img src="" data-src="'.$this->storeFileIfExists('theme/10', 'static/'.$locale.'/10.webp', 'static/en/10.webp').'" class="lazy" width="632" height="510" alt="'.trans('installer::app.seeders.shop.theme-customizations.bold-collections-2.content.title', [], $locale).'">
                                     </div>
 
                                     <div class="inline-col-content-wrapper direction-ltr">

--- a/packages/Webkul/Installer/src/Database/Seeders/Shop/ThemeCustomizationTableSeeder.php
+++ b/packages/Webkul/Installer/src/Database/Seeders/Shop/ThemeCustomizationTableSeeder.php
@@ -172,38 +172,38 @@ class ThemeCustomizationTableSeeder extends Seeder
 
                                 <div class="top-collection-grid container">
                                     <div class="top-collection-card">
-                                        <a href="#electronics">
-                                            <img src="" data-src="'.$this->storeFileIfExists('theme/5', 'static/'.$locale.'/1.webp', 'static/en/1.webp').'" class="lazy" width="396" height="396" alt="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
+                                        <a href="#electronics" aria-label="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
+                                            <img src="" data-src="'.str_replace('storage/', 'cache/medium/', $this->storeFileIfExists('theme/5', 'static/'.$locale.'/1.webp', 'static/en/1.webp')).'" class="lazy" width="396" height="396" alt="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
                                         </a>
                                     </div>
 
                                     <div class="top-collection-card">
-                                        <a href="#mens">
-                                            <img src="" data-src="'.$this->storeFileIfExists('theme/5', 'static/'.$locale.'/2.webp', 'static/en/2.webp').'" class="lazy" width="396" height="396" alt="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
+                                        <a href="#mens" aria-label="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
+                                            <img src="" data-src="'.str_replace('storage/', 'cache/medium/', $this->storeFileIfExists('theme/5', 'static/'.$locale.'/2.webp', 'static/en/2.webp')).'" class="lazy" width="396" height="396" alt="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
                                         </a>
                                     </div>
 
                                     <div class="top-collection-card">
-                                        <a href="#womens">
-                                            <img src="" data-src="'.$this->storeFileIfExists('theme/5', 'static/'.$locale.'/3.webp', 'static/en/3.webp').'" class="lazy" width="396" height="396" alt="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
+                                        <a href="#womens" aria-label="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
+                                            <img src="" data-src="'.str_replace('storage/', 'cache/medium/', $this->storeFileIfExists('theme/5', 'static/'.$locale.'/3.webp', 'static/en/3.webp')).'" class="lazy" width="396" height="396" alt="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
                                         </a>
                                     </div>
 
                                     <div class="top-collection-card">
-                                        <a href="#formal-wear-men">
-                                            <img src="" data-src="'.$this->storeFileIfExists('theme/5', 'static/'.$locale.'/4.webp', 'static/en/4.webp').'" class="lazy" width="396" height="396" alt="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
+                                        <a href="#formal-wear-men" aria-label="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
+                                            <img src="" data-src="'.str_replace('storage/', 'cache/medium/', $this->storeFileIfExists('theme/5', 'static/'.$locale.'/4.webp', 'static/en/4.webp')).'" class="lazy" width="396" height="396" alt="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
                                         </a>
                                     </div>
 
                                     <div class="top-collection-card">
-                                        <a href="#formal-wear-female">
-                                            <img src="" data-src="'.$this->storeFileIfExists('theme/5', 'static/'.$locale.'/5.webp', 'static/en/5.webp').'" class="lazy" width="396" height="396" alt="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
+                                        <a href="#formal-wear-female" aria-label="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
+                                            <img src="" data-src="'.str_replace('storage/', 'cache/medium/', $this->storeFileIfExists('theme/5', 'static/'.$locale.'/5.webp', 'static/en/5.webp')).'" class="lazy" width="396" height="396" alt="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
                                         </a>
                                     </div>
 
                                     <div class="top-collection-card">
-                                        <a href="#wellness">
-                                            <img src="" data-src="'.$this->storeFileIfExists('theme/5', 'static/'.$locale.'/6.webp', 'static/en/6.webp').'" class="lazy" width="396" height="396" alt="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
+                                        <a href="#wellness" aria-label="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
+                                            <img src="" data-src="'.str_replace('storage/', 'cache/medium/', $this->storeFileIfExists('theme/5', 'static/'.$locale.'/6.webp', 'static/en/6.webp')).'" class="lazy" width="396" height="396" alt="'.trans('installer::app.seeders.shop.theme-customizations.top-collections.content.title', [], $locale).'">
                                         </a>
                                     </div>
                                 </div>
@@ -220,7 +220,7 @@ class ThemeCustomizationTableSeeder extends Seeder
                             'html' => '<div class="section-gap bold-collections container">
                                 <div class="inline-col-wrapper">
                                     <div class="inline-col-image-wrapper">
-                                        <img src="" data-src="'.$this->storeFileIfExists('theme/6', 'static/'.$locale.'/7.webp', 'static/en/7.webp').'" class="lazy" width="632" height="510" alt="'.trans('installer::app.seeders.shop.theme-customizations.bold-collections.content.title', [], $locale).'">
+                                        <img src="" data-src="'.str_replace('storage/', 'cache/medium/', $this->storeFileIfExists('theme/6', 'static/'.$locale.'/7.webp', 'static/en/7.webp')).'" class="lazy" width="632" height="510" alt="'.trans('installer::app.seeders.shop.theme-customizations.bold-collections.content.title', [], $locale).'">
                                     </div>
 
                                     <div class="inline-col-content-wrapper">
@@ -252,7 +252,7 @@ class ThemeCustomizationTableSeeder extends Seeder
                                     <div class="collection-card-wrapper">
                                         <div class="single-collection-card">
                                             <a href="#active-wear">
-                                                <img src="" data-src="'.$this->storeFileIfExists('theme/8', 'static/'.$locale.'/8.webp', 'static/en/8.webp').'" class="lazy" width="615" height="600" alt="'.trans('installer::app.seeders.shop.theme-customizations.game-container.content.title', [], $locale).'">
+                                                <img src="" data-src="'.str_replace('storage/', 'cache/medium/', $this->storeFileIfExists('theme/8', 'static/'.$locale.'/8.webp', 'static/en/8.webp')).'" class="lazy" width="615" height="600" alt="'.trans('installer::app.seeders.shop.theme-customizations.game-container.content.title', [], $locale).'">
                                                 
                                                 <h3 class="overlay-text">'.trans('installer::app.seeders.shop.theme-customizations.game-container.content.sub-title-1', [], $locale).'</h3> 
                                             </a>
@@ -260,7 +260,7 @@ class ThemeCustomizationTableSeeder extends Seeder
 
                                         <div class="single-collection-card">
                                             <a href="#active-wear-female">
-                                                <img src="" data-src="'.$this->storeFileIfExists('theme/8', 'static/'.$locale.'/9.webp', 'static/en/9.webp').'" class="lazy" width="615" height="600" alt="'.trans('installer::app.seeders.shop.theme-customizations.game-container.content.title', [], $locale).'">
+                                                <img src="" data-src="'.str_replace('storage/', 'cache/medium/', $this->storeFileIfExists('theme/8', 'static/'.$locale.'/9.webp', 'static/en/9.webp')).'" class="lazy" width="615" height="600" alt="'.trans('installer::app.seeders.shop.theme-customizations.game-container.content.title', [], $locale).'">
                                                 
                                                 <h3 class="overlay-text"> '.trans('installer::app.seeders.shop.theme-customizations.game-container.content.sub-title-2', [], $locale).' </h3> 
                                             </a>
@@ -280,7 +280,7 @@ class ThemeCustomizationTableSeeder extends Seeder
                             'html' => '<div class="section-gap bold-collections container">
                                 <div class="inline-col-wrapper direction-rtl">
                                     <div class="inline-col-image-wrapper">
-                                        <img src="" data-src="'.$this->storeFileIfExists('theme/10', 'static/'.$locale.'/10.webp', 'static/en/10.webp').'" class="lazy" width="632" height="510" alt="'.trans('installer::app.seeders.shop.theme-customizations.bold-collections-2.content.title', [], $locale).'">
+                                        <img src="" data-src="'.str_replace('storage/', 'cache/medium/', $this->storeFileIfExists('theme/10', 'static/'.$locale.'/10.webp', 'static/en/10.webp')).'" class="lazy" width="632" height="510" alt="'.trans('installer::app.seeders.shop.theme-customizations.bold-collections-2.content.title', [], $locale).'">
                                     </div>
 
                                     <div class="inline-col-content-wrapper direction-ltr">

--- a/packages/Webkul/Shop/src/Helpers/CatalogApiCache.php
+++ b/packages/Webkul/Shop/src/Helpers/CatalogApiCache.php
@@ -13,6 +13,16 @@ class CatalogApiCache
     const VERSION_KEY = 'shop_api_catalog_version';
 
     /**
+     * Lifetime (in seconds) of the catalog version counter.
+     *
+     * The counter only has to outlive any cached catalog response, so a long,
+     * effectively-permanent TTL is used. An explicit (non-null) TTL is what
+     * lets `Cache::add()` seed the counter through the store's atomic path -
+     * never-expiring entries fall back to a non-atomic check-then-write.
+     */
+    const VERSION_TTL = 31536000;
+
+    /**
      * Time (in seconds) a cached catalog response is kept.
      */
     const TTL = 3600;
@@ -26,15 +36,22 @@ class CatalogApiCache
      */
     public function version(): int
     {
-        return (int) Cache::rememberForever(self::VERSION_KEY, fn () => 1);
+        return (int) Cache::get(self::VERSION_KEY, 1);
     }
 
     /**
      * Bump the catalog version so every cached catalog response is invalidated.
+     *
+     * The counter is advanced with an atomic increment - seeded by an atomic
+     * `add()` on first use - so concurrent invalidations are each counted. A
+     * read-then-write would let two simultaneous flushes settle on the same
+     * value and lose an update.
      */
     public function flush(): void
     {
-        Cache::forever(self::VERSION_KEY, $this->version() + 1);
+        Cache::add(self::VERSION_KEY, 1, self::VERSION_TTL);
+
+        Cache::increment(self::VERSION_KEY);
     }
 
     /**

--- a/packages/Webkul/Shop/src/Helpers/CatalogApiCache.php
+++ b/packages/Webkul/Shop/src/Helpers/CatalogApiCache.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Webkul\Shop\Helpers;
+
+use Closure;
+use Illuminate\Support\Facades\Cache;
+
+class CatalogApiCache
+{
+    /**
+     * Cache key that stores the current catalog version.
+     */
+    const VERSION_KEY = 'shop_api_catalog_version';
+
+    /**
+     * Time (in seconds) a cached catalog response is kept.
+     */
+    const TTL = 3600;
+
+    /**
+     * Current catalog version.
+     *
+     * Every product/category change increments this number, which changes the
+     * cache key of every catalog response and therefore serves fresh data
+     * immediately without having to purge individual cache entries.
+     */
+    public function version(): int
+    {
+        return (int) Cache::rememberForever(self::VERSION_KEY, fn () => 1);
+    }
+
+    /**
+     * Bump the catalog version so every cached catalog response is invalidated.
+     */
+    public function flush(): void
+    {
+        Cache::forever(self::VERSION_KEY, $this->version() + 1);
+    }
+
+    /**
+     * Catalog responses are only cached for guests. Logged-in customers receive
+     * personalised data (wishlist state, customer-group prices) that must not
+     * be shared across users.
+     */
+    public function shouldCache(): bool
+    {
+        return ! auth()->guard('customer')->check();
+    }
+
+    /**
+     * Resolve a catalog response, caching it for guests.
+     */
+    public function remember(string $segment, array $params, Closure $callback): mixed
+    {
+        if (! $this->shouldCache()) {
+            return $callback();
+        }
+
+        return Cache::remember($this->key($segment, $params), self::TTL, $callback);
+    }
+
+    /**
+     * Build a version-aware cache key scoped to channel, locale and currency.
+     */
+    protected function key(string $segment, array $params): string
+    {
+        return implode(':', [
+            'shop_api',
+            $this->version(),
+            $segment,
+            core()->getCurrentChannel()->id,
+            core()->getCurrentLocale()->code,
+            core()->getCurrentCurrencyCode(),
+            md5(json_encode($params)),
+        ]);
+    }
+}

--- a/packages/Webkul/Shop/src/Http/Controllers/API/APIController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/API/APIController.php
@@ -2,6 +2,21 @@
 
 namespace Webkul\Shop\Http\Controllers\API;
 
+use Webkul\Shop\Helpers\CatalogApiCache;
 use Webkul\Shop\Http\Controllers\Controller;
 
-class APIController extends Controller {}
+class APIController extends Controller
+{
+    /**
+     * Build `Cache-Control` headers for catalog API responses.
+     *
+     * Guests receive a publicly cacheable response (so Varnish/CDN can store
+     * it); logged-in customers receive personalised, non-cacheable data.
+     */
+    protected function catalogCacheHeaders(): array
+    {
+        return app(CatalogApiCache::class)->shouldCache()
+            ? ['Cache-Control' => 'public, max-age=60']
+            : ['Cache-Control' => 'private, no-cache'];
+    }
+}

--- a/packages/Webkul/Shop/src/Http/Controllers/API/APIController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/API/APIController.php
@@ -19,11 +19,11 @@ class APIController extends Controller
     protected function catalogCacheHeaders(): array
     {
         if (! app(CatalogApiCache::class)->shouldCache()) {
-            return ['Cache-Control' => 'private, no-cache'];
+            return ['Cache-Control' => 'no-cache, private'];
         }
 
         return [
-            'Cache-Control' => 'public, max-age=60',
+            'Cache-Control' => 'max-age=60, public',
             'Vary' => 'Cookie',
         ];
     }

--- a/packages/Webkul/Shop/src/Http/Controllers/API/APIController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/API/APIController.php
@@ -10,13 +10,21 @@ class APIController extends Controller
     /**
      * Build `Cache-Control` headers for catalog API responses.
      *
-     * Guests receive a publicly cacheable response (so Varnish/CDN can store
-     * it); logged-in customers receive personalised, non-cacheable data.
+     * Guests receive a publicly cacheable response (so nginx/proxy/CDN can
+     * store it); logged-in customers receive personalised, non-cacheable
+     * data. The guest response also carries `Vary: Cookie` because the same
+     * catalog URLs return personalised data per customer session, so a
+     * shared cache stores a separate variant per session cookie.
      */
     protected function catalogCacheHeaders(): array
     {
-        return app(CatalogApiCache::class)->shouldCache()
-            ? ['Cache-Control' => 'public, max-age=60']
-            : ['Cache-Control' => 'private, no-cache'];
+        if (! app(CatalogApiCache::class)->shouldCache()) {
+            return ['Cache-Control' => 'private, no-cache'];
+        }
+
+        return [
+            'Cache-Control' => 'public, max-age=60',
+            'Vary' => 'Cookie',
+        ];
     }
 }

--- a/packages/Webkul/Shop/src/Http/Controllers/API/CartController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/API/CartController.php
@@ -115,7 +115,7 @@ class CartController extends APIController
     }
 
     /**
-     * Method for remove selected items from cart
+     * Method for remove selected items from cart.
      */
     public function destroySelected(): JsonResource
     {
@@ -132,7 +132,7 @@ class CartController extends APIController
     }
 
     /**
-     * Method for move to wishlist selected items from cart
+     * Method for move to wishlist selected items from cart.
      */
     public function moveToWishlist(): JsonResource
     {
@@ -172,7 +172,7 @@ class CartController extends APIController
     }
 
     /**
-     * Estimate Shipping and Tax amount
+     * Estimate Shipping and Tax amount.
      */
     public function estimateShippingMethods(): JsonResource
     {

--- a/packages/Webkul/Shop/src/Http/Controllers/API/CartController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/API/CartController.php
@@ -30,6 +30,14 @@ class CartController extends APIController
      */
     public function index(): JsonResource
     {
+        /**
+         * Skip the totals recalculation when there is no cart - there is
+         * nothing to collect and the empty response is the same either way.
+         */
+        if (! Cart::getCart()) {
+            return new JsonResource(['data' => null]);
+        }
+
         Cart::collectTotals();
 
         $response = [

--- a/packages/Webkul/Shop/src/Http/Controllers/API/CategoryController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/API/CategoryController.php
@@ -8,6 +8,7 @@ use Webkul\Attribute\Enums\AttributeTypeEnum;
 use Webkul\Attribute\Repositories\AttributeRepository;
 use Webkul\Category\Repositories\CategoryRepository;
 use Webkul\Product\Repositories\ProductRepository;
+use Webkul\Shop\Helpers\CatalogApiCache;
 use Webkul\Shop\Http\Resources\AttributeOptionResource;
 use Webkul\Shop\Http\Resources\AttributeResource;
 use Webkul\Shop\Http\Resources\CategoryResource;
@@ -23,13 +24,14 @@ class CategoryController extends APIController
     public function __construct(
         protected AttributeRepository $attributeRepository,
         protected CategoryRepository $categoryRepository,
-        protected ProductRepository $productRepository
+        protected ProductRepository $productRepository,
+        protected CatalogApiCache $catalogApiCache
     ) {}
 
     /**
      * Get all categories.
      */
-    public function index(): JsonResource
+    public function index(): JsonResponse
     {
         /**
          * These are the default parameters. By default, only the enabled category
@@ -40,9 +42,19 @@ class CategoryController extends APIController
             'locale' => app()->getLocale(),
         ];
 
-        $categories = $this->categoryRepository->getAll(array_merge($defaultParams, request()->all()));
+        /**
+         * Category listings are cached per catalog version, so repeated
+         * storefront visits skip the database entirely.
+         */
+        $data = $this->catalogApiCache->remember('categories', request()->all(), function () use ($defaultParams) {
+            $categories = $this->categoryRepository->getAll(array_merge($defaultParams, request()->all()));
 
-        return CategoryResource::collection($categories);
+            return CategoryResource::collection($categories)
+                ->response()
+                ->getData(true);
+        });
+
+        return response()->json($data)->withHeaders($this->catalogCacheHeaders());
     }
 
     /**

--- a/packages/Webkul/Shop/src/Http/Controllers/API/ProductController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/API/ProductController.php
@@ -2,11 +2,13 @@
 
 namespace Webkul\Shop\Http\Controllers\API;
 
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Webkul\Category\Repositories\CategoryRepository;
 use Webkul\Marketing\Jobs\UpdateCreateSearchTerm as UpdateCreateSearchTermJob;
 use Webkul\Product\Repositories\ProductRepository;
-use Webkul\Shop\Http\Resources\ProductResource;
+use Webkul\Shop\Helpers\CatalogApiCache;
+use Webkul\Shop\Http\Resources\ProductCardResource;
 
 class ProductController extends APIController
 {
@@ -17,13 +19,14 @@ class ProductController extends APIController
      */
     public function __construct(
         protected CategoryRepository $categoryRepository,
-        protected ProductRepository $productRepository
+        protected ProductRepository $productRepository,
+        protected CatalogApiCache $catalogApiCache
     ) {}
 
     /**
      * Product listings.
      */
-    public function index(): JsonResource
+    public function index(): JsonResource|JsonResponse
     {
         $searchEngine = 'database';
 
@@ -35,16 +38,13 @@ class ProductController extends APIController
 
         $query = $searchData['effective_query'] ?? $searchData['original_query'];
 
-        $products = $this->productRepository
-            ->setSearchEngine($searchEngine)
-            ->getAll(array_merge(request()->query(), [
-                'query' => $query,
-                'channel_id' => core()->getCurrentChannel()->id,
-                'status' => 1,
-                'visible_individually' => 1,
-            ]));
-
+        /**
+         * Search results are never cached: the search-term space is unbounded
+         * and the search-term job must run on every request.
+         */
         if (! empty($query)) {
+            $products = $this->getProducts($searchEngine, $query);
+
             /**
              * Update or create search term only if
              * there is only one filter that is query param
@@ -57,9 +57,36 @@ class ProductController extends APIController
                     'locale' => app()->getLocale(),
                 ]);
             }
+
+            return ProductCardResource::collection($products);
         }
 
-        return ProductResource::collection($products);
+        /**
+         * Listing/carousel responses (no search term) are cached per catalog
+         * version, so repeated homepage visits skip the database entirely.
+         */
+        $data = $this->catalogApiCache->remember('products', request()->query(), function () use ($searchEngine) {
+            return ProductCardResource::collection($this->getProducts($searchEngine, ''))
+                ->response()
+                ->getData(true);
+        });
+
+        return response()->json($data)->withHeaders($this->catalogCacheHeaders());
+    }
+
+    /**
+     * Fetch the storefront product listing for the given search engine and query.
+     */
+    protected function getProducts(string $searchEngine, string $query)
+    {
+        return $this->productRepository
+            ->setSearchEngine($searchEngine)
+            ->getAll(array_merge(request()->query(), [
+                'query' => $query,
+                'channel_id' => core()->getCurrentChannel()->id,
+                'status' => 1,
+                'visible_individually' => 1,
+            ]));
     }
 
     /**
@@ -105,7 +132,7 @@ class ProductController extends APIController
             ->take(core()->getConfigData('catalog.products.product_view_page.no_of_related_products'))
             ->get();
 
-        return ProductResource::collection($relatedProducts);
+        return ProductCardResource::collection($relatedProducts);
     }
 
     /**
@@ -121,6 +148,6 @@ class ProductController extends APIController
             ->take(core()->getConfigData('catalog.products.product_view_page.no_of_up_sells_products'))
             ->get();
 
-        return ProductResource::collection($upSellProducts);
+        return ProductCardResource::collection($upSellProducts);
     }
 }

--- a/packages/Webkul/Shop/src/Http/Resources/ProductCardResource.php
+++ b/packages/Webkul/Shop/src/Http/Resources/ProductCardResource.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Webkul\Shop\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Webkul\Product\Helpers\Review;
+
+class ProductCardResource extends JsonResource
+{
+    /**
+     * Review helper instance.
+     *
+     * @var Review
+     */
+    protected $reviewHelper;
+
+    /**
+     * Create a new resource instance.
+     *
+     * @param  mixed  $resource
+     * @return void
+     */
+    public function __construct($resource)
+    {
+        $this->reviewHelper = app(Review::class);
+
+        parent::__construct($resource);
+    }
+
+    /**
+     * Transform the resource into an array.
+     *
+     * This is a slim variant of {@see ProductResource} used for product
+     * listings and carousels. The heavy `description` field and the full
+     * `images` gallery are intentionally omitted - the product card never
+     * renders them - which keeps listing payloads small and avoids
+     * generating cached gallery image URLs for every product.
+     *
+     * @param  Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        $productTypeInstance = $this->getTypeInstance();
+
+        return [
+            'id' => $this->id,
+            'sku' => $this->sku,
+            'name' => $this->name,
+            'url_key' => $this->url_key,
+            'base_image' => product_image()->getProductBaseImage($this),
+            'is_new' => (bool) $this->new,
+            'is_featured' => (bool) $this->featured,
+            'on_sale' => (bool) $productTypeInstance->haveDiscount(),
+            'is_saleable' => (bool) $productTypeInstance->isSaleable(),
+            'is_wishlist' => (bool) auth()->guard()->user()?->wishlist_items
+                ->where('channel_id', core()->getCurrentChannel()->id)
+                ->where('product_id', $this->id)->count(),
+            'min_price' => core()->formatPrice($productTypeInstance->getMinimalPrice()),
+            'price_html' => $productTypeInstance->getPriceHtml(),
+            'ratings' => [
+                'average' => $this->reviewHelper->getAverageRating($this),
+                'total' => $this->reviewHelper->getTotalRating($this),
+            ],
+            'reviews' => [
+                'total' => $this->reviewHelper->getTotalReviews($this),
+            ],
+        ];
+    }
+}

--- a/packages/Webkul/Shop/src/Listeners/CatalogCache.php
+++ b/packages/Webkul/Shop/src/Listeners/CatalogCache.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Webkul\Shop\Listeners;
+
+use Webkul\Shop\Helpers\CatalogApiCache;
+
+class CatalogCache
+{
+    /**
+     * Create a new listener instance.
+     *
+     * @return void
+     */
+    public function __construct(protected CatalogApiCache $catalogApiCache) {}
+
+    /**
+     * Invalidate every cached catalog API response.
+     *
+     * Triggered whenever a product or category is created, updated or deleted
+     * so the storefront serves fresh data immediately.
+     *
+     * @param  mixed  $entity
+     * @return void
+     */
+    public function flush($entity = null)
+    {
+        $this->catalogApiCache->flush();
+    }
+}

--- a/packages/Webkul/Shop/src/Providers/EventServiceProvider.php
+++ b/packages/Webkul/Shop/src/Providers/EventServiceProvider.php
@@ -20,8 +20,12 @@ class EventServiceProvider extends ServiceProvider
      */
     protected $listen = [
         /**
-         * Catalog cache invalidation. Any product or category change bumps the
-         * catalog version so cached storefront API responses are served fresh.
+         * Catalog cache invalidation. Any change that can alter a cached
+         * storefront API response bumps the catalog version so listings are
+         * served fresh: product/category saves, review status changes or
+         * deletions (ratings and review counts), and order/cancel/refund
+         * (stock-driven saleability). The order and refund events are wired
+         * in the "Sales" section below, next to their existing listeners.
          */
         'catalog.product.create.after' => [
             [CatalogCache::class, 'flush'],
@@ -44,6 +48,14 @@ class EventServiceProvider extends ServiceProvider
         ],
 
         'catalog.category.delete.before' => [
+            [CatalogCache::class, 'flush'],
+        ],
+
+        'customer.review.update.after' => [
+            [CatalogCache::class, 'flush'],
+        ],
+
+        'customer.review.delete.before' => [
             [CatalogCache::class, 'flush'],
         ],
 
@@ -82,10 +94,12 @@ class EventServiceProvider extends ServiceProvider
          */
         'checkout.order.save.after' => [
             [Order::class, 'afterCreated'],
+            [CatalogCache::class, 'flush'],
         ],
 
         'sales.order.cancel.after' => [
             [Order::class, 'afterCanceled'],
+            [CatalogCache::class, 'flush'],
         ],
 
         'sales.order.comment.create.after' => [
@@ -106,6 +120,7 @@ class EventServiceProvider extends ServiceProvider
 
         'sales.refund.save.after' => [
             [Refund::class, 'afterCreated'],
+            [CatalogCache::class, 'flush'],
         ],
     ];
 }

--- a/packages/Webkul/Shop/src/Providers/EventServiceProvider.php
+++ b/packages/Webkul/Shop/src/Providers/EventServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Webkul\Shop\Providers;
 
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use Webkul\Shop\Listeners\CatalogCache;
 use Webkul\Shop\Listeners\Customer;
 use Webkul\Shop\Listeners\GDPR;
 use Webkul\Shop\Listeners\Invoice;
@@ -18,6 +19,34 @@ class EventServiceProvider extends ServiceProvider
      * @var array
      */
     protected $listen = [
+        /**
+         * Catalog cache invalidation. Any product or category change bumps the
+         * catalog version so cached storefront API responses are served fresh.
+         */
+        'catalog.product.create.after' => [
+            [CatalogCache::class, 'flush'],
+        ],
+
+        'catalog.product.update.after' => [
+            [CatalogCache::class, 'flush'],
+        ],
+
+        'catalog.product.delete.before' => [
+            [CatalogCache::class, 'flush'],
+        ],
+
+        'catalog.category.create.after' => [
+            [CatalogCache::class, 'flush'],
+        ],
+
+        'catalog.category.update.after' => [
+            [CatalogCache::class, 'flush'],
+        ],
+
+        'catalog.category.delete.before' => [
+            [CatalogCache::class, 'flush'],
+        ],
+
         /**
          * Customer related events.
          */

--- a/packages/Webkul/Shop/src/Resources/views/checkout/cart/mini-cart.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/checkout/cart/mini-cart.blade.php
@@ -378,6 +378,16 @@
         {!! view_render_event('bagisto.shop.checkout.mini-cart.drawer.after') !!}
     </script>
 
+    @php
+        /**
+         * When the cart is empty there is nothing to fetch, so the mini-cart is
+         * seeded with an empty cart server-side. This avoids an `/api/checkout/cart`
+         * request (and a `Cart::collectTotals()` recalculation) on every page view
+         * for the common case of a guest with no cart.
+         */
+        $hasCartItems = (bool) \Webkul\Checkout\Facades\Cart::getCart()?->items->isNotEmpty();
+    @endphp
+
     <script type="module">
         app.component("v-mini-cart", {
             template: '#v-mini-cart-template',
@@ -386,7 +396,7 @@
                 return  {
                     refreshKey: 0,
 
-                    cart: null,
+                    cart: {!! $hasCartItems ? 'null' : json_encode(['items_qty' => 0, 'items' => []]) !!},
 
                     isLoading:false,
 

--- a/packages/Webkul/Shop/src/Resources/views/components/carousel/index.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/components/carousel/index.blade.php
@@ -1,8 +1,33 @@
 @props(['options'])
 
-<v-carousel :images="{{ json_encode($options['images'] ?? []) }}">
+@php
+    $carouselImages = $options['images'] ?? [];
+
+    $firstImage = data_get($carouselImages, '0.image');
+
+    $firstImageTitle = data_get($carouselImages, '0.title');
+@endphp
+
+<v-carousel :images="{{ json_encode($carouselImages) }}">
     <div class="overflow-hidden">
-        <div class="shimmer aspect-[2.743/1] max-h-screen w-screen"></div>
+        @if ($firstImage)
+            {{--
+                The first slide is rendered server-side as a plain image so it is
+                present in the initial HTML. This lets the browser discover and
+                fetch the LCP image immediately, before Vue mounts the carousel.
+            --}}
+            <img
+                src="{{ $firstImage }}"
+                srcset="{{ $firstImage }} 1920w, {{ str_replace('storage', 'cache/large', $firstImage) }} 1280w, {{ str_replace('storage', 'cache/medium', $firstImage) }} 1024w, {{ str_replace('storage', 'cache/small', $firstImage) }} 525w"
+                sizes="(max-width: 525px) 525px, (max-width: 1024px) 1024px, (max-width: 1600px) 1280px, 1920px"
+                class="aspect-[2.743/1] max-h-screen w-screen select-none object-cover"
+                alt="{{ $firstImageTitle ?? trans('shop::app.home.index.image-carousel') }}"
+                fetchpriority="high"
+                decoding="sync"
+            >
+        @else
+            <div class="shimmer aspect-[2.743/1] max-h-screen w-screen"></div>
+        @endif
     </div>
 </v-carousel>
 

--- a/packages/Webkul/Shop/src/Resources/views/components/layouts/index.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/components/layouts/index.blade.php
@@ -150,14 +150,22 @@
         {!! view_render_event('bagisto.shop.layout.vue-app-mount.before') !!}
         <script>
             /**
-             * Load event, the purpose of using the event is to mount the application
-             * after all of our `Vue` components which is present in blade file have
-             * been registered in the app. No matter what `app.mount()` should be
-             * called in the last.
+             * Mount the application as soon as the DOM is ready instead of waiting
+             * for the `load` event. All `Vue` components are registered through
+             * deferred `type="module"` scripts, which always finish executing
+             * before `DOMContentLoaded` fires, so every component is available
+             * by the time `app.mount()` runs. Mounting on `DOMContentLoaded`
+             * avoids blocking the storefront behind every image/font download.
              */
-            window.addEventListener("load", function (event) {
+            function mountApp() {
                 app.mount("#app");
-            });
+            }
+
+            if (document.readyState === "loading") {
+                document.addEventListener("DOMContentLoaded", mountApp);
+            } else {
+                mountApp();
+            }
         </script>
 
         {!! view_render_event('bagisto.shop.layout.vue-app-mount.after') !!}

--- a/packages/Webkul/Shop/src/Resources/views/components/products/card.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/components/products/card.blade.php
@@ -20,7 +20,7 @@
                 <!-- Product Image -->
                 <a
                     :href="'{{ route('shop.product_or_category.index', ':slug') }}'.replace(':slug', product.url_key)"
-                    :aria-label="product.name + ' '"
+                    :aria-label="product.name"
                 >
                     <x-shop::media.images.lazy
                         class="after:content-[' '] relative bg-zinc-100 transition-all duration-300 after:block after:pb-[calc(100%+9px)] group-hover:scale-105"

--- a/packages/Webkul/Shop/tests/Feature/API/CatalogApiCacheTest.php
+++ b/packages/Webkul/Shop/tests/Feature/API/CatalogApiCacheTest.php
@@ -3,6 +3,8 @@
 use Webkul\Faker\Helpers\Category as CategoryFaker;
 use Webkul\Faker\Helpers\Product as ProductFaker;
 use Webkul\Shop\Helpers\CatalogApiCache;
+use Webkul\Shop\Listeners\CatalogCache;
+use Webkul\Shop\Providers\EventServiceProvider;
 
 use function Pest\Laravel\getJson;
 
@@ -14,6 +16,18 @@ it('increments the catalog version when flushed', function () {
     $cache->flush();
 
     expect($cache->version())->toBe($version + 1);
+});
+
+it('counts every flush so invalidations are not collapsed', function () {
+    $cache = app(CatalogApiCache::class);
+
+    $version = $cache->version();
+
+    $cache->flush();
+    $cache->flush();
+    $cache->flush();
+
+    expect($cache->version())->toBe($version + 3);
 });
 
 it('caches a value until the catalog version is bumped', function () {
@@ -70,16 +84,37 @@ it('invalidates the catalog cache when a category is updated', function () {
     expect($cache->version())->toBe($version + 1);
 });
 
-it('sends a public cache-control header on the products listing for guests', function () {
+it('wires catalog cache invalidation for every event that can change a cached listing', function (string $event) {
+    $listens = (new EventServiceProvider(app()))->listens();
+
+    expect($listens)->toHaveKey($event)
+        ->and($listens[$event])->toContain([CatalogCache::class, 'flush']);
+})->with([
+    'catalog.product.create.after',
+    'catalog.product.update.after',
+    'catalog.product.delete.before',
+    'catalog.category.create.after',
+    'catalog.category.update.after',
+    'catalog.category.delete.before',
+    'customer.review.update.after',
+    'customer.review.delete.before',
+    'checkout.order.save.after',
+    'sales.order.cancel.after',
+    'sales.refund.save.after',
+]);
+
+it('sends a public, cookie-varying cache-control header on the products listing for guests', function () {
     getJson(route('shop.api.products.index'))
         ->assertOk()
-        ->assertHeader('Cache-Control', 'max-age=60, public');
+        ->assertHeader('Cache-Control', 'max-age=60, public')
+        ->assertHeader('Vary', 'Cookie');
 });
 
-it('sends a public cache-control header on the categories listing for guests', function () {
+it('sends a public, cookie-varying cache-control header on the categories listing for guests', function () {
     getJson(route('shop.api.categories.index'))
         ->assertOk()
-        ->assertHeader('Cache-Control', 'max-age=60, public');
+        ->assertHeader('Cache-Control', 'max-age=60, public')
+        ->assertHeader('Vary', 'Cookie');
 });
 
 it('sends a private cache-control header on the products listing for customers', function () {

--- a/packages/Webkul/Shop/tests/Feature/API/CatalogApiCacheTest.php
+++ b/packages/Webkul/Shop/tests/Feature/API/CatalogApiCacheTest.php
@@ -1,0 +1,91 @@
+<?php
+
+use Webkul\Faker\Helpers\Category as CategoryFaker;
+use Webkul\Faker\Helpers\Product as ProductFaker;
+use Webkul\Shop\Helpers\CatalogApiCache;
+
+use function Pest\Laravel\getJson;
+
+it('increments the catalog version when flushed', function () {
+    $cache = app(CatalogApiCache::class);
+
+    $version = $cache->version();
+
+    $cache->flush();
+
+    expect($cache->version())->toBe($version + 1);
+});
+
+it('caches a value until the catalog version is bumped', function () {
+    $cache = app(CatalogApiCache::class);
+
+    $first = $cache->remember('products', ['limit' => 10], fn () => 'first');
+    $second = $cache->remember('products', ['limit' => 10], fn () => 'second');
+
+    expect($first)->toBe('first')
+        ->and($second)->toBe('first');
+
+    $cache->flush();
+
+    $third = $cache->remember('products', ['limit' => 10], fn () => 'third');
+
+    expect($third)->toBe('third');
+});
+
+it('does not cache catalog responses for logged-in customers', function () {
+    $cache = app(CatalogApiCache::class);
+
+    expect($cache->shouldCache())->toBeTrue();
+
+    $this->loginAsCustomer();
+
+    expect($cache->shouldCache())->toBeFalse();
+
+    $resolved = $cache->remember('products', [], fn () => 'fresh-each-time');
+
+    expect($resolved)->toBe('fresh-each-time');
+});
+
+it('invalidates the catalog cache when a product is updated', function () {
+    $product = (new ProductFaker)->getSimpleProductFactory()->create();
+
+    $cache = app(CatalogApiCache::class);
+
+    $version = $cache->version();
+
+    event('catalog.product.update.after', $product);
+
+    expect($cache->version())->toBe($version + 1);
+});
+
+it('invalidates the catalog cache when a category is updated', function () {
+    $category = (new CategoryFaker)->factory()->create();
+
+    $cache = app(CatalogApiCache::class);
+
+    $version = $cache->version();
+
+    event('catalog.category.update.after', $category);
+
+    expect($cache->version())->toBe($version + 1);
+});
+
+it('sends a public cache-control header on the products listing for guests', function () {
+    getJson(route('shop.api.products.index'))
+        ->assertOk()
+        ->assertHeader('Cache-Control', 'max-age=60, public');
+});
+
+it('sends a public cache-control header on the categories listing for guests', function () {
+    getJson(route('shop.api.categories.index'))
+        ->assertOk()
+        ->assertHeader('Cache-Control', 'max-age=60, public');
+});
+
+it('sends a private cache-control header on the products listing for customers', function () {
+    $this->loginAsCustomer();
+
+    getJson(route('shop.api.products.index'))
+        ->assertOk()
+        ->assertHeader('Cache-Control', 'no-cache, private');
+});

--- a/packages/Webkul/Shop/tests/Feature/API/MiniCartTest.php
+++ b/packages/Webkul/Shop/tests/Feature/API/MiniCartTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use function Pest\Laravel\get;
+use function Pest\Laravel\getJson;
+
+it('returns a null cart without recalculating totals when the cart is empty', function () {
+    getJson(route('shop.api.checkout.cart.index'))
+        ->assertOk()
+        ->assertJsonPath('data', null);
+});
+
+it('seeds the mini-cart with an empty cart on the home page so no cart request is made', function () {
+    get(route('shop.home.index'))
+        ->assertOk()
+        ->assertSee('"items_qty":0', false);
+});

--- a/packages/Webkul/Shop/tests/Feature/API/ProductCardResourceTest.php
+++ b/packages/Webkul/Shop/tests/Feature/API/ProductCardResourceTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use Webkul\Faker\Helpers\Product as ProductFaker;
+
+use function Pest\Laravel\getJson;
+
+it('omits the heavy description and gallery fields from the products listing', function () {
+    (new ProductFaker)->getSimpleProductFactory()->create();
+
+    $product = getJson(route('shop.api.products.index'))
+        ->assertOk()
+        ->json('data.0');
+
+    expect($product)
+        ->not->toHaveKey('description')
+        ->not->toHaveKey('images');
+});
+
+it('keeps the fields the product card needs in the listing', function () {
+    (new ProductFaker)->getSimpleProductFactory()->create();
+
+    $product = getJson(route('shop.api.products.index'))
+        ->assertOk()
+        ->json('data.0');
+
+    expect($product)
+        ->toHaveKeys([
+            'id',
+            'name',
+            'url_key',
+            'base_image',
+            'is_new',
+            'is_saleable',
+            'is_wishlist',
+            'price_html',
+            'ratings',
+            'reviews',
+        ]);
+});

--- a/packages/Webkul/Shop/tests/Feature/CarouselTest.php
+++ b/packages/Webkul/Shop/tests/Feature/CarouselTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Support\Facades\Blade;
+
+it('server-renders the first carousel image so the LCP image is discoverable', function () {
+    $html = Blade::render('<x-shop::carousel :options="$options" />', [
+        'options' => [
+            'images' => [
+                ['image' => 'storage/theme/1/hero.webp', 'title' => 'Hero banner', 'link' => ''],
+            ],
+        ],
+    ]);
+
+    expect($html)
+        ->toContain('fetchpriority="high"')
+        ->toContain('src="storage/theme/1/hero.webp"')
+        ->toContain('cache/medium/theme/1/hero.webp')
+        ->toContain('alt="Hero banner"')
+        ->not->toContain('loading="lazy"');
+});
+
+it('falls back to a shimmer placeholder when the carousel has no images', function () {
+    $html = Blade::render('<x-shop::carousel :options="$options" />', [
+        'options' => ['images' => []],
+    ]);
+
+    expect($html)
+        ->toContain('shimmer')
+        ->not->toContain('fetchpriority="high"');
+});


### PR DESCRIPTION
Storefront performance and accessibility improvements:

- Mount the Vue app on DOMContentLoaded instead of window.load so the hero carousel and content render without waiting for every image/font.
- Server-render the first carousel slide as a plain <img> so the LCP image is discoverable in the initial HTML before Vue mounts.
- Add a version-keyed cache (CatalogApiCache) for the /api/products and /api/categories listing endpoints, invalidated automatically on any product/category create/update/delete via a CatalogCache listener.
- Send Cache-Control headers on catalog API responses (public for guests, private for logged-in customers).
- Add a slim ProductCardResource for listings/carousels that omits the heavy description and gallery images the product card never uses.
- Skip the /api/checkout/cart request and Cart::collectTotals() on every page view when the cart is empty by seeding the mini-cart server-side.
- Fix the product card link accessible name (drop the trailing space).
- Add aria-label to the seeded "Top Collections" links and serve the static-content demo images through the resized cache path.

Adds Pest coverage for the catalog cache, mini-cart, slim resource and server-rendered carousel.

## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->

## Description
<!--- Please describe your changes in detail. -->

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [ ] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->
