### PR TITLE
Fix docblock params that do not match the signatures in Product

### DIFF
--- a/packages/Webkul/Product/src/Helpers/Indexers/AbstractIndexer.php
+++ b/packages/Webkul/Product/src/Helpers/Indexers/AbstractIndexer.php
@@ -70,7 +70,7 @@ abstract class AbstractIndexer
     /**
      * Reindex single product
      *
-     * @param  array  $products
+     * @param  \Webkul\Product\Contracts\Product  $product
      * @return void
      */
     public function reindexRow($product)

--- a/packages/Webkul/Product/src/Models/Product.php
+++ b/packages/Webkul/Product/src/Models/Product.php
@@ -294,8 +294,6 @@ class Product extends Model implements ProductContract
     /**
      * Is saleable.
      *
-     * @param  string  $key
-     *
      * @throws Exception
      */
     public function isSaleable(): bool

--- a/packages/Webkul/Product/src/Models/ProductImage.php
+++ b/packages/Webkul/Product/src/Models/ProductImage.php
@@ -68,7 +68,7 @@ class ProductImage extends Model implements ProductImageContract
     /**
      * Is custom attribute.
      *
-     * @param  string  $key
+     * @param  string  $attribute
      * @return bool
      */
     public function isCustomAttribute($attribute)

--- a/packages/Webkul/Product/src/Repositories/ProductRepository.php
+++ b/packages/Webkul/Product/src/Repositories/ProductRepository.php
@@ -596,7 +596,7 @@ class ProductRepository extends Repository
     /**
      * Return category product maximum price.
      *
-     * @param  int  $categoryId
+     * @param  array  $params
      * @return float
      */
     public function getMaxPrice($params = [])

--- a/packages/Webkul/Product/src/Type/AbstractType.php
+++ b/packages/Webkul/Product/src/Type/AbstractType.php
@@ -604,7 +604,6 @@ abstract class AbstractType
     /**
      * Get product minimal price.
      *
-     * @param  int  $qty
      * @return float
      */
     public function getMinimalPrice()


### PR DESCRIPTION
## Issue Reference

Follow-up to #11404, which you merged earlier — same kind of thing, this time in `packages/Webkul/Product`.

## Description

Five `@param` tags name an argument the method does not take.

| Where | Documented | Actual |
|---|---|---|
| `Repositories/ProductRepository.php:599` `getMaxPrice` | `int $categoryId` | `getMaxPrice($params = [])` |
| `Models/Product.php:297` `isSaleable` | `string $key` | `isSaleable(): bool` — takes nothing |
| `Models/ProductImage.php:71` `isCustomAttribute` | `string $key` | `$attribute` |
| `Type/AbstractType.php:607` `getMinimalPrice` | `int $qty` | `getMinimalPrice()` — takes nothing |
| `Helpers/Indexers/AbstractIndexer.php:73` `reindexRow` | `array $products` | one `$product`; the body wraps it itself: `reindexBatch([$product])` |

`reindexRow` is the one that misleads most: plural name and `array` type suggest you can hand it a list, but it takes a single product and does the wrapping internally.

## Checked, deliberately left alone

`Type/AbstractType.php:664` `getFinalPrice($qty = null)` carries an identical `@param int $qty` block — there the parameter is real, so that one is correct and untouched. The two blocks are byte-identical, so this was edited by line rather than by search-and-replace.

## How To Test This?

Nothing to run — docblocks only. No signature, call site, or behaviour is touched.

## Documentation

- [ ] My pull request requires an update on the documentation repository.

## Branch Selection

- [x] Target Branch: 2.4

## Tailwind Reordering

Not applicable — no view files touched.
