### PR TITLE
Fix payment gateway controllers reusing stale cart reference after collectTotals()

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -156,6 +156,7 @@ Or manually create:
 - Follow Laravel conventions
 - Use type hints where possible
 - Write meaningful variable/method names
+- **No comments inside method bodies.** Keep docblocks above classes, methods, and properties — nothing else. Do not narrate what a statement does or why it changed; that belongs in the commit message. Applies to `//` and `/** */` alike, in PHP, Blade, JS, and Vue. A line that needs prose to be understood should become a named method instead.
 
 ## Testing
 
@@ -182,7 +183,7 @@ cd packages/Webkul/Shop && npx playwright test --config=tests/e2e-pw/playwright.
 Tests require a running Laravel server (`php artisan serve`) and seeded database.
 
 ### Translations
-When adding new translation keys, provide translations for **all 21 locales** in the package's `Resources/lang/` directory. Verify with:
+When adding new translation keys, provide translations for **all 22 locales** in the package's `Resources/lang/` directory. Verify with:
 ```bash
 php artisan bagisto:translations:check
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@
 ├── database/
 │   ├── migrations/             # App-level migrations
 │   └── seeders/
-├── packages/Webkul/            # ★ All Bagisto packages live here (40 packages)
+├── packages/Webkul/            # ★ All Bagisto packages live here (41 packages)
 │   ├── Admin/                  # Admin panel (controllers, views, DataGrids, reporting, e2e-pw tests)
 │   ├── Shop/                   # Customer storefront (controllers, views, e2e-pw tests)
 │   ├── Core/                   # Helpers, models, jobs, listeners, exchange rates
@@ -102,7 +102,7 @@ Every package in `packages/Webkul/{Name}/src/` follows:
 ├── Repositories/               # Prettus L5 repositories
 ├── Resources/
 │   ├── assets/                 # JS, CSS, images (Vite-compiled)
-│   ├── lang/{locale}/          # 21 locales
+│   ├── lang/{locale}/          # 22 locales
 │   └── views/
 ├── Routes/
 │   ├── admin-routes.php
@@ -117,7 +117,7 @@ Every package in `packages/Webkul/{Name}/src/` follows:
 - **Path Repositories**: `composer.json` uses `"type": "path"` for `packages/*/*`, packages are symlinked — no `composer update` needed for package code changes. Run `composer dump-autoload` after adding new packages.
 - **Service Providers**: Each package has a main ServiceProvider (routes, views, translations, migrations, config) registered in `bootstrap/providers.php`.
 - **Dual Route Files**: Admin routes (`['web', 'admin']` middleware, `config('app.admin_url')` prefix) and Shop routes (`['web', 'locale', 'theme', 'currency']` middleware).
-- **21 Locales**: ar, bn, ca, de, en, es, fa, fr, he, hi_IN, id, it, ja, nl, pl, pt_BR, ru, sin, tr, uk, zh_CN. Translation changes must be applied to ALL locale files. Verify with `php artisan bagisto:translations:check`.
+- **22 Locales**: ar, bn, ca, de, en, es, fa, fr, he, hi_IN, id, it, ja, nl, pl, pt_BR, ro, ru, sin, tr, uk, zh_CN. Translation changes must be applied to ALL locale files. Verify with `php artisan bagisto:translations:check`.
 
 ## Commands
 
@@ -171,7 +171,8 @@ php artisan db:seed              # Seed database
 ## Safety Rails
 
 - **Never modify `bootstrap/providers.php` or `config/concord.php`** without understanding the full provider chain — removing a provider breaks the entire module.
-- **Translations are 21 files per key.** Missing a locale will fail CI. When adding/removing translation keys, hit all 21 files.
+- **Translations are 22 files per key.** Missing a locale will fail CI. When adding/removing translation keys, hit all 22 files.
+- **No comments inside method bodies.** Docblocks above classes, methods, and properties only. Never annotate a statement with what it does or why it changed — that belongs in the commit message. Applies to `//` and `/** */` alike, in PHP, Blade, JS, and Vue. If a line needs prose to be understood, extract a named method instead.
 - **Pint must pass.** Run `vendor/bin/pint --dirty` before finalizing any PHP change.
 - **Tests must pass.** Run affected package tests after changes. Do not delete tests without approval.
 - **Do not add/remove composer dependencies without approval.**
@@ -181,7 +182,7 @@ php artisan db:seed              # Seed database
 
 1. `vendor/bin/pint --dirty` — no style violations
 2. `php artisan test --compact` — affected tests pass
-3. `php artisan bagisto:translations:check` — translation keys exist in all 21 locale files (if changed)
+3. `php artisan bagisto:translations:check` — translation keys exist in all 22 locale files (if changed)
 4. No `env()` calls outside `config/` files
 5. New models have Contract + Model + Proxy + Repository
 6. New packages registered in `bootstrap/providers.php` and `config/concord.php`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,9 @@ vendor/bin/pest packages/Webkul/Admin/tests/Feature     # Run tests in a directo
 vendor/bin/pest --filter="test name"                    # Run a single test by name
 ```
 
