### PR TITLE
refactor(shop): adjust login_form_controls.after event position

### DIFF
--- a/packages/Webkul/Shop/src/Resources/views/customers/sign-in.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/customers/sign-in.blade.php
@@ -147,9 +147,10 @@
                         >
                             @lang('shop::app.customers.login-form.button-title')
                         </button>
-
-                        {!! view_render_event('bagisto.shop.customers.login_form_controls.after') !!}
                     </div>
+
+                    {!! view_render_event('bagisto.shop.customers.login_form_controls.after') !!}
+                                
                 </x-shop::form>
             </div>
 

--- a/packages/Webkul/Shop/src/Resources/views/customers/sign-in.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/customers/sign-in.blade.php
@@ -50,7 +50,6 @@
 
             <div class="mt-14 rounded max-sm:mt-8">
                 <x-shop::form :action="route('shop.customer.session.create')">
-
                     {!! view_render_event('bagisto.shop.customers.login_form_controls.before') !!}
 
                     <!-- Email -->
@@ -150,7 +149,6 @@
                     </div>
 
                     {!! view_render_event('bagisto.shop.customers.login_form_controls.after') !!}
-                                
                 </x-shop::form>
             </div>
 


### PR DESCRIPTION
PR Type: Refactoring / UI Improvement

Description: > This PR adjusts the positioning/wrapper of the bagisto.shop.customers.login_form_controls.after view event inside the customer sign-in template.

Why?
The current placement tightly couples injected package views with the login submit button's spacing. Moving or wrapping it cleanly ensures that third-party extensions can inject DOM elements without breaking the core Tailwind layout metrics or overlapping with the .primary-button container.