### PR TITLE
Fix product multiselect initial values

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/catalog/products/edit/controls.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/products/edit/controls.blade.php
@@ -104,13 +104,16 @@
         @break
     @case('multiselect')
         @php
-            $selectedOption = old($attribute->code) ?: explode(',', $product[$attribute->code]);
+            $selectedOption = old($attribute->code, explode(',', $product[$attribute->code] ?? ''));
+
+            $selectedOption = array_values(array_filter((array) $selectedOption, fn ($option) => $option !== null && $option !== ''));
         @endphp
 
         <x-admin::form.control-group.control
             type="multiselect"
             :id="$attribute->code . '[]'"
             :name="$attribute->code . '[]'"
+            ::value='@json($selectedOption)'
             ::rules="{{ $attribute->validations }}"
             :label="$attribute->admin_name"
         >

--- a/packages/Webkul/Admin/src/Resources/views/components/form/control-group/control.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/form/control-group/control.blade.php
@@ -192,14 +192,19 @@
 
     @case('multiselect')
         <v-field
-            as="select"
-            v-slot="{ value }"
-            :class="[errors && errors['{{ $name }}'] ? 'border !border-red-600 hover:border-red-600' : '']"
-            {{ $attributes->except([])->merge(['class' => 'flex w-full flex-col rounded-md border bg-white px-3 py-2.5 text-sm font-normal text-gray-600 transition-all hover:border-gray-400 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-gray-400']) }}
+            v-slot="{ field, errors }"
+            {{ $attributes->only(['name', ':name', 'value', ':value', 'v-model', 'rules', ':rules', 'label', ':label']) }}
             name="{{ $name }}"
-            multiple
         >
-            {{ $slot }}
+            <select
+                name="{{ $name }}"
+                v-bind="field"
+                :class="[errors.length ? 'border !border-red-600 hover:border-red-600' : '']"
+                multiple
+                {{ $attributes->except(['value', ':value', 'v-model', 'rules', ':rules', 'label', ':label'])->merge(['class' => 'flex w-full flex-col rounded-md border bg-white px-3 py-2.5 text-sm font-normal text-gray-600 transition-all hover:border-gray-400 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-gray-400']) }}
+            >
+                {{ $slot }}
+            </select>
         </v-field>
 
         @break


### PR DESCRIPTION
## Summary
- initialize product edit multiselect attributes with their saved selected option IDs
- bind the admin multiselect control through vee-validate's field object so validation sees existing selections before user interaction
- normalize empty multiselect values to avoid treating an empty saved value as selected

Fixes #10963

## Testing
- `php -l packages/Webkul/Admin/src/Resources/views/catalog/products/edit/controls.blade.php`
- `php -l packages/Webkul/Admin/src/Resources/views/components/form/control-group/control.blade.php`
- `git diff --check`

Note: full browser validation was not run locally because this checkout does not have Composer/NPM dependencies or a configured Bagisto database.