### PR TITLE
Add video uploads to static content themes

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/ThemeController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/ThemeController.php
@@ -48,7 +48,7 @@ class ThemeController extends Controller
                 core()->getRequestedLocaleCode().'.options.*.image' => 'image|extensions:jpeg,jpg,png,svg,webp',
                 core()->getRequestedLocaleCode().'.options.*.video' => [
                     'file',
-                    'mimetypes:application/octet-stream,video/mp4,video/ogg,video/quicktime,video/webm',
+                    'mimetypes:video/mp4,video/ogg,video/quicktime,video/webm',
                     'extensions:mov,mp4,ogg,webm',
                 ],
             ]);

--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/ThemeController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/ThemeController.php
@@ -46,6 +46,11 @@ class ThemeController extends Controller
         if (request()->has('id')) {
             $this->validate(request(), [
                 core()->getRequestedLocaleCode().'.options.*.image' => 'image|extensions:jpeg,jpg,png,svg,webp',
+                core()->getRequestedLocaleCode().'.options.*.video' => [
+                    'file',
+                    'mimetypes:application/octet-stream,video/mp4,video/ogg,video/quicktime,video/webm',
+                    'extensions:mov,mp4,ogg,webm',
+                ],
             ]);
 
             $theme = $this->themeCustomizationRepository->find(request()->input('id'));

--- a/packages/Webkul/Admin/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en/app.php
@@ -3843,6 +3843,7 @@ return [
                 'add-filter-btn' => 'Add Filter',
                 'add-footer-link-btn' => 'Add Footer Link',
                 'add-image-btn' => 'Add Image',
+                'add-video-btn' => 'Add Video',
                 'add-link' => 'Add Link',
                 'asc' => 'Asc',
                 'back' => 'Back',
@@ -3900,6 +3901,7 @@ return [
                 'url' => 'URL',
                 'value' => 'Value: :value',
                 'value-input' => 'Value',
+                'video-upload-message' => 'Only videos (.mp4, .mov, .ogg, .webm) are allowed.',
 
                 'services-content' => [
                     'add-btn' => 'Add Services',

--- a/packages/Webkul/Admin/src/Resources/views/settings/themes/edit/static-content.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/themes/edit/static-content.blade.php
@@ -25,7 +25,7 @@
                         class="flex gap-2.5"
                         v-if="isHtmlEditorActive"
                     >
-                        <!-- Hidden Input Filed for upload images -->
+                        <!-- Hidden Input Field for upload images -->
                         <label
                             class="secondary-button"
                             for="static_image"
@@ -42,6 +42,25 @@
                             ref="static_image"
                             label="Image"
                             @change="storeImage($event)"
+                        >
+
+                        <!-- Hidden Input Field for upload videos -->
+                        <label
+                            class="secondary-button"
+                            for="static_video"
+                        >
+                            @lang('admin::app.settings.themes.edit.add-video-btn')
+                        </label>
+
+                        <input
+                            type="file"
+                            name="static_video"
+                            id="static_video"
+                            class="hidden"
+                            accept="video/mp4,video/webm,video/ogg,video/quicktime"
+                            ref="static_video"
+                            label="Video"
+                            @change="storeVideo($event)"
                         >
                     </div>
                 </div>
@@ -181,28 +200,42 @@
                 },
 
                 storeImage($event) {
-                    let imageInput = this.$refs.static_image;
+                    this.storeMedia($event, 'image');
+                },
 
-                    if (imageInput.files == undefined) {
+                storeVideo($event) {
+                    this.storeMedia($event, 'video');
+                },
+
+                storeMedia($event, mediaType) {
+                    const mediaInput = mediaType === 'video'
+                        ? this.$refs.static_video
+                        : this.$refs.static_image;
+
+                    if (mediaInput.files == undefined) {
                         return;
                     }
 
-                    const validFiles = Array.from(imageInput.files).every(file => file.type.includes('image/'));
+                    const allowedTypes = mediaType === 'video'
+                        ? ['video/mp4', 'video/webm', 'video/ogg', 'video/quicktime']
+                        : ['image/jpeg', 'image/png', 'image/webp', 'image/jpg'];
+
+                    const validFiles = Array.from(mediaInput.files).every(file => allowedTypes.includes(file.type));
 
                     if (! validFiles) {
                         this.$emitter.emit('add-flash', {
                             type: 'warning',
-                            message: '@lang('admin::app.settings.themes.edit.image-upload-message')'
+                            message: mediaType === 'video'
+                                ? '@lang('admin::app.settings.themes.edit.video-upload-message')'
+                                : '@lang('admin::app.settings.themes.edit.image-upload-message')'
                         });
 
-                        imageInput.value = '';
+                        mediaInput.value = '';
 
                         return;
                     }
 
-                    imageInput.files.forEach((file, index) => {
-                        this.$refs.editor.storeImage($event);
-                    });
+                    this.$refs.editor.storeMedia($event, mediaType);
                 },
 
                 applydarkColor() {
@@ -264,22 +297,24 @@
                     });
                 },
 
-                storeImage($event) {
-                    let selectedImage = $event.target.files[0];
+                storeMedia($event, mediaType = 'image') {
+                    let selectedMedia = $event.target.files[0];
 
-                    if (! selectedImage) {
+                    if (! selectedMedia) {
                         return;
                     }
 
-                    const allowedImageTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/jpg'];
+                    const allowedTypes = mediaType === 'video'
+                        ? ['video/mp4', 'video/webm', 'video/ogg', 'video/quicktime']
+                        : ['image/jpeg', 'image/png', 'image/webp', 'image/jpg'];
 
-                    if (! allowedImageTypes.includes(selectedImage.type)) {
+                    if (! allowedTypes.includes(selectedMedia.type)) {
                         return;
                     }
 
                     let formData = new FormData();
 
-                    formData.append('{{ $currentLocale->code }}[options][][image]', selectedImage);
+                    formData.append(`{{ $currentLocale->code }}[options][][${mediaType}]`, selectedMedia);
                     formData.append('id', '{{ $theme->id }}');
                     formData.append('type', 'static_content');
 
@@ -289,12 +324,16 @@
 
                             let cursorPointer = editor.getCursor();
 
-                            editor.replaceRange(`<img class="lazy" src="" data-src="${response.data}">`, {
+                            const html = mediaType === 'video'
+                                ? `<video controls src="${response.data}"></video>`
+                                : `<img class="lazy" src="" data-src="${response.data}">`;
+
+                            editor.replaceRange(html, {
                                 line: cursorPointer.line, ch: cursorPointer.ch
                             });
 
                             editor.setCursor({
-                                line: cursorPointer.line, ch: cursorPointer.ch + response.data.length
+                                line: cursorPointer.line, ch: cursorPointer.ch + html.length
                             });
                         })
                         .catch((error) => {

--- a/packages/Webkul/Admin/src/Resources/views/settings/themes/edit/static-content.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/themes/edit/static-content.blade.php
@@ -57,7 +57,7 @@
                             name="static_video"
                             id="static_video"
                             class="hidden"
-                            accept="video/mp4,video/webm,video/ogg,video/quicktime"
+                            accept=".mov,.mp4,.ogg,.webm,video/mp4,video/ogg,video/quicktime,video/webm"
                             ref="static_video"
                             label="Video"
                             @change="storeVideo($event)"
@@ -200,42 +200,51 @@
                 },
 
                 storeImage($event) {
-                    this.storeMedia($event, 'image');
-                },
+                    let imageInput = this.$refs.static_image;
 
-                storeVideo($event) {
-                    this.storeMedia($event, 'video');
-                },
-
-                storeMedia($event, mediaType) {
-                    const mediaInput = mediaType === 'video'
-                        ? this.$refs.static_video
-                        : this.$refs.static_image;
-
-                    if (mediaInput.files == undefined) {
+                    if (imageInput.files == undefined) {
                         return;
                     }
 
-                    const allowedTypes = mediaType === 'video'
-                        ? ['video/mp4', 'video/webm', 'video/ogg', 'video/quicktime']
-                        : ['image/jpeg', 'image/png', 'image/webp', 'image/jpg'];
-
-                    const validFiles = Array.from(mediaInput.files).every(file => allowedTypes.includes(file.type));
+                    const validFiles = Array.from(imageInput.files).every(file => file.type.includes('image/'));
 
                     if (! validFiles) {
                         this.$emitter.emit('add-flash', {
                             type: 'warning',
-                            message: mediaType === 'video'
-                                ? '@lang('admin::app.settings.themes.edit.video-upload-message')'
-                                : '@lang('admin::app.settings.themes.edit.image-upload-message')'
+                            message: '@lang('admin::app.settings.themes.edit.image-upload-message')'
                         });
 
-                        mediaInput.value = '';
+                        imageInput.value = '';
 
                         return;
                     }
 
-                    this.$refs.editor.storeMedia($event, mediaType);
+                    this.$refs.editor.storeImage($event);
+                },
+
+                storeVideo($event) {
+                    let videoInput = this.$refs.static_video;
+
+                    if (videoInput.files == undefined) {
+                        return;
+                    }
+
+                    const allowedVideoTypes = ['video/mp4', 'video/ogg', 'video/quicktime', 'video/webm'];
+
+                    const validFiles = Array.from(videoInput.files).every(file => allowedVideoTypes.includes(file.type));
+
+                    if (! validFiles) {
+                        this.$emitter.emit('add-flash', {
+                            type: 'warning',
+                            message: '@lang('admin::app.settings.themes.edit.video-upload-message')'
+                        });
+
+                        videoInput.value = '';
+
+                        return;
+                    }
+
+                    this.$refs.editor.storeVideo($event);
                 },
 
                 applydarkColor() {
@@ -297,24 +306,22 @@
                     });
                 },
 
-                storeMedia($event, mediaType = 'image') {
-                    let selectedMedia = $event.target.files[0];
+                storeImage($event) {
+                    let selectedImage = $event.target.files[0];
 
-                    if (! selectedMedia) {
+                    if (! selectedImage) {
                         return;
                     }
 
-                    const allowedTypes = mediaType === 'video'
-                        ? ['video/mp4', 'video/webm', 'video/ogg', 'video/quicktime']
-                        : ['image/jpeg', 'image/png', 'image/webp', 'image/jpg'];
+                    const allowedImageTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/jpg'];
 
-                    if (! allowedTypes.includes(selectedMedia.type)) {
+                    if (! allowedImageTypes.includes(selectedImage.type)) {
                         return;
                     }
 
                     let formData = new FormData();
 
-                    formData.append(`{{ $currentLocale->code }}[options][][${mediaType}]`, selectedMedia);
+                    formData.append('{{ $currentLocale->code }}[options][][image]', selectedImage);
                     formData.append('id', '{{ $theme->id }}');
                     formData.append('type', 'static_content');
 
@@ -324,16 +331,54 @@
 
                             let cursorPointer = editor.getCursor();
 
-                            const html = mediaType === 'video'
-                                ? `<video controls src="${response.data}"></video>`
-                                : `<img class="lazy" src="" data-src="${response.data}">`;
-
-                            editor.replaceRange(html, {
+                            editor.replaceRange(`<img class="lazy" src="" data-src="${response.data}">`, {
                                 line: cursorPointer.line, ch: cursorPointer.ch
                             });
 
                             editor.setCursor({
-                                line: cursorPointer.line, ch: cursorPointer.ch + html.length
+                                line: cursorPointer.line, ch: cursorPointer.ch + response.data.length
+                            });
+                        })
+                        .catch((error) => {
+                            if (error.response.status == 422) {
+                                this.$emitter.emit('add-flash', { type: 'warning', message: error.response.data.message });
+                            }
+                        });
+                },
+
+                storeVideo($event) {
+                    let selectedVideo = $event.target.files[0];
+
+                    if (! selectedVideo) {
+                        return;
+                    }
+
+                    const allowedVideoTypes = ['video/mp4', 'video/ogg', 'video/quicktime', 'video/webm'];
+
+                    if (! allowedVideoTypes.includes(selectedVideo.type)) {
+                        return;
+                    }
+
+                    let formData = new FormData();
+
+                    formData.append('{{ $currentLocale->code }}[options][][video]', selectedVideo);
+                    formData.append('id', '{{ $theme->id }}');
+                    formData.append('type', 'static_content');
+
+                    this.$axios.post('{{ route('admin.settings.themes.store') }}', formData)
+                        .then((response) => {
+                            let editor = this._html.getDoc();
+
+                            let cursorPointer = editor.getCursor();
+
+                            let video = `<video controls src="${response.data}"></video>`;
+
+                            editor.replaceRange(video, {
+                                line: cursorPointer.line, ch: cursorPointer.ch
+                            });
+
+                            editor.setCursor({
+                                line: cursorPointer.line, ch: cursorPointer.ch + video.length
                             });
                         })
                         .catch((error) => {

--- a/packages/Webkul/Theme/src/Repositories/ThemeCustomizationRepository.php
+++ b/packages/Webkul/Theme/src/Repositories/ThemeCustomizationRepository.php
@@ -69,7 +69,7 @@ class ThemeCustomizationRepository extends Repository
     }
 
     /**
-     * Upload media.
+     * Upload images and static content videos.
      *
      * @return void|string
      */
@@ -102,8 +102,7 @@ class ThemeCustomizationRepository extends Repository
                 && $image['video'] instanceof UploadedFile
             ) {
                 try {
-                    $path = 'theme/'.$theme->id.'/'.Str::random(40).'.'
-                        .$image['video']->getClientOriginalExtension();
+                    $path = 'theme/'.$theme->id.'/'.Str::random(40).'.'.$image['video']->getClientOriginalExtension();
 
                     Storage::put($path, file_get_contents($image['video']->getRealPath()));
                 } catch (\Exception $e) {

--- a/packages/Webkul/Theme/src/Repositories/ThemeCustomizationRepository.php
+++ b/packages/Webkul/Theme/src/Repositories/ThemeCustomizationRepository.php
@@ -69,7 +69,7 @@ class ThemeCustomizationRepository extends Repository
     }
 
     /**
-     * Upload images
+     * Upload media.
      *
      * @return void|string
      */
@@ -96,6 +96,23 @@ class ThemeCustomizationRepository extends Repository
                     'description' => $image['description'],
                     'title' => $image['title'],
                 ];
+            } elseif (
+                ($data['type'] ?? '') === 'static_content'
+                && isset($image['video'])
+                && $image['video'] instanceof UploadedFile
+            ) {
+                try {
+                    $path = 'theme/'.$theme->id.'/'.Str::random(40).'.'
+                        .$image['video']->getClientOriginalExtension();
+
+                    Storage::put($path, file_get_contents($image['video']->getRealPath()));
+                } catch (\Exception $e) {
+                    session()->flash('error', $e->getMessage());
+
+                    return redirect()->back();
+                }
+
+                return Storage::url($path);
             } elseif ($image['image'] instanceof UploadedFile) {
                 try {
                     $path = 'theme/'.$theme->id.'/'.Str::random(40).'.webp';


### PR DESCRIPTION
## Summary
- add an Add Video action to the static content theme editor
- validate static content video uploads with restricted video MIME types and extensions
- store uploaded videos under the theme media directory and insert a `<video controls>` tag into the HTML editor

Fixes #10282

## Testing
- `php -l packages/Webkul/Admin/src/Http/Controllers/Settings/ThemeController.php`
- `php -l packages/Webkul/Theme/src/Repositories/ThemeCustomizationRepository.php`
- `php -l packages/Webkul/Admin/src/Resources/views/settings/themes/edit/static-content.blade.php`
- `php -l packages/Webkul/Admin/src/Resources/lang/en/app.php`
- `git diff --check`

Note: full Laravel/Pest tests were not run locally because this checkout does not have Composer dependencies installed (`vendor/autoload.php` is missing).