### PR TITLE
refactor: add parameter and return type hints to destroy methods in SearchSEO controllers

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Marketing/SearchSEO/SearchSynonymController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Marketing/SearchSEO/SearchSynonymController.php
@@ -88,11 +88,8 @@ class SearchSynonymController extends Controller
 
     /**
      * Remove the specified resource from storage.
-     *
-     * @param  int  $id
-     * @return void
      */
-    public function destroy($id)
+    public function destroy(int $id): JsonResponse
     {
         try {
             Event::dispatch('marketing.search_seo.search_synonyms.delete.before', $id);

--- a/packages/Webkul/Admin/src/Http/Controllers/Marketing/SearchSEO/SearchTermController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Marketing/SearchSEO/SearchTermController.php
@@ -98,11 +98,8 @@ class SearchTermController extends Controller
 
     /**
      * Remove the specified resource from storage.
-     *
-     * @param  int  $id
-     * @return void
      */
-    public function destroy($id)
+    public function destroy(int $id): JsonResponse
     {
         try {
             Event::dispatch('marketing.search_seo.search_terms.delete.before', $id);

--- a/packages/Webkul/Admin/src/Http/Controllers/Marketing/SearchSEO/SitemapController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Marketing/SearchSEO/SitemapController.php
@@ -91,11 +91,8 @@ class SitemapController extends Controller
 
     /**
      * Remove the specified resource from storage.
-     *
-     * @param  int  $id
-     * @return void
      */
-    public function destroy($id)
+    public function destroy(int $id): JsonResponse
     {
         $sitemap = $this->sitemapRepository->findOrFail($id);
 

--- a/packages/Webkul/Admin/src/Http/Controllers/Marketing/SearchSEO/URLRewriteController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Marketing/SearchSEO/URLRewriteController.php
@@ -100,11 +100,8 @@ class URLRewriteController extends Controller
 
     /**
      * Remove the specified resource from storage.
-     *
-     * @param  int  $id
-     * @return void
      */
-    public function destroy($id)
+    public function destroy(int $id): JsonResponse
     {
         try {
             Event::dispatch('marketing.search_seo.url_rewrites.delete.before', $id);


### PR DESCRIPTION
### Description
This PR adds proper parameter and return type declarations to the `destroy` methods in four `Marketing/SearchSEO` controllers. This improves static analysis, type safety, and IDE autocompletion.

### Changes
- Declared parameter type `int $id`
- Declared return type `JsonResponse`

### Files Modified
- `packages/Webkul/Admin/src/Http/Controllers/Marketing/SearchSEO/SearchSynonymController.php`
- `packages/Webkul/Admin/src/Http/Controllers/Marketing/SearchSEO/SearchTermController.php`
- `packages/Webkul/Admin/src/Http/Controllers/Marketing/SearchSEO/SitemapController.php`
- `packages/Webkul/Admin/src/Http/Controllers/Marketing/SearchSEO/URLRewriteController.php`
