### PR TITLE
feat: implement channel association for sitemaps via new database mig…

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Marketing/SearchSEO/SitemapDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Marketing/SearchSEO/SitemapDataGrid.php
@@ -16,13 +16,22 @@ class SitemapDataGrid extends DataGrid
      */
     public function prepareQueryBuilder()
     {
-        return DB::table('sitemaps')
+        $queryBuilder = DB::table('sitemaps')
             ->addSelect(
-                'id',
-                'file_name',
-                'path',
-                'path as url'
-            );
+                'sitemaps.id',
+                'sitemaps.file_name',
+                'sitemaps.path',
+                'sitemaps.path as url'
+            )
+            ->addSelect(DB::raw('GROUP_CONCAT(DISTINCT channels.code) as channel'))
+            ->addSelect(DB::raw('GROUP_CONCAT(DISTINCT channels.id) as channel_ids'))
+            ->leftJoin('sitemap_channels', 'sitemaps.id', '=', 'sitemap_channels.sitemap_id')
+            ->leftJoin('channels', 'sitemap_channels.channel_id', '=', 'channels.id')
+            ->groupBy('sitemaps.id');
+
+        $this->addFilter('channel', 'sitemap_channels.channel_id');
+
+        return $queryBuilder;
     }
 
     /**
@@ -37,6 +46,19 @@ class SitemapDataGrid extends DataGrid
             'label' => trans('admin::app.marketing.search-seo.sitemaps.index.datagrid.id'),
             'type' => 'integer',
             'filterable' => true,
+            'sortable' => true,
+        ]);
+
+        $this->addColumn([
+            'index' => 'channel',
+            'label' => trans('admin::app.marketing.search-seo.sitemaps.index.datagrid.channel'),
+            'type' => 'string',
+            'filterable' => true,
+            'filterable_type' => 'dropdown',
+            'filterable_options' => collect(core()->getAllChannels())
+                ->map(fn ($channel) => ['label' => $channel->name, 'value' => $channel->id])
+                ->values()
+                ->toArray(),
             'sortable' => true,
         ]);
 
@@ -63,6 +85,20 @@ class SitemapDataGrid extends DataGrid
             'type' => 'string',
             'closure' => function ($row) {
                 return Storage::disk('public')->url(clean_path($row->path.'/'.$row->file_name));
+            },
+        ]);
+
+        $this->addColumn([
+            'index' => 'channel_ids',
+            'label' => 'Channel IDs',
+            'type' => 'string',
+            'visibility' => false,
+            'closure' => function ($row) {
+                if (empty($row->channel_ids)) {
+                    return [];
+                }
+
+                return array_map('intval', explode(',', $row->channel_ids));
             },
         ]);
     }

--- a/packages/Webkul/Admin/src/Http/Controllers/Marketing/SearchSEO/SitemapController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Marketing/SearchSEO/SitemapController.php
@@ -39,6 +39,7 @@ class SitemapController extends Controller
     public function store(): JsonResponse
     {
         $this->validate(request(), [
+            'channels' => 'required|array|min:1',
             'file_name' => 'required|regex:/^[\w\-\.]+$/|ends_with:.xml',
             'path' => 'required|starts_with:/|regex:/^(?!.*\/\/)[\w\-\.\/]+$/|ends_with:/',
         ]);
@@ -46,6 +47,7 @@ class SitemapController extends Controller
         Event::dispatch('marketing.search_seo.sitemap.create.before');
 
         $sitemap = $this->sitemapRepository->create(request()->only([
+            'channels',
             'file_name',
             'path',
         ]));
@@ -69,6 +71,7 @@ class SitemapController extends Controller
         $id = request()->id;
 
         $this->validate(request(), [
+            'channels' => 'required|array|min:1',
             'file_name' => 'required|regex:/^[\w\-\.]+$/|ends_with:.xml',
             'path' => 'required|starts_with:/|regex:/^(?!.*\/\/)[\w\-\.\/]+$/|ends_with:/',
         ]);
@@ -76,6 +79,7 @@ class SitemapController extends Controller
         Event::dispatch('marketing.search_seo.sitemap.update.before', $id);
 
         $sitemap = $this->sitemapRepository->update(request()->only([
+            'channels',
             'file_name',
             'path',
         ]), $id);

--- a/packages/Webkul/Admin/src/Resources/lang/ar/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ar/app.php
@@ -3085,6 +3085,7 @@ return [
 
                     'datagrid' => [
                         'actions' => 'إجراءات',
+                        'channel' => 'القناة',
                         'delete' => 'حذف',
                         'edit' => 'تعديل',
                         'file-name' => 'اسم الملف',
@@ -3094,6 +3095,7 @@ return [
                     ],
 
                     'create' => [
+                        'channels' => 'القنوات',
                         'delete-warning' => 'هل أنت متأكد أنك تريد القيام بهذا الإجراء؟',
                         'file-name' => 'اسم الملف',
                         'file-name-info' => 'مثال: sitemap.xml',

--- a/packages/Webkul/Admin/src/Resources/lang/bn/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/bn/app.php
@@ -3085,6 +3085,7 @@ return [
 
                     'datagrid' => [
                         'actions' => 'ক্রিয়া',
+                        'channel' => 'চ্যানেল',
                         'delete' => 'মুছে ফেলুন',
                         'edit' => 'সম্পাদনা করুন',
                         'file-name' => 'ফাইল নাম',
@@ -3094,6 +3095,7 @@ return [
                     ],
 
                     'create' => [
+                        'channels' => 'চ্যানেলস',
                         'delete-warning' => 'আপনি কি এই ক্রিয়াটি সম্পাদন করতে চান তা নিশ্চিত?',
                         'file-name' => 'ফাইল নাম',
                         'file-name-info' => 'উদাহরণ: sitemap.xml',

--- a/packages/Webkul/Admin/src/Resources/lang/ca/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ca/app.php
@@ -3085,6 +3085,7 @@ return [
 
                     'datagrid' => [
                         'actions' => 'Accions',
+                        'channel' => 'Canal',
                         'delete' => 'Eliminar',
                         'edit' => 'Editar',
                         'file-name' => 'Nom de l\'arxiu',
@@ -3094,6 +3095,7 @@ return [
                     ],
 
                     'create' => [
+                        'channels' => 'Canals',
                         'delete-warning' => 'Estàs segur que vols realitzar aquesta acció?',
                         'file-name' => 'Nom del fitxer',
                         'file-name-info' => 'Exemple: sitemap.xml',

--- a/packages/Webkul/Admin/src/Resources/lang/de/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/de/app.php
@@ -3085,6 +3085,7 @@ return [
 
                     'datagrid' => [
                         'actions' => 'Aktionen',
+                        'channel' => 'Kanal',
                         'delete' => 'Löschen',
                         'edit' => 'Bearbeiten',
                         'file-name' => 'Dateiname',
@@ -3094,6 +3095,7 @@ return [
                     ],
 
                     'create' => [
+                        'channels' => 'Kanäle',
                         'delete-warning' => 'Sind Sie sicher, dass Sie diese Aktion ausführen möchten?',
                         'file-name' => 'Dateiname',
                         'file-name-info' => 'Beispiel: sitemap.xml',

--- a/packages/Webkul/Admin/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en/app.php
@@ -3085,6 +3085,7 @@ return [
 
                     'datagrid' => [
                         'actions' => 'Actions',
+                        'channel' => 'Channel',
                         'delete' => 'Delete',
                         'edit' => 'Edit',
                         'file-name' => 'File Name',
@@ -3094,6 +3095,7 @@ return [
                     ],
 
                     'create' => [
+                        'channels' => 'Channels',
                         'delete-warning' => 'Are you sure, you want to perform this action?',
                         'file-name' => 'File Name',
                         'file-name-info' => 'Example: sitemap.xml',

--- a/packages/Webkul/Admin/src/Resources/lang/es/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/es/app.php
@@ -3085,6 +3085,7 @@ return [
 
                     'datagrid' => [
                         'actions' => 'Acciones',
+                        'channel' => 'Canal',
                         'delete' => 'Eliminar',
                         'edit' => 'Editar',
                         'file-name' => 'Nombre del archivo',
@@ -3094,6 +3095,7 @@ return [
                     ],
 
                     'create' => [
+                        'channels' => 'Canales',
                         'delete-warning' => '¿Estás seguro de que deseas realizar esta acción?',
                         'file-name' => 'Nombre del archivo',
                         'file-name-info' => 'Ejemplo: sitemap.xml',

--- a/packages/Webkul/Admin/src/Resources/lang/fa/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/fa/app.php
@@ -3085,6 +3085,7 @@ return [
 
                     'datagrid' => [
                         'actions' => 'عملیات',
+                        'channel' => 'کانال',
                         'delete' => 'حذف',
                         'edit' => 'ویرایش',
                         'file-name' => 'نام فایل',
@@ -3094,6 +3095,7 @@ return [
                     ],
 
                     'create' => [
+                        'channels' => 'کانال‌ها',
                         'delete-warning' => 'آیا از انجام این عملیات مطمئن هستید؟',
                         'file-name' => 'نام فایل',
                         'file-name-info' => 'مثال: sitemap.xml',

--- a/packages/Webkul/Admin/src/Resources/lang/fr/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/fr/app.php
@@ -3085,6 +3085,7 @@ return [
 
                     'datagrid' => [
                         'actions' => 'Actions',
+                        'channel' => 'Canal',
                         'delete' => 'Supprimer',
                         'edit' => 'Modifier',
                         'file-name' => 'Nom de fichier',
@@ -3094,6 +3095,7 @@ return [
                     ],
 
                     'create' => [
+                        'channels' => 'Canaux',
                         'delete-warning' => 'Êtes-vous sûr de vouloir effectuer cette action ?',
                         'file-name' => 'Nom de fichier',
                         'file-name-info' => 'Exemple : sitemap.xml',

--- a/packages/Webkul/Admin/src/Resources/lang/he/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/he/app.php
@@ -3085,6 +3085,7 @@ return [
 
                     'datagrid' => [
                         'actions' => 'פעולות',
+                        'channel' => 'ערוץ',
                         'delete' => 'מחיקה',
                         'edit' => 'עריכה',
                         'file-name' => 'שם קובץ',
@@ -3094,6 +3095,7 @@ return [
                     ],
 
                     'create' => [
+                        'channels' => 'ערוצים',
                         'delete-warning' => 'האם אתה בטוח שברצונך לבצע פעולה זו?',
                         'file-name' => 'שם קובץ',
                         'file-name-info' => 'דוגמה: sitemap.xml',

--- a/packages/Webkul/Admin/src/Resources/lang/hi_IN/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/hi_IN/app.php
@@ -3085,6 +3085,7 @@ return [
 
                     'datagrid' => [
                         'actions' => 'Actions',
+                        'channel' => 'चैनल',
                         'delete' => 'Delete',
                         'edit' => 'Edit',
                         'file-name' => 'File Name',
@@ -3094,6 +3095,7 @@ return [
                     ],
 
                     'create' => [
+                        'channels' => 'चैनल',
                         'delete-warning' => 'Are you sure, you want to perform this action?',
                         'file-name' => 'File Name',
                         'file-name-info' => 'Example: sitemap.xml',

--- a/packages/Webkul/Admin/src/Resources/lang/id/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/id/app.php
@@ -3085,6 +3085,7 @@ return [
 
                     'datagrid' => [
                         'actions' => 'Aksi',
+                        'channel' => 'Saluran',
                         'delete' => 'Hapus',
                         'edit' => 'Edit',
                         'file-name' => 'Nama File',
@@ -3094,6 +3095,7 @@ return [
                     ],
 
                     'create' => [
+                        'channels' => 'Saluran',
                         'delete-warning' => 'Apakah Anda yakin ingin melakukan tindakan ini?',
                         'file-name' => 'Nama File',
                         'file-name-info' => 'Contoh: sitemap.xml',
@@ -4049,7 +4051,7 @@ return [
         'products' => [
             'index' => [
                 'all-channels' => 'Semua Channel',
-                'channel' => 'Channel',
+                'channel' => 'Saluran',
                 'end-date' => 'Tanggal Akhir',
                 'id' => 'ID',
                 'interval' => 'Interval',

--- a/packages/Webkul/Admin/src/Resources/lang/it/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/it/app.php
@@ -3085,6 +3085,7 @@ return [
 
                     'datagrid' => [
                         'actions' => 'Azioni',
+                        'channel' => 'Canale',
                         'delete' => 'Elimina',
                         'edit' => 'Modifica',
                         'file-name' => 'Nome File',
@@ -3094,6 +3095,7 @@ return [
                     ],
 
                     'create' => [
+                        'channels' => 'Canali',
                         'delete-warning' => 'Sei sicuro di voler eseguire questa azione?',
                         'file-name' => 'Nome File',
                         'file-name-info' => 'Esempio: sitemap.xml',

--- a/packages/Webkul/Admin/src/Resources/lang/ja/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ja/app.php
@@ -3085,6 +3085,7 @@ return [
 
                     'datagrid' => [
                         'actions' => 'アクション',
+                        'channel' => 'チャネル',
                         'delete' => '削除',
                         'edit' => '編集',
                         'file-name' => 'ファイル名',
@@ -3094,6 +3095,7 @@ return [
                     ],
 
                     'create' => [
+                        'channels' => 'チャンネル',
                         'delete-warning' => '本当にこのアクションを実行しますか？',
                         'file-name' => 'ファイル名',
                         'file-name-info' => '例: sitemap.xml',

--- a/packages/Webkul/Admin/src/Resources/lang/nl/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/nl/app.php
@@ -3085,6 +3085,7 @@ return [
 
                     'datagrid' => [
                         'actions' => 'Acties',
+                        'channel' => 'Kanaal',
                         'delete' => 'Verwijderen',
                         'edit' => 'Bewerk',
                         'file-name' => 'Bestandsnaam',
@@ -3094,6 +3095,7 @@ return [
                     ],
 
                     'create' => [
+                        'channels' => 'Kanalen',
                         'delete-warning' => 'Weet je zeker dat je deze actie wilt uitvoeren?',
                         'file-name' => 'Bestandsnaam',
                         'file-name-info' => 'Voorbeeld: sitemap.xml',

--- a/packages/Webkul/Admin/src/Resources/lang/pl/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/pl/app.php
@@ -3085,6 +3085,7 @@ return [
 
                     'datagrid' => [
                         'actions' => 'Akcje',
+                        'channel' => 'Kanał',
                         'delete' => 'Usuń',
                         'edit' => 'Edytuj',
                         'file-name' => 'Nazwa pliku',
@@ -3094,6 +3095,7 @@ return [
                     ],
 
                     'create' => [
+                        'channels' => 'Kanały',
                         'delete-warning' => 'Czy na pewno chcesz wykonać tę akcję?',
                         'file-name' => 'Nazwa pliku',
                         'file-name-info' => 'Przykład: sitemap.xml',

--- a/packages/Webkul/Admin/src/Resources/lang/pt_BR/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/pt_BR/app.php
@@ -3085,6 +3085,7 @@ return [
 
                     'datagrid' => [
                         'actions' => 'Ações',
+                        'channel' => 'Canal',
                         'delete' => 'Excluir',
                         'edit' => 'Editar',
                         'file-name' => 'Nome do Arquivo',
@@ -3094,6 +3095,7 @@ return [
                     ],
 
                     'create' => [
+                        'channels' => 'Canais',
                         'delete-warning' => 'Você tem certeza de que deseja executar esta ação?',
                         'file-name' => 'Nome do Arquivo',
                         'file-name-info' => 'Exemplo: sitemap.xml',

--- a/packages/Webkul/Admin/src/Resources/lang/ro/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ro/app.php
@@ -3085,6 +3085,7 @@ return [
 
                     'datagrid' => [
                         'actions' => 'Actions',
+                        'channel' => 'Channel',
                         'delete' => 'Delete',
                         'edit' => 'Edit',
                         'file-name' => 'File Name',
@@ -3094,6 +3095,7 @@ return [
                     ],
 
                     'create' => [
+                        'channels' => 'Channels',
                         'delete-warning' => 'Are you sure, you want to perform this action?',
                         'file-name' => 'File Name',
                         'file-name-info' => 'Example: sitemap.xml',

--- a/packages/Webkul/Admin/src/Resources/lang/ru/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ru/app.php
@@ -3085,6 +3085,7 @@ return [
 
                     'datagrid' => [
                         'actions' => 'Действия',
+                        'channel' => 'Канал',
                         'delete' => 'Удалить',
                         'edit' => 'Редактировать',
                         'file-name' => 'Имя файла',
@@ -3094,6 +3095,7 @@ return [
                     ],
 
                     'create' => [
+                        'channels' => 'Каналы',
                         'delete-warning' => 'Вы уверены, что хотите выполнить это действие?',
                         'file-name' => 'Имя файла',
                         'file-name-info' => 'Пример: sitemap.xml',

--- a/packages/Webkul/Admin/src/Resources/lang/sin/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/sin/app.php
@@ -3085,6 +3085,7 @@ return [
 
                     'datagrid' => [
                         'actions' => 'ක්‍රියා',
+                        'channel' => 'චැනලය',
                         'delete' => 'මකාදමන්',
                         'edit' => 'සංස්කරණය',
                         'file-name' => 'ගොනුවේ නම',
@@ -3094,6 +3095,7 @@ return [
                     ],
 
                     'create' => [
+                        'channels' => 'නිලධාරීන්',
                         'delete-warning' => 'ඔබට මෙම ක්‍රියාන්විය කලමනාකර, මම නිවැරදියියේයයිද?',
                         'file-name' => 'ගොනුවේ නම',
                         'file-name-info' => 'උදා: sitemap.xml',

--- a/packages/Webkul/Admin/src/Resources/lang/tr/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/tr/app.php
@@ -3085,6 +3085,7 @@ return [
 
                     'datagrid' => [
                         'actions' => 'İşlemler',
+                        'channel' => 'Kanal',
                         'delete' => 'Sil',
                         'edit' => 'Düzenle',
                         'file-name' => 'Dosya Adı',
@@ -3094,6 +3095,7 @@ return [
                     ],
 
                     'create' => [
+                        'channels' => 'Kanallar',
                         'delete-warning' => 'Emin misiniz, bu işlemi gerçekleştirmek istediğinize?',
                         'file-name' => 'Dosya Adı',
                         'file-name-info' => 'Örnek: sitemap.xml',

--- a/packages/Webkul/Admin/src/Resources/lang/uk/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/uk/app.php
@@ -3085,6 +3085,7 @@ return [
 
                     'datagrid' => [
                         'actions' => 'Дії',
+                        'channel' => 'Канал',
                         'delete' => 'Видалити',
                         'edit' => 'Редагувати',
                         'file-name' => 'Ім я файлу',
@@ -3094,6 +3095,7 @@ return [
                     ],
 
                     'create' => [
+                        'channels' => 'Канали',
                         'delete-warning' => 'Ви впевнені, що хочете виконати цю дію?',
                         'file-name' => 'Ім я файлу',
                         'file-name-info' => 'Приклад: sitemap.xml',

--- a/packages/Webkul/Admin/src/Resources/lang/zh_CN/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/zh_CN/app.php
@@ -3085,6 +3085,7 @@ return [
 
                     'datagrid' => [
                         'actions' => '操作',
+                        'channel' => '渠道',
                         'delete' => '删除',
                         'edit' => '编辑',
                         'file-name' => '文件名',
@@ -3094,6 +3095,7 @@ return [
                     ],
 
                     'create' => [
+                        'channels' => '渠道',
                         'delete-warning' => '您确定要执行此操作吗？',
                         'file-name' => '文件名',
                         'file-name-info' => '示例：sitemap.xml',

--- a/packages/Webkul/Admin/src/Resources/views/marketing/search-seo/sitemaps/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/marketing/search-seo/sitemaps/index.blade.php
@@ -40,7 +40,7 @@
                 @if (bouncer()->hasPermission('marketing.search_seo.sitemaps.create'))
                     <div
                         class="primary-button"
-                        @click="selectedSitemap=0; $refs.sitemap.toggle()"
+                        @click="selectedSitemap=0; selectedChannels=[]; $refs.sitemap.toggle()"
                     >
                         @lang('admin::app.marketing.search-seo.sitemaps.index.create-btn')
                     </div>
@@ -72,16 +72,27 @@
                             :style="`grid-template-columns: repeat(${gridsCount}, minmax(0, 1fr))`"
                         >
                             <!-- ID -->
-                            <p>@{{ record.id }}</p>
+                            <p v-if="available.columns.find(column => column.index === 'id')?.visibility">
+                                @{{ record.id }}
+                            </p>
+
+                            <!-- Channel -->
+                            <p v-if="available.columns.find(column => column.index === 'channel')?.visibility">
+                                @{{ record.channel }}
+                            </p>
 
                             <!-- File Name -->
-                            <p>@{{ record.file_name }}</p>
+                            <p v-if="available.columns.find(column => column.index === 'file_name')?.visibility">
+                                @{{ record.file_name }}
+                            </p>
 
                             <!-- Path -->
-                            <p>@{{ record.path }}</p>
+                            <p v-if="available.columns.find(column => column.index === 'path')?.visibility">
+                                @{{ record.path }}
+                            </p>
 
                             <!-- URL -->
-                            <p>
+                            <p v-if="available.columns.find(column => column.index === 'url')?.visibility">
                                 <a :href="record.url" target="_blank">
                                     @{{ record.url}}
                                 </a>
@@ -199,6 +210,36 @@
                                     @lang('admin::app.marketing.search-seo.sitemaps.index.create.path-info')
                                 </p>
                             </x-admin::form.control-group>
+
+                            <!-- Select Channels -->
+                            <x-admin::form.control-group.label class="required">
+                                @lang('admin::app.marketing.search-seo.sitemaps.index.create.channels')
+                            </x-admin::form.control-group.label>
+
+                            @foreach(core()->getAllChannels() as $channel)
+                                <x-admin::form.control-group class="!mb-2 flex select-none items-center gap-2.5 last:!mb-0">
+                                    <x-admin::form.control-group.control
+                                        type="checkbox"
+                                        :id="'channels_' . $channel->id"
+                                        name="channels[]"
+                                        rules="required"
+                                        :value="$channel->id"
+                                        :for="'channels_' . $channel->id"
+                                        :label="trans('admin::app.marketing.search-seo.sitemaps.index.create.channels')"
+                                        ::checked="selectedChannels.includes({{ $channel->id }})"
+                                    />
+
+                                    <label
+                                        class="cursor-pointer text-xs font-medium text-gray-600 dark:text-gray-300"
+                                        for="channels_{{ $channel->id }}"
+                                        v-pre
+                                    >
+                                        {{ core()->getChannelName($channel) }}
+                                    </label>
+                                </x-admin::form.control-group>
+                            @endforeach
+
+                            <x-admin::form.control-group.error control-name="channels[]" />
                         </x-slot>
 
                         <!-- Modal Footer -->
@@ -225,13 +266,15 @@
                     return {
                         selectedSitemap: 0,
 
+                        selectedChannels: [],
+
                         isLoading: false,
                     }
                 },
 
                 computed: {
                     gridsCount() {
-                        let count = this.$refs.datagrid.available.columns.length;
+                        let count = this.$refs.datagrid.available.columns.filter((column) => column.visibility).length;
 
                         if (this.$refs.datagrid.available.actions.length) {
                             ++count;
@@ -277,6 +320,8 @@
                     },
 
                     editModal(values) {
+                        this.selectedChannels = values.channel_ids ?? [];
+
                         this.$refs.sitemap.toggle();
 
                         this.$refs.modalForm.setValues(values);

--- a/packages/Webkul/Sitemap/src/Database/Migrations/2026_07_03_170000_create_sitemap_channels_table.php
+++ b/packages/Webkul/Sitemap/src/Database/Migrations/2026_07_03_170000_create_sitemap_channels_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('sitemap_channels', function (Blueprint $table) {
+            $table->integer('sitemap_id')->unsigned();
+            $table->integer('channel_id')->unsigned();
+
+            $table->unique(['sitemap_id', 'channel_id']);
+
+            $table->foreign('sitemap_id')->references('id')->on('sitemaps')->cascadeOnDelete();
+            $table->foreign('channel_id')->references('id')->on('channels')->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('sitemap_channels');
+    }
+};

--- a/packages/Webkul/Sitemap/src/Jobs/ProcessSitemap.php
+++ b/packages/Webkul/Sitemap/src/Jobs/ProcessSitemap.php
@@ -61,6 +61,11 @@ class ProcessSitemap implements ShouldQueue
         $this->sitemap->deleteFromStorage();
 
         /**
+         * Fetch the associated channel IDs for the sitemap.
+         */
+        $channelIds = $this->sitemap->channels->pluck('id')->toArray();
+
+        /**
          * Process the store URL.
          */
         $this->processItems([Url::create('/')]);
