### PR TITLE
Fix groupBy clause in Customer reporting queries

### DIFF
--- a/packages/Webkul/Admin/src/Helpers/Reporting/Cart.php
+++ b/packages/Webkul/Admin/src/Helpers/Reporting/Cart.php
@@ -202,7 +202,7 @@ class Cart extends AbstractReporting
     {
         return $this->cartRepository
             ->resetModel()
-            ->groupBy(DB::raw('CONCAT(customer_email, "-", customer_id)'))
+            ->groupBy(['customer_email', 'customer_id'])
             ->whereIn('cart.channel_id', $this->channelIds)
             ->whereBetween('created_at', [$startDate, $endDate])
             ->get()

--- a/packages/Webkul/Admin/src/Helpers/Reporting/Customer.php
+++ b/packages/Webkul/Admin/src/Helpers/Reporting/Customer.php
@@ -134,7 +134,7 @@ class Customer extends AbstractReporting
             )
             ->whereIn('channel_id', $this->channelIds)
             ->whereBetween('created_at', [$this->startDate, $this->endDate])
-            ->groupBy(DB::raw('CONCAT(customer_email, "-", customer_id)'))
+            ->groupBy(DB::raw('orders.customer_email, orders.customer_id'))
             ->orderByDesc('total')
             ->limit($limit)
             ->get();
@@ -159,7 +159,7 @@ class Customer extends AbstractReporting
             )
             ->whereIn('channel_id', $this->channelIds)
             ->whereBetween('created_at', [$this->startDate, $this->endDate])
-            ->groupBy(DB::raw('CONCAT(customer_email, "-", customer_id)'))
+            ->groupBy(DB::raw('orders.customer_email, orders.customer_id'))
             ->orderByDesc('orders')
             ->limit($limit)
             ->get();

--- a/packages/Webkul/Admin/src/Helpers/Reporting/Customer.php
+++ b/packages/Webkul/Admin/src/Helpers/Reporting/Customer.php
@@ -134,7 +134,7 @@ class Customer extends AbstractReporting
             )
             ->whereIn('channel_id', $this->channelIds)
             ->whereBetween('created_at', [$this->startDate, $this->endDate])
-            ->groupBy(DB::raw('orders.customer_email, orders.customer_id'))
+            ->groupBy(['customer_email', 'customer_id'])
             ->orderByDesc('total')
             ->limit($limit)
             ->get();
@@ -159,7 +159,7 @@ class Customer extends AbstractReporting
             )
             ->whereIn('channel_id', $this->channelIds)
             ->whereBetween('created_at', [$this->startDate, $this->endDate])
-            ->groupBy(DB::raw('orders.customer_email, orders.customer_id'))
+            ->groupBy(['customer_email', 'customer_id'])
             ->orderByDesc('orders')
             ->limit($limit)
             ->get();

--- a/packages/Webkul/Admin/src/Helpers/Reporting/Sale.php
+++ b/packages/Webkul/Admin/src/Helpers/Reporting/Sale.php
@@ -677,7 +677,7 @@ class Sale extends AbstractReporting
             ->resetModel()
             ->whereIn('channel_id', $this->channelIds)
             ->whereBetween('created_at', [$startDate, $endDate])
-            ->groupBy(DB::raw('CONCAT(customer_email, "-", customer_id)'))
+            ->groupBy(['customer_email', 'customer_id'])
             ->get()
             ->count();
     }


### PR DESCRIPTION
Grouping orders using CONCAT(customer_email, "-", customer_id) causes invalid aggregation results: for guest checkouts where customer_id is NULL, CONCAT() returns NULL. As a result, all guest orders are mistakenly merged into a single group, bloating their aggregated totals.