### PR TITLE
fix: correct validation rule syntax for gender and entity_type

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Marketing/SearchSEO/URLRewriteController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Marketing/SearchSEO/URLRewriteController.php
@@ -40,7 +40,7 @@ class URLRewriteController extends Controller
     public function store(): JsonResponse
     {
         $this->validate(request(), [
-            'entity_type' => 'required:in:category,product,cms_page',
+            'entity_type' => 'required|in:category,product,cms_page',
             'request_path' => 'required',
             'target_path' => 'required',
             'redirect_type' => 'required|in:301,302',
@@ -74,7 +74,7 @@ class URLRewriteController extends Controller
         $id = request()->id;
 
         $this->validate(request(), [
-            'entity_type' => 'required:in:category,product,cms_page',
+            'entity_type' => 'required|in:category,product,cms_page',
             'request_path' => 'required',
             'target_path' => 'required',
             'redirect_type' => 'required|in:301,302',

--- a/packages/Webkul/DataTransfer/src/Helpers/Importers/Customer/Importer.php
+++ b/packages/Webkul/DataTransfer/src/Helpers/Importers/Customer/Importer.php
@@ -186,7 +186,7 @@ class Importer extends AbstractImporter
             'customer_group_code' => 'required',
             'first_name' => 'required|string',
             'last_name' => 'required|string',
-            'gender' => 'required:in,Male,Female,Other',
+            'gender' => 'required|in:Male,Female,Other',
             'email' => 'required|email',
             'date_of_birth' => [
                 'required',


### PR DESCRIPTION
### Description
This PR fixes syntax errors in validation rule definitions in the customer `Importer` and `URLRewriteController`. 

Previously, `required:in...` (using a colon instead of a pipe `|`) caused Laravel to parse `in` as a parameter to the `required` rule rather than a standalone `in:...` validation rule. Consequently, validation on `gender` and `entity_type` was bypassed.

### Changes
- Corrected `gender` rule from `'required:in,Male,Female,Other'` to `'required|in:Male,Female,Other'` in `Customer/Importer.php`.
- Corrected `entity_type` rule from `'required:in:category,product,cms_page'` to `'required|in:category,product,cms_page'` in `URLRewriteController.php` (both `store` and `update` methods).

### Files Modified
- `packages/Webkul/DataTransfer/src/Helpers/Importers/Customer/Importer.php`
- `packages/Webkul/Admin/src/Http/Controllers/Marketing/SearchSEO/URLRewriteController.php`
