### PR TITLE
fix: update compare count badge in header on add/remove

### DIFF
--- a/packages/Webkul/Shop/src/Http/Controllers/API/CompareController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/API/CompareController.php
@@ -56,8 +56,10 @@ class CompareController extends APIController
             'product_id' => 'required|integer|exists:products,id',
         ]);
 
+        $customer = auth()->guard('customer')->user();
+
         $compareProduct = $this->compareItemRepository->findOneByField([
-            'customer_id' => auth()->guard('customer')->user()->id,
+            'customer_id' => $customer->id,
             'product_id' => request()->input('product_id'),
         ]);
 
@@ -70,13 +72,23 @@ class CompareController extends APIController
         Event::dispatch('customer.compare.create.before');
 
         $compareProduct = $this->compareItemRepository->create([
-            'customer_id' => auth()->guard('customer')->user()->id,
+            'customer_id' => $customer->id,
             'product_id' => request()->input('product_id'),
         ]);
 
         Event::dispatch('customer.compare.create.after', $compareProduct);
 
+        $productIds = $this->compareItemRepository
+            ->findByField('customer_id', $customer->id)
+            ->pluck('product_id')
+            ->toArray();
+
+        $products = $this->productRepository
+            ->whereIn('id', $productIds)
+            ->get();
+
         return new JsonResource([
+            'data' => CompareItemResource::collection($products),
             'message' => trans('shop::app.compare.item-add-success'),
         ]);
     }

--- a/packages/Webkul/Shop/src/Resources/views/compare/index.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/compare/index.blade.php
@@ -219,6 +219,8 @@
 
                                     localStorage.setItem('compare_items', JSON.stringify(items));
 
+                                    this.$emitter.emit('update-compare-count', items.length);
+
                                     return;
                                 }
 
@@ -228,6 +230,8 @@
                                     })
                                     .then(response => {
                                         this.items = response.data.data;
+
+                                        this.$emitter.emit('update-compare-count', response.data.data.length);
 
                                         this.$emitter.emit('add-flash', { type: 'success', message: response.data.message });
 
@@ -247,6 +251,8 @@
 
                                     this.items = [];
 
+                                    this.$emitter.emit('update-compare-count', 0);
+
                                     this.$emitter.emit('add-flash', { type: 'success', message:  "@lang('shop::app.compare.remove-all-success')" });
 
                                     return;
@@ -257,6 +263,8 @@
                                     })
                                     .then(response => {
                                         this.items = [];
+
+                                        this.$emitter.emit('update-compare-count', 0);
 
                                         this.$emitter.emit('add-flash', { type: 'success', message: response.data.data.message });
                                     })

--- a/packages/Webkul/Shop/src/Resources/views/components/layouts/header/compare-count.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/components/layouts/header/compare-count.blade.php
@@ -1,0 +1,74 @@
+<!-- Compare Count Vue Component -->
+<v-compare-count></v-compare-count>
+
+@pushOnce('scripts')
+    <script
+        type="text/x-template"
+        id="v-compare-count-template"
+    >
+        <span
+            class="absolute -top-4 rounded-[44px] bg-navyBlue px-2 py-1.5 text-xs font-semibold leading-[9px] text-white ltr:left-5 rtl:right-5 max-md:px-2 max-md:py-1.5 max-md:ltr:left-4 max-md:rtl:right-4"
+            v-if="count"
+        >
+            @{{ count }}
+        </span>
+    </script>
+
+    <script type="module">
+        app.component('v-compare-count', {
+            template: '#v-compare-count-template',
+
+            data() {
+                return {
+                    count: 0,
+
+                    isCustomer: '{{ auth()->guard('customer')->check() }}',
+                };
+            },
+
+            mounted() {
+                this.getCount();
+
+                this.$emitter.on('update-compare-count', (count) => {
+                    if (typeof count === 'number') {
+                        this.count = count;
+
+                        return;
+                    }
+
+                    this.getCount();
+                });
+            },
+
+            methods: {
+                getCount() {
+                    let productIds = [];
+
+                    if (! this.isCustomer) {
+                        productIds = this.getStorageValue();
+                    }
+
+                    this.$axios.get('{{ route("shop.api.compare.index") }}', {
+                            params: {
+                                product_ids: productIds,
+                            },
+                        })
+                        .then(response => {
+                            this.count = response.data.data.length;
+                        })
+                        .catch(error => {});
+                },
+
+                getStorageValue() {
+                    let value = localStorage.getItem('compare_items');
+
+                    if (! value) {
+                        return [];
+                    }
+
+                    return JSON.parse(value);
+                },
+            },
+        });
+    </script>
+@endpushOnce

