### PR TITLE
feat(core): implement queue worker heartbeat and admin health alerts

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/components/layouts/queue-worker-warning.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/layouts/queue-worker-warning.blade.php
@@ -1,0 +1,17 @@
+@if (
+    config('queue.default') !== 'sync' && 
+    (! cache()->has('queue_worker_heartbeat') || cache('queue_worker_heartbeat') < now()->subMinutes(5)->timestamp)
+)
+    <div class="flex items-center justify-between p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400 border border-red-200" role="alert">
+        <div class="flex items-center gap-2">
+            <span class="icon-warning text-xl"></span>
+            <div>
+                <span class="font-medium">Queue Worker Not Running:</span> 
+                The application is configured to use the <strong>{{ config('queue.default') }}</strong> queue driver, but no active queue worker has been detected. Background jobs (emails, indexing, imports) may not be processed.
+            </div>
+        </div>
+        <div class="whitespace-nowrap">
+            <code class="px-2 py-1 bg-red-100 text-red-900 rounded font-mono text-xs">php artisan queue:work</code>
+        </div>
+    </div>
+@endif

--- a/packages/Webkul/Core/src/Providers/CoreServiceProvider.php
+++ b/packages/Webkul/Core/src/Providers/CoreServiceProvider.php
@@ -2,13 +2,19 @@
 
 namespace Webkul\Core\Providers;
 
+use Illuminate\Queue\Events\JobQueued;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Queue\Events\Looping;
+use Webkul\Theme\ViewRenderEventManager;
 use Elastic\Elasticsearch\Client;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Foundation\Console\DownCommand;
 use Illuminate\Foundation\Console\UpCommand;
 use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance;
-use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 use Webkul\Core\Console\Commands\BagistoVersion;
 use Webkul\Core\Console\Commands\ExchangeRateUpdate;
@@ -17,7 +23,6 @@ use Webkul\Core\Console\Commands\TranslationsChecker;
 use Webkul\Core\Exceptions\Handler;
 use Webkul\Core\Facades\ElasticSearch;
 use Webkul\Core\View\Compilers\BladeCompiler;
-use Webkul\Theme\ViewRenderEventManager;
 
 class CoreServiceProvider extends ServiceProvider
 {
@@ -50,6 +55,46 @@ class CoreServiceProvider extends ServiceProvider
 
         Event::listen('bagisto.admin.layout.head', static function (ViewRenderEventManager $viewRenderEventManager) {
             $viewRenderEventManager->addTemplate('core::blade.tracer.style');
+        });
+
+        // Inject the Queue Worker Warning Banner into the Admin Layout
+        Event::listen('bagisto.admin.layout.content.before', static function (ViewRenderEventManager $viewRenderEventManager) {
+            $viewRenderEventManager->addTemplate('admin::components.layouts.queue-worker-warning');
+        });
+
+        // Register the Queue Worker Heartbeat
+        if (! $this->app->runningUnitTests()) {
+            Queue::looping(function (Looping $event) {
+                Cache::put('queue_worker_heartbeat', now()->timestamp, now()->addMinutes(5));
+            });
+        }
+
+        // Synchronous Email Alert for Dead Queue Worker
+        Event::listen(JobQueued::class, static function (JobQueued $event) {
+            // Do nothing if using sync queue or running tests
+            if (config('queue.default') === 'sync' || app()->runningUnitTests()) {
+                return;
+            }
+
+            $isWorkerDead = ! Cache::has('queue_worker_heartbeat') || Cache::get('queue_worker_heartbeat') < now()->subMinutes(5)->timestamp;
+            $inCooldown = Cache::has('queue_alert_cooldown');
+
+            // If the worker is dead and we haven't sent an email in the last 30 minutes
+            if ($isWorkerDead && ! $inCooldown) {
+                try {
+                    // Fallback to the system's default sending address for the admin alert
+                    $adminEmail = config('mail.from.address'); 
+                    
+                    Mail::raw("CRITICAL: The Bagisto queue worker is not running. A job was just dispatched but there is no active worker to process it. Please run 'php artisan queue:work' on your server.", function ($message) use ($adminEmail) {
+                        $message->to($adminEmail)->subject('⚠️ ALERT: Bagisto Queue Worker Down');
+                    });
+
+                    // Lock alerts for 30 minutes to prevent email spam
+                    Cache::put('queue_alert_cooldown', true, now()->addMinutes(30));
+                } catch (\Exception $e) {
+                    // Silently fail to prevent crashing the user's current request (like a checkout)
+                }
+            }
         });
 
         $this->callAfterResolving(Schedule::class, function (Schedule $schedule) {


### PR DESCRIPTION
## Issue Reference
Fixes #11343

## Description
This PR introduces a robust, cache-driven queue worker health monitoring and alert system to prevent silent failures of asynchronous background jobs.

**Architectural Implementations:**
1. **Heartbeat Engine:** Hooked into `Queue::looping()` within `CoreServiceProvider` to register a lightweight 5-minute TTL cache timestamp (`queue_worker_heartbeat`) every time the worker cycles. This avoids unreliable OS-level process tracking.
2. **Admin UI Warning:** Injected a dynamic Tailwind-styled Blade component (`queue-worker-warning`) into the `bagisto.admin.layout.content.before` event. If an async queue is configured but the heartbeat is stale/missing, a high-visibility warning banner renders globally across the admin interface.
3. **Synchronous Email Fallback:** Hooked into the `JobQueued` event. If a background job is dispatched while the worker heartbeat is dead, a synchronous email alert is dispatched directly to the system administrator using the default mail transport.
4. **Alert Throttling:** Implemented a `queue_alert_cooldown` cache lock to throttle the emergency email alerts to once every 30 minutes, preventing email storms during high-throughput job dispatching.

## How To Test This?
1. In your `.env` file, ensure `QUEUE_CONNECTION` is set to an asynchronous driver (e.g., `database` or `redis`) and that your mailer is configured.
2. **Ensure no queue workers are running.**
3. Navigate to the Admin Panel. You should immediately see the red "Queue Worker Not Running" warning banner at the top of the layout.
4. Trigger an action that dispatches a queued job (e.g., requesting a data export or triggering a customer email).
5. Check your configured admin inbox (or Mailpit/Telescope). You should receive a synchronous "⚠️ ALERT: Bagisto Queue Worker Down" email.
6. Trigger another queued job immediately after. Verify that a second email is **not** sent (verifying the 30-minute cooldown lock).
7. Start the worker by running `php artisan queue:work`.
8. Refresh the Admin Panel. The warning banner should dynamically disappear now that the heartbeat cache is active.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
*Note: We may want to add a brief mention of the `queue_worker_heartbeat` and `queue_alert_cooldown` cache keys to the queue configuration documentation for server administrators.*

## Branch Selection
- [x] Target Branch: 2.4 

## Tailwind Reordering
- [x] I have ensured all Tailwind classes are cleanly ordered within the new Blade component.
