### PR TITLE
fix: configurable product total quantity always returned zero

### DIFF
--- a/packages/Webkul/Product/src/Type/Configurable.php
+++ b/packages/Webkul/Product/src/Type/Configurable.php
@@ -602,9 +602,7 @@ class Configurable extends AbstractType
         $total = 0;
 
         foreach ($this->product->variants as $variant) {
-            $inventoryIndex = $variant->totalQuantity();
-
-            $total += $inventoryIndex->qty;
+            $total += $variant->getTypeInstance()->totalQuantity();
         }
 
         return $total;


### PR DESCRIPTION
## Issue Reference

No existing issue found for this bug (searched `totalQuantity configurable` / `configurable quantity`).

## Description

`Webkul\Product\Type\Configurable::totalQuantity()` iterates the configurable product's variants and reads `->qty` off the value returned by `$variant->totalQuantity()`:

```php
foreach ($this->product->variants as $variant) {
    $inventoryIndex = $variant->totalQuantity();

    $total += $inventoryIndex->qty;
}
```

However, `$variant` is a `Webkul\Product\Models\Product` model, and the model's `totalQuantity(): int` returns the summed inventory quantity as an **integer** — not an inventory-index object. Reading `->qty` off an int raises `Attempt to read property "qty" on int` (one warning per variant) and yields `null`, so the method always returns `0` for every configurable product.

Any storefront or admin code that asks a configurable product for its total quantity gets `0` regardless of variant stock (e.g. low-stock indicators built on `totalQuantity()`), while `Simple::totalQuantity()` on the same variants returns the real figures.

The fix sums each variant's type-instance quantity, which is the value the guard in `Simple::haveSufficientQuantity()` actually enforces, so the parent and child now agree:

```php
foreach ($this->product->variants as $variant) {
    $total += $variant->getTypeInstance()->totalQuantity();
}
```

## How To Test This?

On a store with a configurable product (e.g. the sample data one):

1. Before the patch:

```bash
php artisan tinker --execute="
    $p = app(\Webkul\Product\Repositories\ProductRepository::class)
        ->findWhere(['type' => 'configurable'])->first();
    var_dump($p->getTypeInstance()->totalQuantity()); // int(0) + one warning per variant
"
```

2. Apply the patch and re-run — the return value is now the sum of the variant quantities (e.g. `int(30)` for six variants at 5 each) and the `Attempt to read property "qty" on int` warnings are gone.

## Documentation

- [ ] My pull request requires an update on the documentation repository.

## Branch Selection

- [x] Target Branch: 2.4

## Tailwind Reordering

No Tailwind classes changed.
