### PR TITLE
fix: remove tax rates from tax category form

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/Tax/TaxCategoryController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/Tax/TaxCategoryController.php
@@ -10,7 +10,6 @@ use Webkul\Admin\DataGrids\Settings\TaxCategoryDataGrid;
 use Webkul\Admin\Http\Controllers\Controller;
 use Webkul\Admin\Http\Resources\TaxCategoryResource;
 use Webkul\Tax\Repositories\TaxCategoryRepository;
-use Webkul\Tax\Repositories\TaxRateRepository;
 
 class TaxCategoryController extends Controller
 {
@@ -19,10 +18,7 @@ class TaxCategoryController extends Controller
      *
      * @return void
      */
-    public function __construct(
-        protected TaxCategoryRepository $taxCategoryRepository,
-        protected TaxRateRepository $taxRateRepository
-    ) {}
+    public function __construct(protected TaxCategoryRepository $taxCategoryRepository) {}
 
     /**
      * Display a listing of the resource.
@@ -35,7 +31,7 @@ class TaxCategoryController extends Controller
             return datagrid(TaxCategoryDataGrid::class)->process();
         }
 
-        return view('admin::settings.taxes.categories.index')->with('taxRates', $this->taxRateRepository->all());
+        return view('admin::settings.taxes.categories.index');
     }
 
     /**
@@ -49,7 +45,6 @@ class TaxCategoryController extends Controller
             'code' => 'required|string|unique:tax_categories,code',
             'name' => 'required|string',
             'description' => 'required|string',
-            'taxrates' => 'array|required',
         ]);
 
         Event::dispatch('tax.category.create.before');
@@ -58,12 +53,9 @@ class TaxCategoryController extends Controller
             'code',
             'name',
             'description',
-            'taxrates',
         ]);
 
         $taxCategory = $this->taxCategoryRepository->create($data);
-
-        $taxCategory->tax_rates()->sync($data['taxrates']);
 
         Event::dispatch('tax.category.create.after', $taxCategory);
 
@@ -93,7 +85,6 @@ class TaxCategoryController extends Controller
             'code' => 'required|string|unique:tax_categories,code,'.$id,
             'name' => 'required|string',
             'description' => 'required|string',
-            'taxrates' => 'array|required',
         ]);
 
         Event::dispatch('tax.category.update.before', $id);
@@ -102,12 +93,9 @@ class TaxCategoryController extends Controller
             'code',
             'name',
             'description',
-            'taxrates',
         ]);
 
         $taxCategory = $this->taxCategoryRepository->update($data, $id);
-
-        $taxCategory->tax_rates()->sync($data['taxrates']);
 
         Event::dispatch('tax.category.update.after', $taxCategory);
 

--- a/packages/Webkul/Admin/src/Resources/views/settings/taxes/categories/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/taxes/categories/index.blade.php
@@ -14,10 +14,7 @@
                 <div class="flex items-center gap-x-2.5">
                     <!-- Create Tax Category Button -->
                     @if (bouncer()->hasPermission('settings.taxes.tax_categories.create'))
-                        <button
-                            type="button"
-                            class="primary-button"
-                        >
+                        <button type="button" class="primary-button">
                             @lang('admin::app.settings.taxes.categories.index.create.title')
                         </button>
                     @endif
@@ -202,41 +199,6 @@
                                 <x-admin::form.control-group.error control-name="description" />
                             </x-admin::form.control-group>
 
-                            <!-- Select Tax Rates -->
-                            <x-admin::form.control-group>
-                                <x-admin::form.control-group.label class="required">
-                                    @lang('admin::app.settings.taxes.categories.index.create.tax-rates')
-                                </x-admin::form.control-group.label>
-
-                                <v-field
-                                    name="taxrates[]"
-                                    rules="required"
-                                    label="@lang('admin::app.settings.taxes.categories.index.create.tax-rates')"
-                                    v-model="selectedTaxRates.tax_rates"
-                                    multiple
-                                >
-                                    <select
-                                        name="taxrates[]"
-                                        class="flex min-h-[39px] w-full rounded-md border px-3 py-2 text-sm text-gray-600 transition-all hover:border-gray-400 focus:border-gray-400 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-gray-400 dark:focus:border-gray-400"
-                                        :class="[errors['options[sort]'] ? 'border border-red-600 hover:border-red-600' : '']"
-                                        multiple
-                                        v-model="selectedTaxRates.tax_rates"
-                                    >
-                                        <option
-                                            v-for="taxRate in taxRates"
-                                            :value="taxRate.id"
-                                            :text="taxRate.identifier"
-                                        >
-                                        </option>
-                                    </select>
-                                </v-field>
-
-                                <x-admin::form.control-group.error
-                                    control-name="taxrates[]"
-                                >
-                                </x-admin::form.control-group.error>
-                            </x-admin::form.control-group>
-
                         </x-slot>
 
                         <!-- Modal Footer -->
@@ -261,8 +223,6 @@
 
                 data() {
                     return {
-                        taxRates: @json($taxRates),
-
                         selectedTaxRates: {},
 
                         selectedTaxCategories: 0,
@@ -288,7 +248,10 @@
                 },
 
                 methods: {
-                    updateOrCreate(params, { resetForm, setErrors }) {
+                    updateOrCreate(params, {
+                        resetForm,
+                        setErrors
+                    }) {
                         this.isLoading = true;
 
                         let formData = new FormData(this.$refs.taxCategoryCreateForm);
@@ -297,11 +260,12 @@
                             formData.append('_method', 'put');
                         }
 
-                        this.$axios.post(params.id ? "{{ route('admin.settings.taxes.categories.update') }}" : "{{ route('admin.settings.taxes.categories.store') }}", formData,{
-                            headers: {
-                                'Content-Type': 'multipart/form-data'
-                                }
-                            })
+                        this.$axios.post(params.id ? "{{ route('admin.settings.taxes.categories.update') }}" :
+                                "{{ route('admin.settings.taxes.categories.store') }}", formData, {
+                                    headers: {
+                                        'Content-Type': 'multipart/form-data'
+                                    }
+                                })
                             .then((response) => {
                                 this.isLoading = false;
 
@@ -309,7 +273,10 @@
 
                                 this.$refs.datagrid.get();
 
-                                this.$emitter.emit('add-flash', { type: 'success', message: response.data.message });
+                                this.$emitter.emit('add-flash', {
+                                    type: 'success',
+                                    message: response.data.message
+                                });
 
                                 this.selectedTaxRates = {};
                             })
@@ -329,7 +296,8 @@
                                 this.$refs.taxCategory.toggle();
                             })
                             .catch(error => this.$emitter.emit('add-flash', {
-                                type: 'error', message: error.response.data.message
+                                type: 'error',
+                                message: error.response.data.message
                             }));
                     },
                 },

--- a/packages/Webkul/Admin/tests/Feature/Settings/TaxCategoriesTest.php
+++ b/packages/Webkul/Admin/tests/Feature/Settings/TaxCategoriesTest.php
@@ -2,7 +2,6 @@
 
 use Illuminate\Support\Arr;
 use Webkul\Tax\Models\TaxCategory;
-use Webkul\Tax\Models\TaxRate;
 
 use function Pest\Laravel\deleteJson;
 use function Pest\Laravel\get;
@@ -27,7 +26,6 @@ it('should fail the validation with errors when certain field not provided when 
         ->assertJsonValidationErrorFor('code')
         ->assertJsonValidationErrorFor('name')
         ->assertJsonValidationErrorFor('description')
-        ->assertJsonValidationErrorFor('taxrates')
         ->assertUnprocessable();
 });
 
@@ -39,7 +37,6 @@ it('should store the tax category', function () {
         'code' => fake()->numerify('code#######'),
         'name' => fake()->words(2, true),
         'description' => fake()->sentence(10),
-        'taxrates' => TaxRate::factory()->count(2)->create()->pluck('id')->toArray(),
     ])
         ->assertOk()
         ->assertSeeText(trans('admin::app.settings.taxes.categories.index.create-success'));
@@ -80,7 +77,6 @@ it('should fail the validation with errors when certain field not provided when 
         ->assertJsonValidationErrorFor('code')
         ->assertJsonValidationErrorFor('name')
         ->assertJsonValidationErrorFor('description')
-        ->assertJsonValidationErrorFor('taxrates')
         ->assertUnprocessable();
 });
 
@@ -96,7 +92,6 @@ it('should update the tax category', function () {
         'code' => fake()->numerify('code#######'),
         'name' => fake()->words(2, true),
         'description' => fake()->sentence(10),
-        'taxrates' => TaxRate::factory()->count(2)->create()->pluck('id')->toArray(),
     ])
         ->assertOk()
         ->assertJsonPath('message', trans('admin::app.settings.taxes.categories.index.update-success'));


### PR DESCRIPTION
## Issue Reference

No issue reference.

## Description

Removed tax-rate selection from tax-category creation and update flows.

Changes:
- Removed tax-rate repository dependency from the controller.
- Removed tax-rate validation and synchronization.
- Removed the tax-rate selector from the admin form.
- Updated feature tests for the simplified workflow.

## How To Test This?

Run:

`vendor/bin/pest packages/Webkul/Admin/tests/Feature/Settings/TaxCategoriesTest.php`

Result: 14 tests passed.

## Documentation

- [ ] This pull request requires an update on the documentation repository.

## Branch Selection

- [x] Target Branch: 2.4

## Tailwind Reordering

Tailwind classes were reordered where required.

<img width="878" height="702" alt="image" src="https://github.com/user-attachments/assets/edd135be-76e8-4a44-ad35-e3b7732c3114" />