### PR TITLE
Fix docblock params that do not match the signatures in Core

### DIFF
--- a/packages/Webkul/Core/src/Core.php
+++ b/packages/Webkul/Core/src/Core.php
@@ -521,7 +521,7 @@ class Core
     /**
      * Format and convert price with currency symbol.
      *
-     * @param  float  $price
+     * @param  float  $amount
      * @return string
      */
     public function currency($amount = 0)
@@ -566,7 +566,6 @@ class Core
     /**
      * Checks if current date of the given channel (in the channel timezone) is within the range.
      *
-     * @param  int|string|Contracts\Channel  $channel
      * @param  string|null  $dateFrom
      * @param  string|null  $dateTo
      * @return bool
@@ -804,7 +803,7 @@ class Core
     /**
      * Convert empty strings to null.
      *
-     * @param  array  $array1
+     * @param  array  $array
      * @return array
      */
     public function convertEmptyStringsToNull($array)
@@ -842,9 +841,9 @@ class Core
     }
 
     /**
-     * Create singleton object through single facade.
+     * Get the tax category of the given id.
      *
-     * @param  string  $className
+     * @param  int  $id
      * @return object
      */
     public function getTaxCategoryById($id)

--- a/packages/Webkul/Core/src/Eloquent/Repository.php
+++ b/packages/Webkul/Core/src/Eloquent/Repository.php
@@ -109,8 +109,7 @@ abstract class Repository extends BaseRepository implements CacheableInterface
     /**
      * Find data by field and value.
      *
-     * @param  string  $field
-     * @param  string  $value
+     * @param  array  $where
      * @param  array  $columns
      * @return mixed
      */

--- a/packages/Webkul/Core/src/Repositories/LocaleRepository.php
+++ b/packages/Webkul/Core/src/Repositories/LocaleRepository.php
@@ -79,7 +79,7 @@ class LocaleRepository extends Repository
     /**
      * Upload image.
      *
-     * @param  array  $attributes
+     * @param  array  $localeImages
      * @param  \Webkul\Core\Models\Locale  $locale
      * @return void
      */

--- a/packages/Webkul/Core/src/Traits/Sanitizer.php
+++ b/packages/Webkul/Core/src/Traits/Sanitizer.php
@@ -35,10 +35,10 @@ trait Sanitizer
     }
 
     /**
-     * Sanitize SVG file.
+     * Check whether the mime type is allowed.
      *
-     * @param  string  $path
-     * @return void
+     * @param  string  $mimeType
+     * @return bool
      */
     public function checkMimeType($mimeType)
     {


### PR DESCRIPTION
## Issue Reference

None — found by reading `packages/Webkul/Core` against its own signatures.

## Description

Eight `@param` tags name an argument the method does not take.

| Where | Documented | Actual |
|---|---|---|
| `Core.php:524` `currency` | `$price` | `currency($amount = 0)` |
| `Core.php:569` `isChannelDateInInterval` | `$channel` | only `$dateFrom`, `$dateTo` |
| `Core.php:807` `convertEmptyStringsToNull` | `$array1` | `$array` |
| `Core.php:847` `getTaxCategoryById` | `$className` | `$id` |
| `Traits/Sanitizer.php:40` `checkMimeType` | `$path` | `$mimeType` |
| `Repositories/LocaleRepository.php:82` `uploadImage` | `$attributes` | `$localeImages` |
| `Eloquent/Repository.php:112` `findOneWhere` | `$field`, `$value` | one `array $where` |

Two of them came in with a whole block copied from another method, so their summary line was wrong as well, and I corrected those too:

- `getTaxCategoryById` was described as "Create singleton object through single facade" — it returns a tax category by id.
- `checkMimeType` was described as "Sanitize SVG file" with `@return void` — it returns a bool from `in_array()`.

`findOneWhere` is the one worth a second look: it documents `$field` and `$value` from an older signature, so the `array $where` it actually takes is undocumented, and the docblock suggests a two-argument call that fails.

## How To Test This?

Nothing to run — the change is confined to docblocks. No signature, call site, or behaviour is touched, and `git diff` shows only comment lines.

## Documentation

- [ ] My pull request requires an update on the documentation repository.

## Branch Selection

- [x] Target Branch: 2.4

## Tailwind Reordering

Not applicable — no view files touched.
