### PR TITLE
fix: update file attribute validation rules to conditionally require based on product state

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/catalog/products/edit/controls.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/catalog/products/edit/controls.blade.php
@@ -183,6 +183,12 @@
         @break
     @case('image')
     @case('file')
+        @php
+            $fileRules = $product[$attribute->code]
+                ? preg_replace('/required:\s*true\s*,?\s*/', '', $attribute->validations)
+                : $attribute->validations;
+        @endphp
+
         <div class="flex gap-2.5">
             @if ($product[$attribute->code])
                 <a
@@ -214,7 +220,7 @@
                 type="file"
                 class="w-full"
                 name="{{ $attribute->code }}"
-                :rules="{{ $attribute->validations }}"
+                :rules="{{ $fileRules }}"
                 v-slot="{ handleChange, handleBlur }"
                 label="{{ $attribute->admin_name }}"
             >
@@ -230,7 +236,7 @@
             </v-field>
         </div>
 
-        @if ($product[$attribute->code])
+        @if ($product[$attribute->code] && ! $attribute->is_required)
             <div class="mt-2.5 flex items-center gap-2.5">
                 <x-admin::form.control-group.control
                     type="checkbox"


### PR DESCRIPTION
…based on product state

## Issue Reference
<img width="1770" height="890" alt="Screenshot" src="https://github.com/user-attachments/assets/c620af15-0696-4e00-84df-106952446402" />


1. Unable to save product 2nd time if file type attribute is required and file already uploaded previously.
2. Remove button is coming even if attribute is required which can not be saved empty after removing.