### PR TITLE
Scope customer email uniqueness by channel (#11418)

### DIFF
--- a/packages/Webkul/Shop/src/Http/Requests/Customer/ProfileRequest.php
+++ b/packages/Webkul/Shop/src/Http/Requests/Customer/ProfileRequest.php
@@ -24,14 +24,16 @@ class ProfileRequest extends FormRequest
      */
     public function rules()
     {
-        $id = auth()->guard('customer')->user()->id;
+        $customer = auth()->guard('customer')->user();
+
+        $id = $customer->id;
 
         return [
             'first_name' => ['required'],
             'last_name' => ['required'],
             'gender' => 'required|in:Other,Male,Female',
             'date_of_birth' => 'date|before:today',
-            'email' => 'email|unique:customers,email,'.$id,
+            'email' => 'email|unique:customers,email,'.$id.',id,channel_id,'.$customer->channel_id,
             'new_password' => 'confirmed|min:6|required_with:current_password',
             'new_password_confirmation' => 'required_with:new_password',
             'current_password' => 'required_with:new_password',

--- a/packages/Webkul/Shop/tests/Feature/Customers/AccountTest.php
+++ b/packages/Webkul/Shop/tests/Feature/Customers/AccountTest.php
@@ -4,6 +4,7 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Notification;
+use Webkul\Core\Models\Channel;
 use Webkul\Customer\Models\Customer;
 use Webkul\Customer\Models\CustomerAddress;
 use Webkul\Faker\Helpers\Product as ProductFaker;
@@ -477,4 +478,72 @@ it('should fails the validation errors certain inputs not provided', function ()
     // Arrange.
     postJson(route('shop.customers.forgot_password.store'))
         ->assertJsonValidationErrorFor('email');
+});
+
+it('should update the customer profile when the same email exists in a different channel', function () {
+    // Arrange.
+    $otherChannel = Channel::factory()->create();
+
+    $sharedEmail = fake()->safeEmail();
+
+    Customer::factory()->create([
+        'email' => $sharedEmail,
+        'channel_id' => $otherChannel->id,
+    ]);
+
+    $customer = Customer::factory()->create([
+        'email' => $sharedEmail,
+        'channel_id' => 1,
+    ]);
+
+    $this->loginAsCustomer($customer);
+
+    // Act and Assert.
+    postJson(route('shop.customers.account.profile.update'), [
+        'first_name' => $customer->first_name,
+        'last_name' => $customer->last_name,
+        'gender' => $customer->gender,
+        'email' => $sharedEmail,
+        'phone' => fake()->e164PhoneNumber(),
+        'date_of_birth' => now()->subYear(20)->toDateString(),
+    ])
+        ->assertRedirect(route('shop.customers.account.profile.index'));
+
+    $this->assertModelWise([
+        Customer::class => [
+            [
+                'id' => $customer->id,
+                'email' => $sharedEmail,
+                'channel_id' => 1,
+            ],
+        ],
+    ]);
+});
+
+it('should fail the validation when the email is already taken within the same channel', function () {
+    // Arrange.
+    $sharedEmail = fake()->safeEmail();
+
+    Customer::factory()->create([
+        'email' => $sharedEmail,
+        'channel_id' => 1,
+    ]);
+
+    $customer = Customer::factory()->create([
+        'channel_id' => 1,
+    ]);
+
+    $this->loginAsCustomer($customer);
+
+    // Act and Assert.
+    postJson(route('shop.customers.account.profile.update'), [
+        'first_name' => $customer->first_name,
+        'last_name' => $customer->last_name,
+        'gender' => $customer->gender,
+        'email' => $sharedEmail,
+        'phone' => fake()->e164PhoneNumber(),
+        'date_of_birth' => now()->subYear(20)->toDateString(),
+    ])
+        ->assertJsonValidationErrorFor('email')
+        ->assertUnprocessable();
 });


### PR DESCRIPTION
Fixes #11418

## Problem
Registration already scopes email uniqueness by channel (`RegistrationRequest`: `unique:customers,email,NULL,id,channel_id,`.core()->getCurrentChannel()->id), so the same email can legitimately be registered on multiple channels. However `ProfileRequest` (used when a customer updates their own profile) validated email uniqueness globally across the whole `customers` table with no channel scoping, so a customer whose email happens to also exist under a different channel gets a false "The email has already been taken" error when saving their own profile, even without changing the email.

## Fix
- `packages/Webkul/Shop/src/Http/Requests/Customer/ProfileRequest.php`: scoped the `email` unique rule by the authenticated customer's own `channel_id`, mirroring the existing pattern already used in `RegistrationRequest` and the admin `CustomerController`.

## Test plan
- Added two Pest feature tests to `packages/Webkul/Shop/tests/Feature/Customers/AccountTest.php`:
  - profile update succeeds when the same email exists under a *different* channel (the reported bug).
  - profile update still fails validation when the email is already taken by another customer *within the same channel* (regression guard, uniqueness is not disabled entirely).

**Disclosure:** No PHP runtime is available in the environment these changes were authored in, so the new tests could not be executed locally. They follow the existing Pest conventions already used in `AccountTest.php` and should be verified by CI.