-Test suites defined in `phpunit.xml`: Admin Feature, Core Unit, Customer Unit, DataGrid Unit, Installer Feature, PayGlocal Unit/Feature, PayU Unit/Feature, Razorpay Unit/Feature, Shop Feature, Stripe Unit/Feature.
+Test suites defined in `phpunit.xml`: Admin Feature, Core Unit, Customer Unit, DataGrid Unit, EUWithdrawal Feature, Installer Feature, PayGlocal Unit/Feature, PayU Unit/Feature, Razorpay Unit/Feature, Shop Feature, Stripe Unit/Feature.
+
+Every package that has tests is registered above. Packages without a `tests/` directory (PhonePe, Checkout, Product, Sales, RMA, and others) have no suite — adding a `<testsuite>` for a path that does not exist makes PHPUnit error, so write the tests first.
 
 Tests use **Pest 3** with package-specific TestCase classes bound in `tests/Pest.php`. Each package's tests live in `packages/Webkul/<Package>/tests/`.
 
@@ -55,6 +57,28 @@ vendor/bin/pint             # Fix PHP code style (Laravel Pint)
 vendor/bin/pint --test      # Check style without fixing
 ```
 
+**Do not write comments inside method bodies.** Keep only the docblock above a class, method, or property — that is the only comment this codebase wants. Do not narrate what a statement does, why a line was added, or what a fix changed; the code and the commit message carry that. This applies to `//` line comments and `/** */` blocks alike, and to PHP, Blade, JavaScript, and Vue.
+
+```php
+// Bad - explains a statement inside the body
+public function updateStatus(int $id): RedirectResponse
+{
+    // Re-fetch the cart because collectTotals swapped the instance
+    $cart = Cart::getCart();
+}
+
+// Good - docblock only, body speaks for itself
+/**
+ * Update RMA status.
+ */
+public function updateStatus(int $id): RedirectResponse
+{
+    $cart = Cart::getCart();
+}
+```
+
+If a line genuinely cannot be understood without prose, that is a signal to extract a well-named method instead of annotating it.
+
 ### Translations
 When adding new translation keys, always provide translations for **all locales** in the package's `Resources/lang/` directory. Verify with:
 ```bash
@@ -65,7 +89,7 @@ php artisan bagisto:translations:check
 
 ### Modular Package System
 
-All core functionality lives in **`packages/Webkul/`** (~42 packages). Each package is a self-contained Laravel package with its own models, controllers, routes, views, migrations, and service providers.
+All core functionality lives in **`packages/Webkul/`** (41 packages). Each package is a self-contained Laravel package with its own models, controllers, routes, views, migrations, and service providers.
 
 **Dual registration**: Each package registers in two places:
 1. **`bootstrap/providers.php`** - Main ServiceProvider (routes, views, events, config)

--- a/packages/Webkul/PayGlocal/src/Http/Controllers/PayGlocalController.php
+++ b/packages/Webkul/PayGlocal/src/Http/Controllers/PayGlocalController.php
@@ -249,6 +249,12 @@ class PayGlocalController extends Controller
 
             Cart::collectTotals();
 
+            $cart = Cart::getCart();
+
+            if (! $cart) {
+                return null;
+            }
+
             if (! $this->amountMatches($cart, $response)) {
                 return null;
             }

--- a/packages/Webkul/PayGlocal/tests/Feature/PayGlocalPaymentTest.php
+++ b/packages/Webkul/PayGlocal/tests/Feature/PayGlocalPaymentTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Webkul\Checkout\Facades\Cart;
 use Webkul\Core\Models\CoreConfig;
@@ -326,6 +327,39 @@ it('refuses to place the order when the cart no longer totals what was captured'
     $response->assertJsonPath('status', 'payment_not_confirmed');
 
     expect(Order::where('cart_id', $cart->id)->first())->toBeNull();
+});
+
+it('settles against the totals collect totals recalculated, not the stale ones it was handed', function () {
+    // Arrange
+    $cart = $this->createCartWithItems('payglocal');
+
+    /**
+     * Drift the stored totals away from what the items add up to. collectTotals() recomputes
+     * them from the items, so the figures on the cart instance read back before it runs are
+     * the drifted ones, and the figures it leaves behind are the true ones.
+     */
+    DB::table('cart')->where('id', $cart->id)->update([
+        'grand_total' => $cart->grand_total + 500,
+        'base_grand_total' => $cart->base_grand_total + 500,
+        'sub_total' => $cart->sub_total + 500,
+        'base_sub_total' => $cart->base_sub_total + 500,
+    ]);
+
+    mockCallbackToken(callbackClaims($cart));
+
+    mockConfirmedStatus($this->payGlocalMock, $cart);
+
+    // Act
+    $response = $this->postJson(route('payglocal.webhook'), ['x-gl-token' => 'token']);
+
+    // Assert
+    $response->assertOk();
+
+    $order = Order::where('cart_id', $cart->id)->first();
+
+    expect($order)->not->toBeNull();
+
+    expect((float) $order->base_grand_total)->toBe((float) $cart->base_grand_total);
 });
 
 it('refuses to place the order when the cart currency no longer matches what was captured', function () {

--- a/packages/Webkul/PayU/src/Http/Controllers/PayUController.php
+++ b/packages/Webkul/PayU/src/Http/Controllers/PayUController.php
@@ -109,8 +109,13 @@ class PayUController extends Controller
 
             Cart::collectTotals();
 
-            // Re-fetch: collectTotals() ends with an internal refresh; reusing the pre-refresh reference here would serialize stale cart state.
             $cart = Cart::getCart();
+
+            if (! $cart) {
+                session()->flash('error', trans('payu::app.response.cart-not-found'));
+
+                return redirect()->route('shop.checkout.cart.index');
+            }
 
             $data = (new OrderResource($cart))->jsonSerialize();
 

--- a/packages/Webkul/PayU/src/Http/Controllers/PayUController.php
+++ b/packages/Webkul/PayU/src/Http/Controllers/PayUController.php
@@ -109,6 +109,9 @@ class PayUController extends Controller
 
             Cart::collectTotals();
 
+            // Re-fetch: collectTotals() ends with an internal refresh; reusing the pre-refresh reference here would serialize stale cart state.
+            $cart = Cart::getCart();
+
             $data = (new OrderResource($cart))->jsonSerialize();
 
             $data['payment']['additional'] = [

--- a/packages/Webkul/PhonePe/src/Http/Controllers/PhonePeController.php
+++ b/packages/Webkul/PhonePe/src/Http/Controllers/PhonePeController.php
@@ -143,8 +143,13 @@ class PhonePeController extends Controller
 
                 Cart::collectTotals();
 
-                // Re-fetch: collectTotals() ends with an internal refresh; reusing the pre-refresh reference here would serialize stale cart state.
                 $cart = Cart::getCart();
+
+                if (! $cart) {
+                    session()->flash('info', trans('phonepe::app.response.cart-not-found'));
+
+                    return redirect()->route('phonepe.cancel', ['merchantOrderId' => $merchantOrderId]);
+                }
 
                 $data = (new OrderResource($cart))->jsonSerialize();
 
@@ -274,8 +279,16 @@ class PhonePeController extends Controller
 
             Cart::collectTotals();
 
-            // Re-fetch: collectTotals() ends with an internal refresh; reusing the pre-refresh reference here would serialize stale cart state.
+            /**
+             * Cart::collectTotals() ends with an internal refresh that swaps the cart instance,
+             * so the totals it calculated live on the refreshed one. Serializing the reference
+             * captured above would persist the order with pre-calculation totals.
+             */
             $cart = Cart::getCart();
+
+            if (! $cart) {
+                return response()->json(['status' => 'cart_inactive'], 200);
+            }
 
             $data = (new OrderResource($cart))->jsonSerialize();
 

--- a/packages/Webkul/PhonePe/src/Http/Controllers/PhonePeController.php
+++ b/packages/Webkul/PhonePe/src/Http/Controllers/PhonePeController.php
@@ -143,6 +143,9 @@ class PhonePeController extends Controller
 
                 Cart::collectTotals();
 
+                // Re-fetch: collectTotals() ends with an internal refresh; reusing the pre-refresh reference here would serialize stale cart state.
+                $cart = Cart::getCart();
+
                 $data = (new OrderResource($cart))->jsonSerialize();
 
                 /**
@@ -270,6 +273,9 @@ class PhonePeController extends Controller
             Cart::setCart($cart);
 
             Cart::collectTotals();
+
+            // Re-fetch: collectTotals() ends with an internal refresh; reusing the pre-refresh reference here would serialize stale cart state.
+            $cart = Cart::getCart();
 
             $data = (new OrderResource($cart))->jsonSerialize();
 

--- a/packages/Webkul/PhonePe/src/Http/Controllers/PhonePeController.php
+++ b/packages/Webkul/PhonePe/src/Http/Controllers/PhonePeController.php
@@ -278,12 +278,7 @@ class PhonePeController extends Controller
             Cart::setCart($cart);
 
             Cart::collectTotals();
-
-            /**
-             * Cart::collectTotals() ends with an internal refresh that swaps the cart instance,
-             * so the totals it calculated live on the refreshed one. Serializing the reference
-             * captured above would persist the order with pre-calculation totals.
-             */
+            
             $cart = Cart::getCart();
 
             if (! $cart) {

--- a/packages/Webkul/Stripe/src/Http/Controllers/StripeController.php
+++ b/packages/Webkul/Stripe/src/Http/Controllers/StripeController.php
@@ -103,8 +103,13 @@ class StripeController extends Controller
 
             Cart::collectTotals();
 
-            // Re-fetch: collectTotals() ends with an internal refresh; reusing the pre-refresh reference here would serialize stale cart state.
             $cart = Cart::getCart();
+
+            if (! $cart) {
+                session()->flash('error', trans('stripe::app.response.cart-processed'));
+
+                return redirect()->route('shop.checkout.cart.index');
+            }
 
             $data = (new OrderResource($cart))->jsonSerialize();
 

--- a/packages/Webkul/Stripe/src/Http/Controllers/StripeController.php
+++ b/packages/Webkul/Stripe/src/Http/Controllers/StripeController.php
@@ -103,6 +103,9 @@ class StripeController extends Controller
 
             Cart::collectTotals();
 
+            // Re-fetch: collectTotals() ends with an internal refresh; reusing the pre-refresh reference here would serialize stale cart state.
+            $cart = Cart::getCart();
+
             $data = (new OrderResource($cart))->jsonSerialize();
 
             $data['payment']['additional'] = [


### PR DESCRIPTION
Cart::collectTotals() ends with an unconditional $this->refreshCart(), which replaces the internal cart instance with a freshly re-queried one from the DB. Any $cart variable captured before that call holds a stale in-memory reference, so passing it to OrderResource serializes outdated relation state.

Re-fetch the cart via Cart::getCart() immediately after Cart::collectTotals() in each affected call site, aligning with the pattern already used in SmartButtonController::saveOrder() and OnepageController::storeOrder().

Fixed call sites:
- Webkul\Stripe\Http\Controllers\StripeController::success()
- Webkul\PayU\Http\Controllers\PayUController::success()
- Webkul\PhonePe\Http\Controllers\PhonePeController::callback()
- Webkul\PhonePe\Http\Controllers\PhonePeController::webhook()
