### PR TITLE
Fix the remaining docblock params that do not match signatures

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Marketing/SearchSEO/SearchSynonymController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Marketing/SearchSEO/SearchSynonymController.php
@@ -61,7 +61,6 @@ class SearchSynonymController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param  int  $id
      */
     public function update(): JsonResponse
     {

--- a/packages/Webkul/Admin/src/Http/Controllers/Marketing/SearchSEO/SearchTermController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Marketing/SearchSEO/SearchTermController.php
@@ -65,7 +65,6 @@ class SearchTermController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param  int  $id
      */
     public function update(): JsonResponse
     {

--- a/packages/Webkul/Admin/src/Http/Controllers/Marketing/SearchSEO/URLRewriteController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Marketing/SearchSEO/URLRewriteController.php
@@ -67,7 +67,6 @@ class URLRewriteController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param  int  $id
      */
     public function update(): JsonResponse
     {

--- a/packages/Webkul/Admin/src/Http/Controllers/User/SessionController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/User/SessionController.php
@@ -70,7 +70,6 @@ class SessionController extends Controller
     /**
      * Remove the specified resource from storage.
      *
-     * @param  int  $id
      * @return Response
      */
     public function destroy()

--- a/packages/Webkul/Attribute/src/Repositories/AttributeOptionRepository.php
+++ b/packages/Webkul/Attribute/src/Repositories/AttributeOptionRepository.php
@@ -29,8 +29,8 @@ class AttributeOptionRepository extends Repository
     }
 
     /**
+     * @param  array  $data
      * @param  int  $id
-     * @param  string  $attribute
      * @return AttributeOption
      */
     public function update(array $data, $id)

--- a/packages/Webkul/Attribute/src/Repositories/AttributeRepository.php
+++ b/packages/Webkul/Attribute/src/Repositories/AttributeRepository.php
@@ -71,8 +71,8 @@ class AttributeRepository extends Repository
     /**
      * Update attribute.
      *
+     * @param  array  $data
      * @param  int  $id
-     * @param  string  $attribute
      * @return Attribute
      */
     public function update(array $data, $id)

--- a/packages/Webkul/BookingProduct/src/Helpers/Booking.php
+++ b/packages/Webkul/BookingProduct/src/Helpers/Booking.php
@@ -510,7 +510,7 @@ class Booking
     /**
      * Returns true if the cart item is inactive.
      *
-     * @param  \Webkul\Checkout\Contracts\CartItem|array  $cartItem
+     * @param  \Webkul\Checkout\Contracts\CartItem|array  $item
      */
     public function isCartItemInactive($item): bool
     {

--- a/packages/Webkul/Category/src/Repositories/CategoryRepository.php
+++ b/packages/Webkul/Category/src/Repositories/CategoryRepository.php
@@ -104,8 +104,8 @@ class CategoryRepository extends Repository
     /**
      * Update category.
      *
+     * @param  array  $data
      * @param  int  $id
-     * @param  string  $attribute
      * @return Category
      */
     public function update(array $data, $id)

--- a/packages/Webkul/Customer/src/Providers/CustomerServiceProvider.php
+++ b/packages/Webkul/Customer/src/Providers/CustomerServiceProvider.php
@@ -11,7 +11,6 @@ class CustomerServiceProvider extends ServiceProvider
     /**
      * Bootstrap application services.
      *
-     * @param  Router  $router
      */
     public function boot(): void
     {

--- a/packages/Webkul/DataTransfer/src/Helpers/Importers/AbstractImporter.php
+++ b/packages/Webkul/DataTransfer/src/Helpers/Importers/AbstractImporter.php
@@ -171,7 +171,7 @@ abstract class AbstractImporter
     /**
      * Import instance.
      *
-     * @param  Source  $errorHelper
+     * @param  Source  $source
      */
     public function setSource($source)
     {

--- a/packages/Webkul/FPC/src/Listeners/Review.php
+++ b/packages/Webkul/FPC/src/Listeners/Review.php
@@ -28,7 +28,7 @@ class Review
     /**
      * Before review is deleted
      *
-     * @param  \Webkul\Product\Contracts\Review  $review
+     * @param  int  $reviewId
      * @return void
      */
     public function beforeDelete($reviewId)

--- a/packages/Webkul/Paypal/src/Payment/Paypal.php
+++ b/packages/Webkul/Paypal/src/Payment/Paypal.php
@@ -79,7 +79,7 @@ abstract class Paypal extends Payment
     /**
      * Format a currency value according to paypal's api constraints
      *
-     * @param  float|int  $long
+     * @param  float|int  $number
      */
     public function formatCurrencyValue($number): float
     {

--- a/packages/Webkul/Sales/src/Generators/InvoiceSequencer.php
+++ b/packages/Webkul/Sales/src/Generators/InvoiceSequencer.php
@@ -19,7 +19,6 @@ class InvoiceSequencer extends Sequencer
     /**
      * Set all configs.
      *
-     * @param  string  $configKey
      * @return void
      */
     public function setAllConfigs()

--- a/packages/Webkul/Sales/src/Generators/OrderSequencer.php
+++ b/packages/Webkul/Sales/src/Generators/OrderSequencer.php
@@ -19,7 +19,6 @@ class OrderSequencer extends Sequencer
     /**
      * Set all configs.
      *
-     * @param  string  $configKey
      * @return void
      */
     public function setAllConfigs()

--- a/packages/Webkul/Shop/src/Http/Controllers/Customer/CustomerController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/Customer/CustomerController.php
@@ -146,7 +146,6 @@ class CustomerController extends Controller
     /**
      * Remove the specified resource from storage.
      *
-     * @param  int  $id
      * @return Response
      */
     public function destroy()

--- a/packages/Webkul/Shop/src/Listeners/Customer.php
+++ b/packages/Webkul/Shop/src/Listeners/Customer.php
@@ -79,7 +79,7 @@ class Customer extends Base
     /**
      * Send mail on creating Note
      *
-     * @param  \Webkul\Customer\Models\Customer  $customer
+     * @param  \Webkul\Customer\Models\CustomerNote  $note
      * @return void
      */
     public function afterNoteCreated($note)

--- a/packages/Webkul/Theme/src/Exceptions/ThemeNotFound.php
+++ b/packages/Webkul/Theme/src/Exceptions/ThemeNotFound.php
@@ -7,7 +7,7 @@ class ThemeNotFound extends \Exception
     /**
      * Create an instance.
      *
-     * @param  string  $theme
+     * @param  string  $themeName
      * @return void
      */
     public function __construct($themeName)

--- a/packages/Webkul/Theme/src/Exceptions/ViterNotFound.php
+++ b/packages/Webkul/Theme/src/Exceptions/ViterNotFound.php
@@ -7,7 +7,7 @@ class ViterNotFound extends \Exception
     /**
      * Create an instance.
      *
-     * @param  string  $theme
+     * @param  string  $namespace
      * @return void
      */
     public function __construct($namespace)


### PR DESCRIPTION
## Issue Reference

Third and last of this sweep, after #11404 (`Core`) and #11405 (`Product`), both merged. This clears the rest of the codebase.

## Description

Eighteen `@param` tags name an argument the method does not take. Grouped by cause:

**Repositories — `$attribute` is a local, and `$data` went undocumented**

`Attribute/…/AttributeRepository.php`, `Attribute/…/AttributeOptionRepository.php`, `Category/…/CategoryRepository.php` — all three `update(array $data, $id)` document `int $id` plus `string $attribute`. `$attribute` is the local from `$this->find($id)`, and the real first parameter had no tag at all.

**Methods that read their input from the request rather than an argument**

| Where | Documented | Actual |
|---|---|---|
| `Shop/…/Customer/CustomerController.php` `destroy` | `int $id` | takes nothing; the id comes from the guard |
| `Admin/…/User/SessionController.php` `destroy` | `int $id` | takes nothing |
| `Admin/…/SearchSEO/URLRewriteController.php` `update` | `int $id` | takes nothing; `$id = request()->id` |
| `Admin/…/SearchSEO/SearchSynonymController.php` `update` | `int $id` | same |
| `Admin/…/SearchSEO/SearchTermController.php` `update` | `int $id` | same |
| `Sales/…/InvoiceSequencer.php` `setAllConfigs` | `string $configKey` | takes nothing |
| `Sales/…/OrderSequencer.php` `setAllConfigs` | `string $configKey` | takes nothing |
| `Customer/…/CustomerServiceProvider.php` `boot` | `Router $router` | takes nothing |

**Plain renames**

| Where | Documented | Actual |
|---|---|---|
| `BookingProduct/…/Booking.php` `isCartItemInactive` | `$cartItem` | `$item` |
| `Shop/…/Listeners/Customer.php` `afterNoteCreated` | `Customer $customer` | `CustomerNote $note` |
| `FPC/…/Listeners/Review.php` `beforeDelete` | `Review $review` | `int $reviewId` |
| `DataTransfer/…/AbstractImporter.php` `setSource` | `Source $errorHelper` | `$source` |
| `Theme/…/ThemeNotFound.php` `__construct` | `$theme` | `$themeName` |
| `Theme/…/ViterNotFound.php` `__construct` | `$theme` | `$namespace` |
| `Paypal/…/Paypal.php` `formatCurrencyValue` | `float\|int $long` | `$number` |

## Checked, deliberately left alone

Several of these sit next to near-identical blocks that are **correct**, so each was edited by line rather than by search-and-replace:

- `Shop/…/Listeners/Customer.php` — `afterCreated($customer)`, `afterPasswordUpdated($customer)` and `afterSubscribed($customer)` all document `$customer` correctly; only `afterNoteCreated` had drifted.
- `FPC/…/Listeners/Review.php` — `afterUpdate($review)` is correct; only `beforeDelete` had drifted.
- `BookingProduct/…/Booking.php` — `isItemHaveQuantity($cartItem)` is correct.

## How To Test This?

Nothing to run — docblocks only. `git diff` touches no line outside a comment block: no signature, call site, or behaviour is changed.

## Documentation

- [ ] My pull request requires an update on the documentation repository.

## Branch Selection

- [x] Target Branch: 2.4

## Tailwind Reordering

Not applicable — no view files touched.