@@ -68,17 +73,42 @@ class ProcessSitemap implements ShouldQueue
         /**
          * Process the categories.
          */
-        Category::query()->chunk(100, fn ($items) => $this->processItems($items));
+        Category::query()
+            ->when(! empty($channelIds), function ($query) use ($channelIds) {
+                $channels = core()->getAllChannels()->whereIn('id', $channelIds);
+
+                $query->where(function ($q) use ($channels) {
+                    foreach ($channels as $channel) {
+                        $rootCategory = Category::query()->find($channel->root_category_id);
+
+                        if ($rootCategory) {
+                            $q->orWhere(function ($subQ) use ($rootCategory) {
+                                $subQ->where('_lft', '>', $rootCategory->_lft)
+                                    ->where('_rgt', '<', $rootCategory->_rgt);
+                            });
+                        }
+                    }
+                });
+            })
+            ->chunk(100, fn ($items) => $this->processItems($items));
 
         /**
          * Process the products.
          */
-        Product::query()->chunk(100, fn ($items) => $this->processItems($items));
+        Product::query()
+            ->when(! empty($channelIds), function ($query) use ($channelIds) {
+                $query->whereHas('channels', fn ($q) => $q->whereIn('channel_id', $channelIds));
+            })
+            ->chunk(100, fn ($items) => $this->processItems($items));
 
         /**
          * Process the CMS pages.
          */
