### PR TITLE
fix(admin): load flatpickr dark theme from local bundled asset instead of npmcdn CDN

### DIFF
--- a/packages/Webkul/Admin/src/Resources/assets/js/plugins/flatpickr.js
+++ b/packages/Webkul/Admin/src/Resources/assets/js/plugins/flatpickr.js
@@ -1,5 +1,6 @@
 import Flatpickr from "flatpickr";
 import "flatpickr/dist/flatpickr.css";
+import darkThemeUrl from "flatpickr/dist/themes/dark.css?url";
 import { Spanish } from "flatpickr/dist/l10n/es.js";
 import { Catalan } from "flatpickr/dist/l10n/cat.js"
 import { Arabic } from "flatpickr/dist/l10n/ar.js";
@@ -74,7 +75,7 @@ export default {
             const linkElement = document.createElement("link");
             linkElement.rel = "stylesheet";
             linkElement.type = "text/css";
-            linkElement.href = `https://npmcdn.com/flatpickr/dist/themes/${theme}.css`;
+            linkElement.href = darkThemeUrl;
             linkElement.id = "flatpickr";
 
             document.head.appendChild(linkElement);


### PR DESCRIPTION
## Problem

When the admin panel is in dark mode, the flatpickr plugin (`packages/Webkul/Admin/src/Resources/assets/js/plugins/flatpickr.js`) dynamically injects a stylesheet from a third-party CDN:

```js
linkElement.href = `https://npmcdn.com/flatpickr/dist/themes/${theme}.css`;
```

This has several issues:

1. **npmcdn.com is deprecated** — it is the pre-2016 name of unpkg and today is just a redirector. Each dark-mode page load goes through a 2-hop redirect chain (`npmcdn.com` → `unpkg.com/flatpickr/...` → `unpkg.com/flatpickr@4.6.13/...`).
2. **Unpinned third-party CSS in the admin panel** — the URL is version-floating, so whatever flatpickr publishes next is served to every admin. Subresource Integrity cannot be used with a floating version. Malicious or compromised CSS in an admin context enables data exfiltration via CSS selectors.
3. **CSP violations** — any Content-Security-Policy with a `style-src` allow-list flags 3 violations per load (one per redirect hop). A store hardening its admin with CSP must allow-list two general-purpose CDN hosts just for this one file.
4. **Unnecessary dependency** — the identical file already ships in `node_modules/flatpickr/dist/themes/dark.css` (the plugin already bundles `flatpickr/dist/flatpickr.css` on the line above), and adds a runtime dependency on third-party CDN uptime plus an IP/referrer leak for every admin user in dark mode.

## Solution

Import the dark theme through Vite with the `?url` suffix so it is emitted as a hashed local asset, and point the dynamically injected `<link>` at it:

```js
import darkThemeUrl from "flatpickr/dist/themes/dark.css?url";
...
linkElement.href = darkThemeUrl;
```

- The lazy-loading semantics are preserved: the CSS is emitted as a separate asset in the manifest (`assets` entry, not `css`), so it is **only fetched when dark mode is active** — light-mode users download nothing extra.
- The existing add/remove `<link id="flatpickr">` mechanism, the light early-return, and the `change-theme` listener are untouched.
- `vite.config.js` needs no changes (`experimental.renderBuiltUrl` only rewrites `hostType === "css"` URLs, so the JS-hosted asset URL resolves normally under the build base / `ASSET_URL`).

## Verification

Built the admin assets and drove the change in a browser (Playwright against a seeded store):

- Dark mode on (toggle and page-load paths): one `<link id="flatpickr">` pointing to `/themes/admin/default/build/assets/dark-<hash>.css`, served 200 `text/css`; the flatpickr calendar renders with the dark theme background (`#3f4458`).
- Light mode: the link is removed; rapid repeated toggling leaves no duplicate links.
- Zero `securitypolicyviolation` events and zero requests to npmcdn/unpkg in the whole session.

Built assets are intentionally not included to keep the diff reviewable — `npm run build` in `packages/Webkul/Admin` picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