--- a/packages/Webkul/Shop/src/Resources/views/components/layouts/header/desktop/bottom.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/components/layouts/header/desktop/bottom.blade.php
@@ -111,11 +111,14 @@
                 <a
                     href="{{ route('shop.compare.index') }}"
                     aria-label="@lang('shop::app.components.layouts.header.desktop.bottom.compare')"
+                    class="relative"
                 >
                     <span
                         class="inline-block text-2xl cursor-pointer icon-compare"
                         role="presentation"
                     ></span>
+
+                    @include('shop::components.layouts.header.compare-count')
                 </a>
             @endif
 

--- a/packages/Webkul/Shop/src/Resources/views/components/layouts/header/mobile/index.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/components/layouts/header/mobile/index.blade.php
@@ -47,8 +47,11 @@
                     <a
                         href="{{ route('shop.compare.index') }}"
                         aria-label="@lang('shop::app.components.layouts.header.mobile.compare')"
+                        class="relative"
                     >
                         <span class="text-2xl cursor-pointer icon-compare"></span>
+
+                        @include('shop::components.layouts.header.compare-count')
                     </a>
                 @endif
 

--- a/packages/Webkul/Shop/src/Resources/views/components/products/card.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/components/products/card.blade.php
@@ -379,7 +379,9 @@
                                 'product_id': productId
                             })
                             .then(response => {
-                                this.$emitter.emit('add-flash', { type: 'success', message: response.data.data.message });
+                                this.$emitter.emit('update-compare-count', response.data.data.length);
+
+                                this.$emitter.emit('add-flash', { type: 'success', message: response.data.message });
                             })
                             .catch(error => {
                                 if ([400, 422].includes(error.response.status)) {
@@ -405,12 +407,16 @@
 
                             localStorage.setItem('compare_items', JSON.stringify(items));
 
+                            this.$emitter.emit('update-compare-count', items.length);
+
                             this.$emitter.emit('add-flash', { type: 'success', message: "@lang('shop::app.components.products.card.add-to-compare-success')" });
                         } else {
                             this.$emitter.emit('add-flash', { type: 'warning', message: "@lang('shop::app.components.products.card.already-in-compare')" });
                         }
                     } else {
                         localStorage.setItem('compare_items', JSON.stringify([productId]));
+
+                        this.$emitter.emit('update-compare-count', 1);
 
                         this.$emitter.emit('add-flash', { type: 'success', message: "@lang('shop::app.components.products.card.add-to-compare-success')" });
 

--- a/packages/Webkul/Shop/src/Resources/views/products/view.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/products/view.blade.php
@@ -692,7 +692,9 @@
                                     'product_id': productId
                                 })
                                 .then(response => {
-                                    this.$emitter.emit('add-flash', { type: 'success', message: response.data.data.message });
+                                    this.$emitter.emit('update-compare-count', response.data.data.length);
+
+                                    this.$emitter.emit('add-flash', { type: 'success', message: response.data.message });
                                 })
                                 .catch(error => {
                                     if ([400, 422].includes(error.response.status)) {
@@ -718,12 +720,16 @@
 
                                 this.setStorageValue(this.getCompareItemsStorageKey(), existingItems);
 
+                                this.$emitter.emit('update-compare-count', existingItems.length);
+
                                 this.$emitter.emit('add-flash', { type: 'success', message: "@lang('shop::app.products.view.add-to-compare')" });
                             } else {
                                 this.$emitter.emit('add-flash', { type: 'warning', message: "@lang('shop::app.products.view.already-in-compare')" });
                             }
                         } else {
                             this.setStorageValue(this.getCompareItemsStorageKey(), [productId]);
+
+                            this.$emitter.emit('update-compare-count', 1);
 
                             this.$emitter.emit('add-flash', { type: 'success', message: "@lang('shop::app.products.view.add-to-compare')" });
                         }

--- a/packages/Webkul/Shop/tests/Feature/API/CompareTest.php
+++ b/packages/Webkul/Shop/tests/Feature/API/CompareTest.php
@@ -1,0 +1,175 @@
+<?php
+
+use Webkul\Customer\Models\Customer as ModelsCustomer;
+use Webkul\Faker\Helpers\Product as ProductFaker;
+
+use function Pest\Laravel\deleteJson;
+use function Pest\Laravel\getJson;
+use function Pest\Laravel\postJson;
+
+it('should add the product to the compare list and return the updated list', function () {
+    // Arrange.
+    $product = (new ProductFaker([
+        'attributes' => [
+            5 => 'new',
+            6 => 'featured',
+            11 => 'price',
+            26 => 'guest_checkout',
+        ],
+        'attribute_value' => [
+            'new' => [
+                'boolean_value' => true,
+            ],
+            'featured' => [
+                'boolean_value' => true,
+            ],
+            'price' => [
+                'float_value' => fake()->randomFloat(2, 1000, 5000),
+            ],
+            'guest_checkout' => [
+                'boolean_value' => true,
+            ],
+        ],
+    ]))->getSimpleProductFactory()->create();
+
+    // Act and Assert.
+    $this->loginAsCustomer();
+
+    postJson(route('shop.api.compare.store'), [
+        'product_id' => $product->id,
+    ])
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.id', $product->id)
+        ->assertJsonPath('message', trans('shop::app.compare.item-add-success'));
+});
+
+it('should fail when adding the same product to the compare list twice', function () {
+    // Arrange.
+    $product = (new ProductFaker([
+        'attributes' => [
+            5 => 'new',
+            6 => 'featured',
+            11 => 'price',
+            26 => 'guest_checkout',
+        ],
+        'attribute_value' => [
+            'new' => [
+                'boolean_value' => true,
+            ],
+            'featured' => [
+                'boolean_value' => true,
+            ],
+            'price' => [
+                'float_value' => fake()->randomFloat(2, 1000, 5000),
+            ],
+            'guest_checkout' => [
+                'boolean_value' => true,
+            ],
+        ],
+    ]))->getSimpleProductFactory()->create();
+
+    $customer = ModelsCustomer::factory()->create();
+
+    // Act and Assert.
+    $this->loginAsCustomer($customer);
+
+    postJson(route('shop.api.compare.store'), [
+        'product_id' => $product->id,
+    ])->assertOk();
+
+    postJson(route('shop.api.compare.store'), [
+        'product_id' => $product->id,
+    ])
+        ->assertUnprocessable()
+        ->assertJsonPath('data.message', trans('shop::app.compare.already-added'));
+});
+
+it('should remove the product from the compare list and return the updated list', function () {
+    // Arrange.
+    $products = (new ProductFaker([
+        'attributes' => [
+            5 => 'new',
+            6 => 'featured',
+            11 => 'price',
+            26 => 'guest_checkout',
+        ],
+        'attribute_value' => [
+            'new' => [
+                'boolean_value' => true,
+            ],
+            'featured' => [
+                'boolean_value' => true,
+            ],
+            'price' => [
+                'float_value' => fake()->randomFloat(2, 1000, 5000),
+            ],
+            'guest_checkout' => [
+                'boolean_value' => true,
+            ],
+        ],
+    ]))->getSimpleProductFactory()->count(2)->create();
+
+    $customer = ModelsCustomer::factory()->create();
+
+    $this->loginAsCustomer($customer);
+
+    foreach ($products as $product) {
+        postJson(route('shop.api.compare.store'), [
+            'product_id' => $product->id,
+        ])->assertOk();
+    }
+
+    // Act and Assert.
+    deleteJson(route('shop.api.compare.destroy'), [
+        'product_id' => $products->first()->id,
+    ])
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('message', trans('shop::app.compare.remove-success'));
+});
+
+it('should remove all products from the compare list', function () {
+    // Arrange.
+    $products = (new ProductFaker([
+        'attributes' => [
+            5 => 'new',
+            6 => 'featured',
+            11 => 'price',
+            26 => 'guest_checkout',
+        ],
+        'attribute_value' => [
+            'new' => [
+                'boolean_value' => true,
+            ],
+            'featured' => [
+                'boolean_value' => true,
+            ],
+            'price' => [
+                'float_value' => fake()->randomFloat(2, 1000, 5000),
+            ],
+            'guest_checkout' => [
+                'boolean_value' => true,
+            ],
+        ],
+    ]))->getSimpleProductFactory()->count(2)->create();
+
+    $customer = ModelsCustomer::factory()->create();
+
+    $this->loginAsCustomer($customer);
+
+    foreach ($products as $product) {
+        postJson(route('shop.api.compare.store'), [
+            'product_id' => $product->id,
+        ])->assertOk();
+    }
+
+    // Act and Assert.
+    deleteJson(route('shop.api.compare.destroy_all'))
+        ->assertOk()
+        ->assertJsonPath('data.message', trans('shop::app.compare.remove-all-success'));
+
+    getJson(route('shop.api.compare.index'))
+        ->assertOk()
+        ->assertJsonCount(0, 'data');
+});


### PR DESCRIPTION
## Issue Reference
#10705

## Description
The compare icon in the header never showed how many products were in the comparison list, and didn't update when a product was added to or removed from compare - unlike the cart icon, which already shows a live item count via the mini-cart badge.

This adds a `v-compare-count` Vue component (mirroring the existing `v-mini-cart` pattern) that:
- Fetches the initial count on mount (via the existing `shop.api.compare.index` endpoint, using `product_ids` from `localStorage` for guests).
- Listens for an `update-compare-count` event and updates reactively.

That event is now emitted from every place a product is added to or removed from compare:
- Product card "Add to Compare" button (logged-in and guest paths).
- Product detail page "Add to Compare" button (logged-in and guest paths).
- The compare page itself, for single-item remove and remove-all (logged-in and guest paths).

`CompareController::store()` was also updated to return the updated item list alongside the message, matching the existing shape of `destroy()`, so the frontend can derive the new count without an extra request.

## How To Test This?
1. Enable **Compare** under *Catalog > Settings* (it's enabled by default).
2. As a guest or logged-in customer, go to the shop and click "Add to Compare" on any product (from a product card, a product carousel, or a product detail page).
3. Confirm a count badge appears next to the compare icon in the header (desktop and mobile), and increments correctly for each subsequent product added.
4. Go to the compare page, remove a single item, and confirm the header badge count decreases.
5. Click "Remove All" on the compare page, and confirm the header badge disappears (count returns to 0).
6. Repeat as both a guest (localStorage-backed) and a logged-in customer (DB-backed) to confirm both paths update the badge.

Automated coverage: added `packages/Webkul/Shop/tests/Feature/API/CompareTest.php`, covering `store`/`destroy`/`destroy_all` returning the updated compare list/count for logged-in customers.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

## Branch Selection
- [x] Target Branch: 2.4

## Tailwind Reordering
- [x] Please make sure all the Tailwind classes are reordered.