-        Page::query()->chunk(100, fn ($items) => $this->processItems($items));
+        Page::query()
+            ->when(! empty($channelIds), function ($query) use ($channelIds) {
+                $query->whereHas('channels', fn ($q) => $q->whereIn('channel_id', $channelIds));
+            })
+            ->chunk(100, fn ($items) => $this->processItems($items));
 
         /**
          * If there are any items left to be processed then generate the sitemap.

--- a/packages/Webkul/Sitemap/src/Models/Sitemap.php
+++ b/packages/Webkul/Sitemap/src/Models/Sitemap.php
@@ -5,7 +5,9 @@ namespace Webkul\Sitemap\Models;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Facades\Storage;
+use Webkul\Core\Models\ChannelProxy;
 use Webkul\Marketing\Database\Factories\SitemapFactory;
 use Webkul\Sitemap\Contracts\Sitemap as SitemapContract;
 
@@ -24,6 +26,14 @@ class Sitemap extends Model implements SitemapContract
         'generated_at',
         'path',
     ];
+
+    /**
+     * Get the channels that belong to the sitemap.
+     */
+    public function channels(): BelongsToMany
+    {
+        return $this->belongsToMany(ChannelProxy::modelClass(), 'sitemap_channels', 'sitemap_id');
+    }
 
     /**
      * The attributes that should be cast.

--- a/packages/Webkul/Sitemap/src/Repositories/SitemapRepository.php
+++ b/packages/Webkul/Sitemap/src/Repositories/SitemapRepository.php
@@ -14,4 +14,33 @@ class SitemapRepository extends Repository
     {
         return Sitemap::class;
     }
+
+    /**
+     * Create sitemap.
+     *
+     * @return Sitemap
+     */
+    public function create(array $data)
+    {
+        $sitemap = parent::create($data);
+
+        $sitemap->channels()->sync($data['channels']);
+
+        return $sitemap;
+    }
+
+    /**
+     * Update sitemap.
+     *
+     * @param  int  $id
+     * @return Sitemap
+     */
+    public function update(array $data, $id)
+    {
+        $sitemap = parent::update($data, $id);
+
+        $sitemap->channels()->sync($data['channels']);
+
+        return $sitemap;
+    }
 }


### PR DESCRIPTION
## Description
Introduces channel-based management for SEO sitemaps, allowing administrators to generate and filter sitemaps specific to individual channels.

**Key Changes:**
- **Database:** Added `sitemap_channels` pivot table migration (legacy sitemaps remain backward-compatible).
- **Backend:** Bound `channels` relationship to the `Sitemap` model. Updated `SitemapRepository` to sync channels on create/update.
- **Job Processing:** Refactored `ProcessSitemap` to dynamically filter queries (Categories, Products, CMS Pages) using `when()` based on assigned channels.
- **Admin UI:** Added channel multi-select in the Vue edit modal, integrated validation, added a channel filter/column in `SitemapDataGrid`, and fixed a CSS grid visibility bug.
- **Localization:** Added translations for `channel` and `channels` across all 21 locales.

## How To Test This?
1. Run `php artisan migrate`.
2. Go to **Marketing -> Sitemaps** and create a new sitemap (verify channel selection is required).
3. Check that the Channels display correctly in the DataGrid.
4. Toggle the visibility of the Channel column and verify the CSS row layout does not break.
5. Run the queue worker and verify the generated XML only contains entities linked to the selected channels.
