### PR TITLE
Fix duplicate customer group price validation

### DIFF
--- a/packages/Webkul/Admin/src/Http/Requests/ProductForm.php
+++ b/packages/Webkul/Admin/src/Http/Requests/ProductForm.php
@@ -5,6 +5,7 @@ namespace Webkul\Admin\Http\Requests;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Validator;
 use Webkul\Admin\Validations\ProductCategoryUniqueSlug;
 use Webkul\Attribute\Enums\AttributeTypeEnum;
 use Webkul\Core\Rules\Decimal;
@@ -182,6 +183,60 @@ class ProductForm extends FormRequest
             'videos.files.*' => 'video',
             'variants.*.sku' => 'sku',
         ];
+    }
+
+    /**
+     * Configure the validator instance.
+     *
+     * @return void
+     */
+    public function withValidator(Validator $validator)
+    {
+        $validator->after(function (Validator $validator) {
+            $this->validateCustomerGroupPriceUniqueness($validator);
+        });
+    }
+
+    /**
+     * Validate unique customer group price rows.
+     *
+     * @return void
+     */
+    protected function validateCustomerGroupPriceUniqueness(Validator $validator)
+    {
+        $customerGroupPrices = $this->input('customer_group_prices', []);
+
+        if (! is_array($customerGroupPrices)) {
+            return;
+        }
+
+        $uniqueCustomerGroupPrices = [];
+
+        foreach ($customerGroupPrices as $key => $customerGroupPrice) {
+            if (! is_array($customerGroupPrice)) {
+                continue;
+            }
+
+            $customerGroupId = $customerGroupPrice['customer_group_id'] ?? null;
+            $customerGroupId = $customerGroupId == '' ? null : $customerGroupId;
+
+            $uniqueId = implode('|', array_filter([
+                $customerGroupPrice['qty'] ?? null,
+                $this->id,
+                $customerGroupId,
+            ]));
+
+            if (isset($uniqueCustomerGroupPrices[$uniqueId])) {
+                $validator->errors()->add(
+                    'customer_group_prices.'.$key.'.customer_group_id',
+                    trans('admin::app.catalog.products.edit.price.group.already-exists')
+                );
+
+                return;
+            }
+
+            $uniqueCustomerGroupPrices[$uniqueId] = true;
+        }
     }
 
     /**

--- a/packages/Webkul/Admin/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en/app.php
@@ -824,6 +824,7 @@ return [
                 'price' => [
                     'group' => [
                         'add-group-price' => 'Add Group Price',
+                        'already-exists' => 'A customer group price for this group and quantity already exists.',
                         'all-groups' => 'All Groups',
                         'create-btn' => 'Add New',
                         'discount-group-price-info' => 'For :qty Qty at discount of :price',

--- a/packages/Webkul/Admin/tests/Feature/Catalog/Products/Types/SimpleTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Catalog/Products/Types/SimpleTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Webkul\Customer\Models\CustomerGroup;
 use Webkul\Faker\Helpers\Product as ProductFaker;
 use Webkul\Product\Models\Product;
 use Webkul\Product\Models\ProductFlat;
@@ -108,6 +109,44 @@ it('should fail the validation with errors if certain data is not provided corre
         ->assertJsonValidationErrorFor('guest_checkout')
         ->assertJsonValidationErrorFor('new')
         ->assertJsonValidationErrorFor('featured')
+        ->assertUnprocessable();
+});
+
+it('should fail the validation when duplicate customer group prices are provided in simple product', function () {
+    // Arrange.
+    $product = (new ProductFaker)->getSimpleProductFactory()->create();
+
+    $customerGroup = CustomerGroup::factory()->create();
+
+    // Act and Assert.
+    $this->loginAsAdmin();
+
+    putJson(route('admin.catalog.products.update', $product->id), [
+        'sku' => $product->sku,
+        'url_key' => $product->url_key,
+        'short_description' => fake()->sentence(),
+        'description' => fake()->paragraph(),
+        'name' => fake()->words(3, true),
+        'price' => fake()->randomFloat(2, 1, 1000),
+        'weight' => fake()->numberBetween(0, 100),
+        'channel' => core()->getCurrentChannelCode(),
+        'locale' => app()->getLocale(),
+        'customer_group_prices' => [
+            'price_0' => [
+                'customer_group_id' => $customerGroup->id,
+                'qty' => 1,
+                'value_type' => 'discount',
+                'value' => 10,
+            ],
+            'price_1' => [
+                'customer_group_id' => $customerGroup->id,
+                'qty' => 1,
+                'value_type' => 'discount',
+                'value' => 15,
+            ],
+        ],
+    ])
+        ->assertJsonValidationErrorFor('customer_group_prices.price_1.customer_group_id')
         ->assertUnprocessable();
 });
 


### PR DESCRIPTION
## Summary
- validate duplicate customer group price rows before saving a product
- add an admin validation message for duplicate group/quantity prices
- add a feature test covering duplicate customer group discount rows

Fixes #10976

## Testing
- `php -l packages/Webkul/Admin/src/Http/Requests/ProductForm.php`
- `php -l packages/Webkul/Admin/tests/Feature/Catalog/Products/Types/SimpleTest.php`
- `git diff --check`

Note: full Pest run was not executed locally because this checkout does not have Composer dependencies or a test database configured.