### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ Follow the [Getting Started with Bagisto](https://www.youtube.com/watch?v=s_DhQr
 
 You can browse through the Free [Live Demo](https://demo.bagisto.com/)
 
+Prefer not to run a server? Spin up a fully managed Bagisto instance in one click:
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/bagisto)
+
 ## ☁️ Bagisto Cloud Hosting
 
 Deploy and scale your Bagisto store effortlessly with [Bagisto Cloud Hosting](https://bagisto.com/en/cloud-hosting/)  a fully managed, optimized hosting solution built specifically for Bagisto. Enjoy automatic scaling, built-in security, one-click updates, and expert support so you can focus on growing your business.


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Bagisto to our marketplace, so this PR adds a small "Deploy with Zenith" badge under Getting Started, right after the Live Demo link (links to https://zenith.hosting/host/bagisto).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

---

## Issue Reference
n/a

## Description
Adds a single "Deploy with Zenith" badge line in the Getting Started section (after the Live Demo link), offering a one-click managed-hosting option for people who would rather not run a server. Docs-only, additions-only, one file (README.md), 4 lines added. Does not touch the existing Bagisto Cloud Hosting or AWS AMI sections.

## How To Test This?
Open README.md and confirm the badge renders under Getting Started and links to https://zenith.hosting/host/bagisto. No code, build, or asset changes.

## Documentation
- [ ] My pull request requires an update on the documentation repository.

(n/a — this only edits the repo README, not the docs repository.)

## Branch Selection
- [x] Target Branch: 2.4

## Tailwind Reordering
n/a — no Tailwind or asset changes.
