### PR TITLE
Fix theme carousel storage paths

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/settings/themes/edit/image-carousel.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/themes/edit/image-carousel.blade.php
@@ -1,3 +1,26 @@
+@php
+    $sliderOptions = $theme->translate($currentLocale->code)['options'] ?? null;
+
+    if (! empty($sliderOptions['images'])) {
+        $sliderOptions['images'] = collect($sliderOptions['images'])->map(function ($image) {
+            $path = ltrim($image['image'] ?? '', '/');
+
+            if (! \Illuminate\Support\Str::startsWith($path, ['http://', 'https://', '//'])) {
+                $path = \Illuminate\Support\Str::startsWith($path, 'storage/')
+                    ? \Illuminate\Support\Str::after($path, 'storage/')
+                    : $path;
+
+                $image['image'] = $path;
+                $image['image_url'] = \Illuminate\Support\Facades\Storage::url($path);
+            } else {
+                $image['image_url'] = $path;
+            }
+
+            return $image;
+        })->values()->all();
+    }
+@endphp
+
 <v-image-carousel :errors="errors">
     <x-admin::shimmer.settings.themes.image-carousel />
 </v-image-carousel>
@@ -99,7 +122,7 @@
 
                                     <span class="text-gray-600 transition-all dark:text-gray-300">
                                         <a
-                                            :href="'{{ config('app.url') }}/' + image.image"
+                                            :href="image.image_url || image.image"
                                             :ref="'image_' + index"
                                             target="_blank"
                                             class="text-blue-600 transition-all hover:underline ltr:ml-2 rtl:mr-2"
@@ -238,7 +261,7 @@
 
             data() {
                 return {
-                    sliders: @json($theme->translate($currentLocale->code)['options'] ?? null),
+                    sliders: @json($sliderOptions),
 
                     deletedSliders: [],
                 };
@@ -314,4 +337,4 @@
             },
         });
     </script>
-@endPushOnce    
+@endPushOnce

--- a/packages/Webkul/Shop/src/Resources/views/components/carousel/index.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/components/carousel/index.blade.php
@@ -1,6 +1,36 @@
 @props(['options'])
 
-<v-carousel :images="{{ json_encode($options['images'] ?? []) }}">
+@php
+    $carouselImages = collect($options['images'] ?? [])->map(function ($image) {
+        $path = ltrim($image['image'] ?? '', '/');
+
+        if (\Illuminate\Support\Str::startsWith($path, ['http://', 'https://', '//'])) {
+            $image['image'] = $path;
+            $image['srcset'] = $path.' 1920w';
+
+            return $image;
+        }
+
+        $path = \Illuminate\Support\Str::startsWith($path, 'storage/')
+            ? \Illuminate\Support\Str::after($path, 'storage/')
+            : $path;
+
+        $image['image'] = \Illuminate\Support\Facades\Storage::url($path);
+
+        $image['srcset'] = config('filesystems.default') === 'public'
+            ? implode(', ', [
+                \Illuminate\Support\Facades\Storage::url($path).' 1920w',
+                asset('cache/large/'.$path).' 1280w',
+                asset('cache/medium/'.$path).' 1024w',
+                asset('cache/small/'.$path).' 525w',
+            ])
+            : $image['image'].' 1920w';
+
+        return $image;
+    })->values()->all();
+@endphp
+
+<v-carousel :images='@json($carouselImages)'>
     <div class="overflow-hidden">
         <div class="shimmer aspect-[2.743/1] max-h-screen w-screen"></div>
     </div>
@@ -28,7 +58,7 @@
                         class="aspect-[2.743/1] max-h-full w-full max-w-full select-none transition-transform duration-300 ease-in-out will-change-transform"
                         ::lazy="index === 0 ? false : true"
                         ::src="image.image"
-                        ::srcset="image.image + ' 1920w, ' + image.image.replace('storage', 'cache/large') + ' 1280w,' + image.image.replace('storage', 'cache/medium') + ' 1024w, ' + image.image.replace('storage', 'cache/small') + ' 525w'"
+                        ::srcset="image.srcset"
                         ::sizes="
                             '(max-width: 525px) 525px, ' +
                             '(max-width: 1024px) 1024px, ' +

--- a/packages/Webkul/Theme/src/Repositories/ThemeCustomizationRepository.php
+++ b/packages/Webkul/Theme/src/Repositories/ThemeCustomizationRepository.php
@@ -80,7 +80,9 @@ class ThemeCustomizationRepository extends Repository
 
         if (isset($data[$locale]['deleted_sliders'])) {
             foreach ($data[$locale]['deleted_sliders'] as $slider) {
-                Storage::delete(str_replace('storage/', '', $slider['image']));
+                if ($path = $this->getStoragePath($slider['image'] ?? null)) {
+                    Storage::delete($path);
+                }
             }
         }
 
@@ -115,11 +117,13 @@ class ThemeCustomizationRepository extends Repository
                 }
 
                 $options['images'][] = [
-                    'image' => 'storage/'.$path,
+                    'image' => $path,
                     'link' => $image['link'],
                     'title' => $image['title'],
                 ];
             } else {
+                $image['image'] = $this->getStoragePath($image['image'] ?? null);
+
                 $options['images'][] = $image;
             }
         }
@@ -128,5 +132,29 @@ class ThemeCustomizationRepository extends Repository
         $translatedModel->options = $options ?? [];
         $translatedModel->theme_customization_id = $theme->id;
         $translatedModel->save();
+    }
+
+    /**
+     * Get the storage path from a stored image value.
+     */
+    protected function getStoragePath(?string $path): ?string
+    {
+        if (empty($path)) {
+            return $path;
+        }
+
+        $path = ltrim($path, '/');
+
+        $storageUrl = rtrim(Storage::url(''), '/').'/';
+
+        if (Str::startsWith($path, $storageUrl)) {
+            return Str::after($path, $storageUrl);
+        }
+
+        if (Str::startsWith($path, 'storage/')) {
+            return Str::after($path, 'storage/');
+        }
+
+        return $path;
     }
 }


### PR DESCRIPTION
## Summary
- save image carousel uploads as relative storage paths instead of hardcoded `storage/...` values
- normalize legacy `storage/...` image values when deleting or resaving sliders
- render admin and storefront carousel image URLs with `Storage::url()` and keep local cache srcsets only for the public disk

Fixes #10816

## Testing
- `php -l packages/Webkul/Theme/src/Repositories/ThemeCustomizationRepository.php`
- `php -l packages/Webkul/Admin/src/Resources/views/settings/themes/edit/image-carousel.blade.php`
- `php -l packages/Webkul/Shop/src/Resources/views/components/carousel/index.blade.php`
- `git diff --check`

Note: full browser/Laravel test coverage was not run locally because this checkout does not have Composer/NPM dependencies or a configured Bagisto database.