### PR TITLE
Allow richer TinyMCE content in purifier

### DIFF
--- a/config/purify.php
+++ b/config/purify.php
@@ -43,9 +43,10 @@ return [
         'default' => [
             'Core.Encoding' => 'utf-8',
             'HTML.Doctype' => 'HTML 4.01 Transitional',
-            'HTML.Allowed' => 'h1,h2,h3,h4,h5,h6,b,u,strong,i,em,s,del,a[href|title],ul,ol,li,p[style],br,span[style],img[width|height|alt|src],blockquote',
-            'HTML.ForbiddenElements' => '',
-            'CSS.AllowedProperties' => 'font,font-size,font-weight,font-style,font-family,text-decoration,padding-left,color,background-color,text-align',
+            'HTML.Allowed' => 'h1,h2,h3,h4,h5,h6,b,u,strong,i,em,s,del,a[href|title|target|rel],ul,ol,li,p[style|class],br,span[style|class],img[width|height|alt|src|class|loading],blockquote,table[style|class],thead,tbody,tfoot,tr[style|class],th[colspan|rowspan|style|class],td[colspan|rowspan|style|class],div[style|class|id],figure,figcaption,hr,pre,code,dl,dt,dd,sup,sub,mark',
+            'HTML.ForbiddenElements' => 'script,iframe,object,embed,form,input,textarea,select,button',
+            'CSS.AllowedProperties' => 'font,font-size,font-weight,font-style,font-family,text-decoration,padding,margin,color,background-color,text-align,line-height,border,border-collapse,width,height,max-width,min-height,vertical-align,white-space,word-break,overflow,display,float,clear,list-style-type,list-style-position',
+            'Attr.AllowedClasses' => null,
             'AutoFormat.AutoParagraph' => false,
             'AutoFormat.RemoveEmpty' => false,
         ],


### PR DESCRIPTION
## Summary
- expand the default Purify HTML allowlist for TinyMCE-authored rich text
- allow table markup and class/style attributes used by product specs and CMS content
- keep active or risky elements such as script, iframe, object, embed, form, and inputs forbidden

Fixes #11316

## Testing
- `php -l config/purify.php`
- `git diff --check`

Note: full Laravel/Purify runtime tests were not run locally because this checkout does not have Composer dependencies installed.