### PR TITLE
Ensure cart is active before getting it from session

### DIFF
--- a/packages/Webkul/Checkout/src/Cart.php
+++ b/packages/Webkul/Checkout/src/Cart.php
@@ -77,7 +77,11 @@ class Cart
             ]);
         } elseif (session()->has('cart')) {
             $cart = $this->cartRepository->find(session()->get('cart')->id);
-            if($cart && $cart->is_active) {
+            
+            if (
+                $cart
+                && $cart->is_active
+            ) {
                 $this->cart = $cart;
             }
         }

--- a/packages/Webkul/Checkout/src/Cart.php
+++ b/packages/Webkul/Checkout/src/Cart.php
@@ -76,7 +76,10 @@ class Cart
                 'is_active' => 1,
             ]);
         } elseif (session()->has('cart')) {
-            $this->cart = $this->cartRepository->find(session()->get('cart')->id);
+            $cart = $this->cartRepository->find(session()->get('cart')->id);
+            if($cart && $cart->is_active) {
+                $this->cart = $cart;
+            }
         }
     }
 


### PR DESCRIPTION
Check if the cart is active before getting it. If IPN deactivates the cart it's still in the user session. If user won't go to successful payment page session cart won't be cleaned up.

