### PR TITLE
docs: correct typos in doc blocks for InventorySourceRequest and CustomerSocialAccount

### DIFF
--- a/packages/Webkul/Admin/src/Http/Requests/InventorySourceRequest.php
+++ b/packages/Webkul/Admin/src/Http/Requests/InventorySourceRequest.php
@@ -12,7 +12,7 @@ use Webkul\Core\Rules\PostCode;
 class InventorySourceRequest extends FormRequest
 {
     /**
-     * Determine if the Configuraion is authorized to make this request.
+     * Determine if the user is authorized to make this request.
      *
      * @return bool
      */

--- a/packages/Webkul/SocialLogin/src/Models/CustomerSocialAccount.php
+++ b/packages/Webkul/SocialLogin/src/Models/CustomerSocialAccount.php
@@ -15,7 +15,7 @@ class CustomerSocialAccount extends Model implements CustomerSocialAccountContra
     ];
 
     /**
-     * Get the customer that belongs to the social aoount.
+     * Get the customer that belongs to the social account.
      */
     public function customer()
     {


### PR DESCRIPTION
### Description
This PR corrects minor spelling typos in the docblocks of two classes:
- Corrects `Configuraion` to `user` in `InventorySourceRequest::authorize()` to match Laravel's standard boilerplate docblock.
- Corrects `aoount` to `account` in `CustomerSocialAccount::customer()`.

### Files Modified
- `packages/Webkul/Admin/src/Http/Requests/InventorySourceRequest.php`
- `packages/Webkul/SocialLogin/src/Models/CustomerSocialAccount.php`
