### PR TITLE
fix: validate duplicate customer group prices to prevent 500 error

### DIFF
--- a/packages/Webkul/Admin/src/Http/Requests/ProductForm.php
+++ b/packages/Webkul/Admin/src/Http/Requests/ProductForm.php
@@ -169,7 +169,35 @@ class ProductForm extends FormRequest
             $this->rules[$attribute->code] = $validations;
         }
 
+        $this->addCustomerGroupPriceRules();
+
         return $this->rules;
+    }
+
+    /**
+     * Add validation rules for customer group prices to prevent duplicate entries.
+     */
+    protected function addCustomerGroupPriceRules(): void
+    {
+        $this->rules['customer_group_prices'] = [
+            'nullable',
+            'array',
+            function ($attribute, $value, $fail) {
+                $seen = [];
+
+                foreach ($value as $row) {
+                    $key = ($row['qty'] ?? 0).'|'.($row['customer_group_id'] ?? '');
+
+                    if (isset($seen[$key])) {
+                        $fail(trans('admin::app.catalog.products.edit.price.group.duplicate-group-price-error'));
+
+                        return;
+                    }
+
+                    $seen[$key] = true;
+                }
+            },
+        ];
     }
 
     /**

--- a/packages/Webkul/Admin/src/Resources/lang/ar/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ar/app.php
@@ -1190,6 +1190,7 @@ return [
                         'all-groups' => 'جميع المجموعات',
                         'create-btn' => 'إضافة جديدة',
                         'discount-group-price-info' => 'لـ :qty كمية بخصم قدره :price',
+                        'duplicate-group-price-error' => 'A discount for the same customer group and quantity already exists.',
                         'edit-btn' => 'تعديل',
                         'empty-info' => 'تسعير خاص للعملاء الذين ينتمون إلى مجموعة معينة.',
                         'fixed-group-price-info' => 'لـ :qty كمية بسعر ثابت قدره :price',

--- a/packages/Webkul/Admin/src/Resources/lang/bn/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/bn/app.php
@@ -1190,6 +1190,7 @@ return [
                         'all-groups' => 'সমস্ত গোষ্ঠী',
                         'create-btn' => 'নতুন যোগ করুন',
                         'discount-group-price-info' => 'মূল্যে :price ছাড় প্রাপ্য :qty পরিমাণে',
+                        'duplicate-group-price-error' => 'A discount for the same customer group and quantity already exists.',
                         'edit-btn' => 'সম্পাদনা',
                         'empty-info' => 'নির্ধারিত গ্রুপে সদস্যদের জন্য বিশেষ মূল্য নির্ধারণ করুন।',
                         'fixed-group-price-info' => ':qty পরিমাণে নির্ধারিত মূল্যে :price সহ',

--- a/packages/Webkul/Admin/src/Resources/lang/ca/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ca/app.php
@@ -1190,6 +1190,7 @@ return [
                         'all-groups' => 'Totes les categories',
                         'create-btn' => 'Afegir nou',
                         'discount-group-price-info' => 'Per a qty Quantitat amb un descompte de :price',
+                        'duplicate-group-price-error' => 'A discount for the same customer group and quantity already exists.',
                         'edit-btn' => 'Editar',
                         'empty-info' => 'Preus especials per a clients que pertanyen a un grup específic.',
                         'fixed-group-price-info' => 'Per a qty Quantitat a un preu fix de :price',

--- a/packages/Webkul/Admin/src/Resources/lang/de/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/de/app.php
@@ -1190,6 +1190,7 @@ return [
                         'all-groups' => 'Alle Gruppen',
                         'create-btn' => 'Neu hinzufügen',
                         'discount-group-price-info' => 'Für :price Rabatt ab :qty Stück',
+                        'duplicate-group-price-error' => 'A discount for the same customer group and quantity already exists.',
                         'edit-btn' => 'Bearbeiten',
                         'empty-info' => 'Sonderpreise für Kunden in einer bestimmten Gruppe.',
                         'fixed-group-price-info' => 'Für :qty Stück zum Festpreis von :price',

--- a/packages/Webkul/Admin/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en/app.php
@@ -1190,6 +1190,7 @@ return [
                         'all-groups' => 'All Groups',
                         'create-btn' => 'Add New',
                         'discount-group-price-info' => 'For :qty Qty at discount of :price',
+                        'duplicate-group-price-error' => 'A discount for the same customer group and quantity already exists.',
                         'edit-btn' => 'Edit',
                         'empty-info' => 'Special pricing for customers belonging to a specific group.',
                         'fixed-group-price-info' => 'For :qty Qty at fixed price of :price',

--- a/packages/Webkul/Admin/src/Resources/lang/es/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/es/app.php
@@ -1190,6 +1190,7 @@ return [
                         'all-groups' => 'Todas las categorías',
                         'create-btn' => 'Agregar nuevo',
                         'discount-group-price-info' => 'Para qty Cantidad con un descuento de :price',
+                        'duplicate-group-price-error' => 'A discount for the same customer group and quantity already exists.',
                         'edit-btn' => 'Editar',
                         'empty-info' => 'Precios especiales para clientes que pertenecen a un grupo específico.',
                         'fixed-group-price-info' => 'Para qty Cantidad a un precio fijo de :price',

--- a/packages/Webkul/Admin/src/Resources/lang/fa/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/fa/app.php
@@ -1190,6 +1190,7 @@ return [
                         'all-groups' => 'تمام گروه‌ها',
                         'create-btn' => 'افزودن جدید',
                         'discount-group-price-info' => 'برای :qty تعداد با تخفیف :price',
+                        'duplicate-group-price-error' => 'A discount for the same customer group and quantity already exists.',
                         'edit-btn' => 'ویرایش',
                         'empty-info' => 'قیمت‌گذاری ویژه برای مشتریان تعلق گرفته به گروه‌های خاص.',
                         'fixed-group-price-info' => 'برای تعداد :qty با قیمت ثابت :price',

--- a/packages/Webkul/Admin/src/Resources/lang/fr/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/fr/app.php
@@ -1190,6 +1190,7 @@ return [
                         'all-groups' => 'Tous les groupes',
                         'create-btn' => 'Ajouter un nouveau',
                         'discount-group-price-info' => 'Pour :qty quantité à un rabais de :price',
+                        'duplicate-group-price-error' => 'A discount for the same customer group and quantity already exists.',
                         'edit-btn' => 'Modifier',
                         'empty-info' => 'Tarification spéciale pour les clients appartenant à un groupe spécifique.',
                         'fixed-group-price-info' => 'Pour :qty quantité à un prix fixe de :price',

--- a/packages/Webkul/Admin/src/Resources/lang/he/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/he/app.php
@@ -1190,6 +1190,7 @@ return [
                         'all-groups' => 'כל הקבוצות',
                         'create-btn' => 'הוסף חדש',
                         'discount-group-price-info' => 'עבור כמות :price בהנחה של :qty',
+                        'duplicate-group-price-error' => 'A discount for the same customer group and quantity already exists.',
                         'edit-btn' => 'ערוך',
                         'empty-info' => 'מחיר מיוחד ללקוחות שנמצאים בקבוצה ספציפית.',
                         'fixed-group-price-info' => 'עבור :qty יחידות במחיר קבוע של :price',

--- a/packages/Webkul/Admin/src/Resources/lang/hi_IN/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/hi_IN/app.php
@@ -1190,6 +1190,7 @@ return [
                         'all-groups' => 'सभी समूह',
                         'create-btn' => 'नया जोड़ें',
                         'discount-group-price-info' => 'मूल्य पर :qty मात्र के लिए :price की छूट',
+                        'duplicate-group-price-error' => 'A discount for the same customer group and quantity already exists.',
                         'edit-btn' => 'संपादित करें',
                         'empty-info' => 'विशेष मूल्यवान ग्राहकों के लिए विशिष्ट मूल्यनिर्धारण।',
                         'fixed-group-price-info' => 'मूल्य :qty मात्र के लिए स्थिर मूल्य पर :price',

--- a/packages/Webkul/Admin/src/Resources/lang/id/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/id/app.php
@@ -1190,6 +1190,7 @@ return [
                         'all-groups' => 'Semua Grup',
                         'create-btn' => 'Tambah Baru',
                         'discount-group-price-info' => 'Untuk :qty Qty dengan diskon :price',
+                        'duplicate-group-price-error' => 'A discount for the same customer group and quantity already exists.',
                         'edit-btn' => 'Edit',
                         'empty-info' => 'Harga khusus untuk pelanggan dalam grup tertentu.',
                         'fixed-group-price-info' => 'Untuk :qty Qty dengan harga tetap :price',

--- a/packages/Webkul/Admin/src/Resources/lang/it/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/it/app.php
@@ -1190,6 +1190,7 @@ return [
                         'all-groups' => 'Tutti i Gruppi',
                         'create-btn' => 'Aggiungi Nuovo',
                         'discount-group-price-info' => 'Per :qty Qtà con sconto di :price',
+                        'duplicate-group-price-error' => 'A discount for the same customer group and quantity already exists.',
                         'edit-btn' => 'Modifica',
                         'empty-info' => 'Prezzi speciali per i clienti appartenenti a un gruppo specifico.',
                         'fixed-group-price-info' => 'Per :qty Qtà a prezzo fisso di :price',

--- a/packages/Webkul/Admin/src/Resources/lang/ja/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ja/app.php
@@ -1190,6 +1190,7 @@ return [
                         'all-groups' => 'すべてのグループ',
                         'create-btn' => '新規追加',
                         'discount-group-price-info' => ':price の割引価格で :qty 個の数量に対して',
+                        'duplicate-group-price-error' => 'A discount for the same customer group and quantity already exists.',
                         'edit-btn' => '編集',
                         'empty-info' => '特定のグループに所属する顧客のための特別価格',
                         'fixed-group-price-info' => ':price の固定価格で :qty 個の数量に対して',

--- a/packages/Webkul/Admin/src/Resources/lang/nl/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/nl/app.php
@@ -1190,6 +1190,7 @@ return [
                         'all-groups' => 'Alle groepen',
                         'create-btn' => 'Nieuwe toevoegen',
                         'discount-group-price-info' => 'Voor :qty Hoeveelheid met een korting van :price',
+                        'duplicate-group-price-error' => 'A discount for the same customer group and quantity already exists.',
                         'edit-btn' => 'Bewerk',
                         'empty-info' => 'Speciale prijzen voor klanten die behoren tot een specifieke groep.',
                         'fixed-group-price-info' => 'Voor :qty Hoeveelheid tegen een vaste prijs van :price',

--- a/packages/Webkul/Admin/src/Resources/lang/pl/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/pl/app.php
@@ -1190,6 +1190,7 @@ return [
                         'all-groups' => 'Wszystkie grupy',
                         'create-btn' => 'Dodaj nową',
                         'discount-group-price-info' => 'Dla ilości :qty w cenie obniżonej o :price',
+                        'duplicate-group-price-error' => 'A discount for the same customer group and quantity already exists.',
                         'edit-btn' => 'Edytuj',
                         'empty-info' => 'Specjalne ceny dla klientów należących do określonej grupy.',
                         'fixed-group-price-info' => 'Dla :qty sztuk w stałej cenie :price',

--- a/packages/Webkul/Admin/src/Resources/lang/pt_BR/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/pt_BR/app.php
@@ -1190,6 +1190,7 @@ return [
                         'all-groups' => 'Todos os grupos',
                         'create-btn' => 'Adicionar Novo',
                         'discount-group-price-info' => 'Para :qty Quantidade com desconto de :price',
+                        'duplicate-group-price-error' => 'A discount for the same customer group and quantity already exists.',
                         'edit-btn' => 'Editar',
                         'empty-info' => 'Preços especiais para clientes que pertencem a um grupo específico.',
                         'fixed-group-price-info' => 'Para :qty Quantidade a preço fixo de :price',

--- a/packages/Webkul/Admin/src/Resources/lang/ro/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ro/app.php
@@ -1190,6 +1190,7 @@ return [
                         'all-groups' => 'All Groups',
                         'create-btn' => 'Add New',
                         'discount-group-price-info' => 'For :qty Qty at discount of :price',
+                        'duplicate-group-price-error' => 'A discount for the same customer group and quantity already exists.',
                         'edit-btn' => 'Edit',
                         'empty-info' => 'Special pricing for customers belonging to a specific group.',
                         'fixed-group-price-info' => 'For :qty Qty at fixed price of :price',

--- a/packages/Webkul/Admin/src/Resources/lang/ru/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ru/app.php
@@ -1190,6 +1190,7 @@ return [
                         'all-groups' => 'Все группы',
                         'create-btn' => 'Добавить новое',
                         'discount-group-price-info' => 'Для :qty шт. со скидкой :price',
+                        'duplicate-group-price-error' => 'A discount for the same customer group and quantity already exists.',
                         'edit-btn' => 'Редактировать',
                         'empty-info' => 'Специальная цена для клиентов, принадлежащих к определенной группе.',
                         'fixed-group-price-info' => 'Для :qty шт. по фиксированной цене :price',

--- a/packages/Webkul/Admin/src/Resources/lang/sin/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/sin/app.php
@@ -1190,6 +1190,7 @@ return [
                         'all-groups' => 'සියලු සමූහ',
                         'create-btn' => 'නවකරන්න',
                         'discount-group-price-info' => ':qty ප්‍රමාණයට මිල :price වාරිකා කළ යුතුය',
+                        'duplicate-group-price-error' => 'A discount for the same customer group and quantity already exists.',
                         'edit-btn' => 'සංස්කරණය කරන්න',
                         'empty-info' => 'විශේෂ ප්‍රමාණයක් අනුගමනට හෝදන පමණක්.',
                         'fixed-group-price-info' => ':qty ප්‍රමාණයට වලංගු මිල :price වලට වාරිකා කළ යුතුය',

--- a/packages/Webkul/Admin/src/Resources/lang/tr/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/tr/app.php
@@ -1190,6 +1190,7 @@ return [
                         'all-groups' => 'Tüm Gruplar',
                         'create-btn' => 'Yeni Ekle',
                         'discount-group-price-info' => ':qty Miktarında indirimli fiyat :price',
+                        'duplicate-group-price-error' => 'A discount for the same customer group and quantity already exists.',
                         'edit-btn' => 'Düzenle',
                         'empty-info' => 'Belirli bir gruba ait müşteriler için özel fiyatlandırma.',
                         'fixed-group-price-info' => ':qty Miktarında sabit fiyat :price',

--- a/packages/Webkul/Admin/src/Resources/lang/uk/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/uk/app.php
@@ -1190,6 +1190,7 @@ return [
                         'all-groups' => 'Всі групи',
                         'create-btn' => 'Додати новий',
                         'discount-group-price-info' => 'Для :qty штук зі знижкою :price',
+                        'duplicate-group-price-error' => 'A discount for the same customer group and quantity already exists.',
                         'edit-btn' => 'Редагувати',
                         'empty-info' => 'Спеціальні ціни для покупців, які належать до певної групи.',
                         'fixed-group-price-info' => 'Для :qty штук за фіксованою ціною :price',

--- a/packages/Webkul/Admin/src/Resources/lang/zh_CN/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/zh_CN/app.php
@@ -1190,6 +1190,7 @@ return [
                         'all-groups' => '所有群组',
                         'create-btn' => '添加新的',
                         'discount-group-price-info' => '对于 :qty 个数量，折扣价格为 :price',
+                        'duplicate-group-price-error' => 'A discount for the same customer group and quantity already exists.',
                         'edit-btn' => '编辑',
                         'empty-info' => '针对属于特定组的客户的特殊定价。',
                         'fixed-group-price-info' => '对于 :qty 个数量，固定价格为 :price',


### PR DESCRIPTION
## Summary

- Add server-side validation in `ProductForm` to reject duplicate `(qty, customer_group_id)` combinations in customer group prices
- Return a proper validation error message instead of an unhandled 500 Internal Server Error
- Add translation key `duplicate-group-price-error` across all locales

Fixes #10976

## Root Cause

The `product_customer_group_prices` table has a unique constraint on `unique_id` (composed of `qty|product_id|customer_group_id`). When an admin submits duplicate group price entries for the same customer group and quantity, the `ProductCustomerGroupPriceRepository::saveCustomerGroupPrices()` method calls `create()` without checking for duplicates, hitting the unique constraint and throwing an unhandled `QueryException` that surfaces as a 500 ISE.

## Fix

Added a custom validation rule in `ProductForm::addCustomerGroupPriceRules()` that checks the submitted `customer_group_prices` array for duplicate `(qty, customer_group_id)` pairs before the data reaches the repository layer. When duplicates are found, Laravel's validation returns a proper error message: _"A discount for the same customer group and quantity already exists."_

## Test plan

- [ ] Login as Admin
- [ ] Navigate to Catalog → Products → Edit any product
- [ ] Go to the Customer Group Price section
- [ ] Add a group discount (e.g., "Guest" group, qty 1, fixed price $10)
- [ ] Add another discount with the **same** customer group and quantity
- [ ] Click Save Product
- [ ] Verify a validation error message appears instead of a 500 error
- [ ] Verify that different `(group, qty)` combinations still save successfully