### PR TITLE
docs: add RepoCloud as a deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ You can also deploy Bagisto quickly using our pre-configured Amazon Machine Imag
 
 This AMI allows you to get started with Bagisto on a cloud environment without manual setup. Ideal for scalable production or testing environments.
 
+## ☁️ One-Click Deploy on RepoCloud
+
+Deploy Bagisto instantly with managed cloud hosting for open-source applications.
+
+👉 [**Deploy Bagisto on RepoCloud**](https://repocloud.io/details/Bagisto/)
+
 # Accelerate Your Online Store Launch with the Bagisto Starter Pack!
 
 Empower your e-commerce journey with the [Bagisto Starter Pack](https://store.webkul.com/bagisto-starter-pack.html), streamlining setup and integration for a seamless online store launch. Get ready to unlock success in the digital marketplace!


### PR DESCRIPTION
Adds [RepoCloud](https://repocloud.io) as a one-click deployment option alongside the existing cloud hosting and AWS AMI options.

RepoCloud provides managed cloud hosting for open-source applications with one-click deployment.

- Adds deploy section to `README.md`
- Uses the same text link format as the existing AWS AMI section
- Links to: https://repocloud.io/details/Bagisto/