### PR TITLE
Fix: Copy Customizable Options on Product Duplication

### DIFF
--- a/packages/Webkul/Admin/tests/Feature/Catalog/Products/ProductTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Catalog/Products/ProductTest.php
@@ -108,3 +108,49 @@ it('should search the product', function () {
         ->assertJsonPath('data.0.name', $product[0]->name)
         ->assertJsonPath('data.0.sku', $product[0]->sku);
 });
+
+it('should copy the existing product with customizable options', function () {
+    // Arrange.
+    $product = (new ProductFaker)->getSimpleProductFactory()->create();
+
+    // Create a customizable option for the product
+    $customizableOption = $product->customizable_options()->create([
+        'type'        => 'select',
+        'is_required' => 1,
+        'sort_order'  => 1,
+        'label'       => 'Test Option Label',
+    ]);
+
+    // Create a price/value for the customizable option
+    $customizableOption->customizable_option_prices()->create([
+        'label'      => 'Test Value Label',
+        'price'      => 10.00,
+        'sort_order' => 1,
+    ]);
+
+    // Act.
+    $this->loginAsAdmin();
+
+    postJson(route('admin.catalog.products.copy', $product->id))
+        ->assertOk()
+        ->assertJsonPath('message', trans('admin::app.catalog.products.product-copied'));
+
+    // Get the newly created product (last one).
+    $copiedProduct = Product::latest('id')->first();
+
+    // Assert the copied product has customizable options cloned
+    expect($copiedProduct->customizable_options)->toHaveCount(1);
+    
+    $copiedCustomizableOption = $copiedProduct->customizable_options->first();
+    expect($copiedCustomizableOption->type)->toBe('select');
+    expect($copiedCustomizableOption->is_required)->toBe(1);
+    expect($copiedCustomizableOption->label)->toBe('Test Option Label');
+
+    // Assert the customizable option price/value is cloned
+    expect($copiedCustomizableOption->customizable_option_prices)->toHaveCount(1);
+    
+    $copiedPrice = $copiedCustomizableOption->customizable_option_prices->first();
+    expect($copiedPrice->label)->toBe('Test Value Label');
+    expect($copiedPrice->price)->toEqual(10.00);
+});
+

--- a/packages/Webkul/Product/src/Type/AbstractType.php
+++ b/packages/Webkul/Product/src/Type/AbstractType.php
@@ -353,6 +353,16 @@ abstract class AbstractType
                 'child_id' => $product->id,
             ]);
         }
+
+        if (! in_array('customizable_options', $attributesToSkip)) {
+            foreach ($this->product->customizable_options as $customizableOption) {
+                $copiedCustomizableOption = $product->customizable_options()->save($customizableOption->replicate());
+
+                foreach ($customizableOption->customizable_option_prices as $price) {
+                    $copiedCustomizableOption->customizable_option_prices()->save($price->replicate());
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Closes #11380

### Description
This PR fixes the issue where duplicating a product with customizable options (and their option values/prices/translations) does not copy those options over to the duplicated product.

### Changes
- Updated `copyRelationships()` in `AbstractType.php` to replicate `customizable_options` and their associated `customizable_option_prices`.
- Added an automated test in `ProductTest.php` to verify the duplication behavior.
