### PR TITLE
security: fix path traversal in RMAImageRepository and XSS in Shop views

### DIFF
--- a/packages/Webkul/RMA/src/Repositories/RMAImageRepository.php
+++ b/packages/Webkul/RMA/src/Repositories/RMAImageRepository.php
@@ -21,13 +21,6 @@ class RMAImageRepository extends Repository
      */
     public function manageImages($requestImages, $rma): void
     {
-        foreach ($requestImages as $itemImage) {
-            $this->create([
-                'rma_id' => $rma->id,
-                'path' => $itemImage->getClientOriginalName(),
-            ]);
-        }
-
         $this->uploadImages($requestImages, $rma);
     }
 

--- a/packages/Webkul/Shop/src/Resources/views/components/datagrid/table.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/components/datagrid/table.blade.php
@@ -132,8 +132,14 @@
                                     <p
                                         class="break-words"
                                         v-html="record[column.index]"
-                                        v-if="column.visibility"
+                                        v-if="column.visibility && column.allow_html"
                                     >
+                                    </p>
+                                    <p
+                                        class="break-words"
+                                        v-if="column.visibility && !column.allow_html"
+                                    >
+                                        @{{ record[column.index] }}
                                     </p>
                                 </template>
                                 

--- a/packages/Webkul/Shop/src/Resources/views/customers/account/downloadable_products/index.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/customers/account/downloadable_products/index.blade.php
@@ -84,10 +84,8 @@
                                     </div>
             
                                     <div class="text-xs font-normal">
-                                        <p
-                                            class="text-sm font-semibold text-blue-600"
-                                            v-html="record.product_name"
-                                        >
+                                        <p class="text-sm font-semibold text-blue-600">
+                                            @{{ record.product_name }}
                                         </p>
 
                                         <p><span class="text-neutral-500">@lang('Remaining Downloads'):</span> <span class="font-medium">@{{ record.remaining_downloads }}</span></p>


### PR DESCRIPTION
Fixes #11338
Fixes #11339

## Fix 1 — Path traversal in `RMAImageRepository::manageImages()` (#11338)

`manageImages()` created a preliminary DB record using `getClientOriginalName()` as the `path` field before delegating to `uploadImages()`. An attacker submitting a file named `../../../../config/database.php` would have that string stored as the path.

`uploadImages()` then called `Storage::delete($imageModel->path)` on those preliminary records — passing the attacker-controlled filename to `Storage::delete()`, a path traversal vector for file deletion.

`uploadImages()` already creates the correct records using `store()` (safe, server-generated paths) and has always handled both creation and cleanup. The preliminary `create()` loop in `manageImages()` was redundant and unsafe.

**Fix:** Remove the `create()` loop from `manageImages()` so it delegates directly to `uploadImages()`, matching the approach already applied to `RequestController.php`.

```php
// Before
public function manageImages($requestImages, $rma): void
{
    foreach ($requestImages as $itemImage) {
        $this->create([
            'rma_id' => $rma->id,
            'path' => $itemImage->getClientOriginalName(), // ⚠️ attacker-controlled
        ]);
    }
    $this->uploadImages($requestImages, $rma);
}

// After
public function manageImages($requestImages, $rma): void
{
    $this->uploadImages($requestImages, $rma);
}
```

---

## Fix 2 — `v-html` XSS with user-controlled data in Shop views (#11339)

Vue's `v-html` bypasses HTML escaping. Two locations rendered user-supplied data via `v-html`:

**`downloadable_products/index.blade.php`** — `record.product_name` is set by admins or marketplace sellers. Replaced with `@{{ }}` safe interpolation.

**`datagrid/table.blade.php`** — `v-html="record[column.index]"` rendered every column value as raw HTML. Some columns (e.g. status badges) legitimately need HTML; others (product names, titles) do not.

**Fix:** Gate `v-html` behind `column.allow_html`. Columns that intentionally render system-generated HTML can set `allow_html: true`; all other columns default to safe `@{{ }}` interpolation.

This matches the fix already applied to `record.customer_name` in `create.blade.php`.