### PR TITLE
fix: pass initial multiselect value to VeeValidate on product edit

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/catalog/products/edit/controls.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/products/edit/controls.blade.php
@@ -127,7 +127,7 @@
         @break
     @case('multiselect')
         @php
-            $selectedOption = old($attribute->code) ?: explode(',', $product[$attribute->code]);
+            $selectedOption = old($attribute->code) ?: array_values(array_filter(explode(',', $product[$attribute->code])));
         @endphp
 
         <x-admin::form.control-group.control
@@ -135,6 +135,7 @@
             :id="$attribute->code . '[]'"
             :name="$attribute->code . '[]'"
             ::rules="{{ $attribute->validations }}"
+            ::value="{{ json_encode($selectedOption) }}"
             :label="$attribute->admin_name"
         >
             @foreach ($attribute->options()->orderBy('sort_order')->get() as $option)


### PR DESCRIPTION
## Summary

- Pass pre-selected multiselect values to VeeValidate's `v-field` via `::value` so its form state is initialized correctly on the product edit page
- Filter empty strings from `explode()` to properly handle products with no saved multiselect value

Fixes #10963

## Root Cause

VeeValidate's `v-field` component manages form state independently from the DOM. On the product edit page, multiselect `<option>` elements had `selected` attributes (so they visually appeared selected), but VeeValidate's internal form state had no initial value for the field. On re-save without interacting with the multiselect, VeeValidate validated against its empty internal state and failed the `required` check.

The `select` case already passes `:value` correctly - the `multiselect` case was missing this.

## Test plan

- [ ] Create a multiselect attribute with **required** enabled and assign it to an attribute group
- [ ] Go to Product Edit Page that has this required multiselect attribute
- [ ] Select options in the multiselect and save the product
- [ ] Re-open the same Product Edit Page
- [ ] Save the product **without interacting with the multiselect field**
- [ ] Verify the product saves successfully without a "required" validation error on the multiselect