### PR TITLE
Allow relative footer theme links

### DIFF
--- a/packages/Webkul/Admin/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en/app.php
@@ -3862,6 +3862,7 @@ return [
                 'footer-link' => 'Footer Links',
                 'footer-link-description' => 'Navigate via footer links for seamless website exploration and information.',
                 'footer-link-form-title' => 'Footer Link',
+                'footer-link-url-error' => 'Enter a valid URL or relative path.',
                 'footer-title' => 'Title',
                 'general' => 'General',
                 'html' => 'HTML',

--- a/packages/Webkul/Admin/src/Resources/views/settings/themes/edit/footer-links.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/themes/edit/footer-links.blade.php
@@ -82,7 +82,7 @@
                                         @lang('admin::app.settings.themes.edit.url'):
 
                                         <a
-                                            :href="link.url"
+                                            :href="resolveFooterLinkUrl(link.url)"
                                             target="_blank"
                                             class="text-blue-600 transition-all hover:underline"
                                         >
@@ -224,7 +224,7 @@
                                 <x-admin::form.control-group.control
                                     type="text"
                                     name="url"
-                                    rules="required|url"
+                                    rules="required|footer_link_url"
                                     :label="trans('admin::app.settings.themes.edit.url')"
                                     :placeholder="trans('admin::app.settings.themes.edit.url')"
                                 />
@@ -266,6 +266,41 @@
     </script>
 
     <script type="module">
+        window.defineRule('footer_link_url', value => {
+            if (! value) {
+                return true;
+            }
+
+            const url = String(value).trim();
+
+            if (
+                /\s/.test(url)
+                || /^(javascript|data|vbscript):/i.test(url)
+            ) {
+                return "@lang('admin::app.settings.themes.edit.footer-link-url-error')";
+            }
+
+            if (/^(https?:)?\/\//i.test(url)) {
+                try {
+                    new URL(url, window.location.origin);
+
+                    return true;
+                } catch (error) {
+                    return "@lang('admin::app.settings.themes.edit.footer-link-url-error')";
+                }
+            }
+
+            if (
+                /^(mailto|tel):/i.test(url)
+                || /^[#?]/.test(url)
+                || ! /^[a-z][a-z\d+.-]*:/i.test(url)
+            ) {
+                return true;
+            }
+
+            return "@lang('admin::app.settings.themes.edit.footer-link-url-error')";
+        });
+
         app.component('v-footer-links', {
             template: '#v-footer-links-template',
 
@@ -329,13 +364,36 @@
                     this.isUpdating = true;
 
                     this.$refs.footerLinkUpdateOrCreateModal.setValues({
-                        ...footerLink, 
+                        ...footerLink,
                         key,
                     });
 
                     this.$refs.addLinksModal.toggle();
                 },
+
+                resolveFooterLinkUrl(url) {
+                    url = String(url || '').trim();
+
+                    if (
+                        ! url
+                        || /^(javascript|data|vbscript):/i.test(url)
+                    ) {
+                        return '#';
+                    }
+
+                    if (
+                        /^(https?:)?\/\//i.test(url)
+                        || /^(mailto|tel):/i.test(url)
+                        || /^[#?]/.test(url)
+                    ) {
+                        return url;
+                    }
+
+                    const baseUrl = document.querySelector('meta[name="base-url"]')?.content?.replace(/\/$/, '') || window.location.origin;
+
+                    return `${baseUrl}/${url.replace(/^\/+/, '')}`;
+                },
             },
         });
     </script>
-@endPushOnce    
+@endPushOnce

--- a/packages/Webkul/Shop/src/Resources/views/components/layouts/footer/index.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/components/layouts/footer/index.blade.php
@@ -19,6 +19,26 @@
         'theme_code' => $channel->theme,
         'channel_id' => $channel->id,
     ]);
+
+    $resolveFooterUrl = function (?string $url): string {
+        $url = trim($url ?? '');
+
+        if (
+            $url === ''
+            || preg_match('/^(javascript|data|vbscript):/i', $url)
+        ) {
+            return '#';
+        }
+
+        if (preg_match('/^(https?:)?\/\//i', $url)
+            || preg_match('/^(mailto|tel):/i', $url)
+            || preg_match('/^[#?]/', $url)
+        ) {
+            return $url;
+        }
+
+        return url($url);
+    };
 @endphp
 
 <footer class="mt-9 bg-lightOrange max-sm:mt-10">
@@ -39,7 +59,7 @@
 
                         @foreach ($footerLinkSection as $link)
                             <li>
-                                <a href="{{ $link['url'] }}">
+                                <a href="{{ $resolveFooterUrl($link['url'] ?? '') }}">
                                     {{ $link['title'] }}
                                 </a>
                             </li>
@@ -74,7 +94,7 @@
                             @foreach ($footerLinkSection as $link)
                                 <li>
                                     <a
-                                        href="{{ $link['url'] }}"
+                                        href="{{ $resolveFooterUrl($link['url'] ?? '') }}"
                                         class="text-sm font-medium max-sm:text-xs"
                                     >
                                         {{ $link['title'] }}


### PR DESCRIPTION
## Summary
- allow footer theme links to be saved as relative paths like `/about-us` or `contact-us`
- resolve same-site footer links against the storefront base URL when rendering the footer
- keep external links, mailto/tel links, anchors, and query links working while blocking unsafe schemes

Fixes #10361

## Testing
- `php -l packages/Webkul/Shop/src/Resources/views/components/layouts/footer/index.blade.php`
- `php -l packages/Webkul/Admin/src/Resources/views/settings/themes/edit/footer-links.blade.php`
- `php -l packages/Webkul/Admin/src/Resources/lang/en/app.php`
- `git diff --check`

Note: full Laravel/Pest tests were not run locally because this checkout does not have Composer dependencies installed (`vendor/autoload.php` is missing).