### PR TITLE
Validate event ticket special price dates

### DIFF
--- a/packages/Webkul/Admin/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en/app.php
@@ -1305,6 +1305,7 @@ return [
                             'overlap-validation' => 'Time slot overlaps with an existing slot.',
                             'slot-window-too-short' => 'One or more slot windows are shorter than the required :duration-minute duration. Each window must span at least :duration minutes.',
                             'slot-window-too-short-field' => 'This window must span at least :duration minutes.',
+                            'special-price-date-range' => 'Ticket special price dates must be within the event booking dates.',
                         ],
                     ],
 

--- a/packages/Webkul/Admin/src/Resources/views/catalog/products/edit/types/booking/event.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/products/edit/types/booking/event.blade.php
@@ -351,22 +351,31 @@
 
             methods: {
                 store(params) {
+                    if (! this.isSpecialPriceDateRangeValid(params)) {
+                        this.$emitter.emit('add-flash', {
+                            type: 'error',
+                            message: "@lang('admin::app.catalog.products.edit.types.booking.validations.special-price-date-range')",
+                        });
+
+                        return;
+                    }
+
                     if (! params.id) {
-                            this.optionRowCount++;
+                        this.optionRowCount++;
 
-                            params.id = 'option_' + this.optionRowCount;
-                        }
+                        params.id = 'option_' + this.optionRowCount;
+                    }
 
-                        let foundIndex = this.tickets.findIndex(item => item.id === params.id);
+                    let foundIndex = this.tickets.findIndex(item => item.id === params.id);
 
-                        if (foundIndex !== -1) {
-                            this.tickets[foundIndex] = { 
-                                ...this.tickets[foundIndex].params, 
-                                ...params
-                            };
-                        } else {
-                            this.tickets.push(params);
-                        }
+                    if (foundIndex !== -1) {
+                        this.tickets[foundIndex] = {
+                            ...this.tickets[foundIndex].params,
+                            ...params
+                        };
+                    } else {
+                        this.tickets.push(params);
+                    }
 
                     this.toggle();
                 },
@@ -395,6 +404,65 @@
 
                 toggle() {
                     this.$refs.drawerForm.toggle();
+                },
+
+                isSpecialPriceDateRangeValid(ticket) {
+                    const eventStartsAt = this.parseDateForComparison(this.getBookingDateInputValue('available_from'));
+                    const eventEndsAt = this.parseDateForComparison(this.getBookingDateInputValue('available_to'));
+
+                    if (! eventStartsAt || ! eventEndsAt) {
+                        return true;
+                    }
+
+                    const specialPriceStartsAt = this.parseDateForComparison(ticket.special_price_from);
+                    const specialPriceEndsAt = this.parseDateForComparison(ticket.special_price_to);
+
+                    if (
+                        specialPriceStartsAt === false
+                        || specialPriceEndsAt === false
+                    ) {
+                        return false;
+                    }
+
+                    if (
+                        specialPriceStartsAt
+                        && (
+                            specialPriceStartsAt < eventStartsAt
+                            || specialPriceStartsAt > eventEndsAt
+                        )
+                    ) {
+                        return false;
+                    }
+
+                    if (
+                        specialPriceEndsAt
+                        && (
+                            specialPriceEndsAt < eventStartsAt
+                            || specialPriceEndsAt > eventEndsAt
+                        )
+                    ) {
+                        return false;
+                    }
+
+                    return ! (
+                        specialPriceStartsAt
+                        && specialPriceEndsAt
+                        && specialPriceEndsAt < specialPriceStartsAt
+                    );
+                },
+
+                getBookingDateInputValue(field) {
+                    return document.querySelector(`[name="booking[${field}]"]`)?.value || '';
+                },
+
+                parseDateForComparison(value) {
+                    if (! value) {
+                        return null;
+                    }
+
+                    const timestamp = Date.parse(String(value).replace(' ', 'T'));
+
+                    return Number.isNaN(timestamp) ? false : timestamp;
                 },
             }
         });

--- a/packages/Webkul/Product/src/Type/Booking.php
+++ b/packages/Webkul/Product/src/Type/Booking.php
@@ -592,6 +592,18 @@ class Booking extends AbstractType
                     $this->validateSlotWindowDurations($booking, $fail);
                 },
             ],
+
+            'booking.tickets' => [
+                function ($attribute, $value, $fail) {
+                    $booking = request('booking') ?? [];
+
+                    if (($booking['type'] ?? null) !== 'event') {
+                        return;
+                    }
+
+                    $this->validateEventTicketSpecialPriceDates($booking, $fail);
+                },
+            ],
         ];
     }
 
@@ -656,6 +668,79 @@ class Booking extends AbstractType
 
                 return;
             }
+        }
+    }
+
+    /**
+     * Ensures event ticket sale windows stay inside the event booking window.
+     */
+    protected function validateEventTicketSpecialPriceDates(array $booking, \Closure $fail): void
+    {
+        if (empty($booking['tickets'])) {
+            return;
+        }
+
+        $eventStartsAt = $this->parseBookingDate($booking['available_from'] ?? null);
+        $eventEndsAt = $this->parseBookingDate($booking['available_to'] ?? null);
+
+        if (! $eventStartsAt || ! $eventEndsAt) {
+            return;
+        }
+
+        foreach ($booking['tickets'] as $ticket) {
+            $specialPriceStartsAt = $this->parseBookingDate($ticket['special_price_from'] ?? null);
+            $specialPriceEndsAt = $this->parseBookingDate($ticket['special_price_to'] ?? null);
+
+            if (
+                $specialPriceStartsAt === false
+                || $specialPriceEndsAt === false
+                || (
+                    $specialPriceStartsAt
+                    && (
+                        $specialPriceStartsAt->lt($eventStartsAt)
+                        || $specialPriceStartsAt->gt($eventEndsAt)
+                    )
+                )
+                || (
+                    $specialPriceEndsAt
+                    && (
+                        $specialPriceEndsAt->lt($eventStartsAt)
+                        || $specialPriceEndsAt->gt($eventEndsAt)
+                    )
+                )
+                || (
+                    $specialPriceStartsAt
+                    && $specialPriceEndsAt
+                    && $specialPriceEndsAt->lt($specialPriceStartsAt)
+                )
+            ) {
+                $message = trans('admin::app.catalog.products.edit.types.booking.validations.special-price-date-range');
+
+                session()->flash('error', $message);
+
+                $fail($message);
+
+                return;
+            }
+        }
+    }
+
+    /**
+     * Returns null for empty optional dates, false for invalid non-empty values.
+     */
+    protected function parseBookingDate($value): Carbon|false|null
+    {
+        if (
+            empty($value)
+            || $value === '0000-00-00 00:00:00'
+        ) {
+            return null;
+        }
+
+        try {
+            return Carbon::parse($value);
+        } catch (\Throwable) {
+            return false;
         }
     }
 


### PR DESCRIPTION
## Summary
- validate event ticket special price date windows against the event booking start/end dates on product save
- show an admin flash message when the ticket drawer receives a special price date outside the event window
- add a readable validation message for this booking rule

Fixes #10709

## Testing
- `php -l packages/Webkul/Product/src/Type/Booking.php`
- `php -l packages/Webkul/Admin/src/Resources/lang/en/app.php`
- `php -l packages/Webkul/Admin/src/Resources/views/catalog/products/edit/types/booking/event.blade.php`
- `git diff --check`

Note: full Laravel/Pest tests were not run locally because this checkout does not have Composer dependencies installed (`vendor/autoload.php` is missing).