### PR TITLE
Validate non-numeric products-per-page value (#11421)

### DIFF
--- a/packages/Webkul/Admin/src/Config/system.php
+++ b/packages/Webkul/Admin/src/Config/system.php
@@ -932,6 +932,7 @@ return [
                 'title' => 'admin::app.configuration.index.catalog.products.storefront.products-per-page',
                 'type' => 'text',
                 'info' => 'admin::app.configuration.index.catalog.products.storefront.comma-separated',
+                'validation' => 'nullable|regex:/^\d+(,\d+)*$/',
                 'channel_based' => true,
             ], [
                 'name' => 'sort_by',

--- a/packages/Webkul/Product/src/Helpers/Toolbar.php
+++ b/packages/Webkul/Product/src/Helpers/Toolbar.php
@@ -90,9 +90,14 @@ class Toolbar
     public function getAvailableLimits(): Collection
     {
         if ($productsPerPage = core()->getConfigData('catalog.products.storefront.products_per_page')) {
-            $pages = explode(',', $productsPerPage);
+            $pages = collect(explode(',', $productsPerPage))
+                ->map(fn ($page) => (int) trim($page))
+                ->filter(fn ($page) => $page > 0)
+                ->values();
 
-            return collect($pages);
+            if ($pages->isNotEmpty()) {
+                return $pages;
+            }
         }
 
         return collect([12, 24, 36, 48]);

--- a/packages/Webkul/Product/tests/Unit/ToolbarTest.php
+++ b/packages/Webkul/Product/tests/Unit/ToolbarTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use Webkul\Core\Models\CoreConfig;
+use Webkul\Product\Helpers\Toolbar;
+
+it('falls back to the default limits when the products per page config is non-numeric', function () {
+    // Arrange
+    CoreConfig::create([
+        'code' => 'catalog.products.storefront.products_per_page',
+        'value' => 'ten, twenty',
+    ]);
+
+    // Act
+    $limits = app(Toolbar::class)->getAvailableLimits();
+
+    // Assert
+    expect($limits->toArray())->toBe([12, 24, 36, 48]);
+});
+
+it('filters out non-numeric values but keeps the valid ones from the products per page config', function () {
+    // Arrange
+    CoreConfig::create([
+        'code' => 'catalog.products.storefront.products_per_page',
+        'value' => '10, twenty, 30',
+    ]);
+
+    // Act
+    $limits = app(Toolbar::class)->getAvailableLimits();
+
+    // Assert
+    expect($limits->toArray())->toBe([10, 30]);
+});
+
+it('returns the configured numeric limits as integers', function () {
+    // Arrange
+    CoreConfig::create([
+        'code' => 'catalog.products.storefront.products_per_page',
+        'value' => '10, 20, 30',
+    ]);
+
+    // Act
+    $limits = app(Toolbar::class)->getAvailableLimits();
+
+    // Assert
+    expect($limits->toArray())->toBe([10, 20, 30]);
+});
+
+it('does not crash and falls back to the default limit when the limit param is non-numeric', function () {
+    // Arrange
+    CoreConfig::create([
+        'code' => 'catalog.products.storefront.products_per_page',
+        'value' => 'ten, twenty',
+    ]);
+
+    // Act
+    $limit = app(Toolbar::class)->getLimit(['limit' => 'ten']);
+
+    // Assert
+    expect($limit)->toBe(12);
+});

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -54,6 +54,11 @@
             <directory suffix="Test.php">packages/Webkul/PayU/tests/Feature</directory>
         </testsuite>
 
+        <!-- Product package testsuites. -->
+        <testsuite name="Product Unit Test">
+            <directory suffix="Test.php">packages/Webkul/Product/tests/Unit</directory>
+        </testsuite>
+
         <!-- Razorpay package testsuites. -->
         <testsuite name="Razorpay Unit Test">
             <directory suffix="Test.php">packages/Webkul/Razorpay/tests/Unit</directory>


### PR DESCRIPTION
Fixes #11421

## Problem
The `Products per page` storefront config field (Configuration → Catalog → Products → Storefront) accepts free text with no validation. Saving a non-numeric value (e.g. `ten, twenty`) is persisted as-is and crashes the storefront's category/product-listing pages, because `Toolbar::getAvailableLimits()` blindly exploded the raw string on commas and returned non-numeric strings as the available page-size limits, which later get passed to pagination expecting an int.

## Fix
- `packages/Webkul/Product/src/Helpers/Toolbar.php`: `getAvailableLimits()` now casts each comma-separated value to an int and filters out anything that isn't a positive integer. If nothing valid remains, it falls back to the existing default `[12, 24, 36, 48]` instead of returning garbage.
- `packages/Webkul/Admin/src/Config/system.php`: added a `regex` validation rule to the `products_per_page` config field so the admin form also rejects non-numeric input at save time, matching the field's own "comma separated" hint.

## Test plan
- Added `packages/Webkul/Product/tests/Unit/ToolbarTest.php` (Pest) covering: fully non-numeric config falls back to defaults, mixed valid/invalid values keep only the valid ones, fully numeric config is returned as ints, and `getLimit()` no longer crashes and falls back to the default limit when given a non-numeric value.
- Registered a new `Product Unit Test` suite in `phpunit.xml` (mirrors the existing per-package suite pattern) since the `Product` package previously had no tests directory.

**Disclosure:** No PHP runtime is available in the environment these changes were authored in, so the new test could not be executed locally. It follows the existing Pest conventions used by `packages/Webkul/Core/tests/Unit/CoreTest.php` and should be verified by CI.