### PR TITLE
Show notice with link when no Tax Rates exist on Tax Category form

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/settings/taxes/categories/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/taxes/categories/index.blade.php
@@ -208,33 +208,49 @@
                                     @lang('admin::app.settings.taxes.categories.index.create.tax-rates')
                                 </x-admin::form.control-group.label>
 
-                                <v-field
-                                    name="taxrates[]"
-                                    rules="required"
-                                    label="@lang('admin::app.settings.taxes.categories.index.create.tax-rates')"
-                                    v-model="selectedTaxRates.tax_rates"
-                                    multiple
-                                >
-                                    <select
-                                        name="taxrates[]"
-                                        class="flex min-h-[39px] w-full rounded-md border px-3 py-2 text-sm text-gray-600 transition-all hover:border-gray-400 focus:border-gray-400 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-gray-400 dark:focus:border-gray-400"
-                                        :class="[errors['options[sort]'] ? 'border border-red-600 hover:border-red-600' : '']"
-                                        multiple
-                                        v-model="selectedTaxRates.tax_rates"
-                                    >
-                                        <option
-                                            v-for="taxRate in taxRates"
-                                            :value="taxRate.id"
-                                            :text="taxRate.identifier"
+                                <!-- Empty state: no tax rates exist yet -->
+                                <template v-if="!taxRates.length">
+                                    <p class="mt-1.5 text-sm text-amber-600 dark:text-amber-400">
+                                        @lang('admin::app.settings.taxes.categories.index.create.empty-text')
+                                        <a
+                                            href="{{ route('admin.settings.taxes.rates.create') }}"
+                                            class="font-semibold underline"
+                                            target="_blank"
                                         >
-                                        </option>
-                                    </select>
-                                </v-field>
+                                            @lang('admin::app.settings.taxes.categories.index.create.add-tax-rates')
+                                        </a>
+                                    </p>
+                                </template>
 
-                                <x-admin::form.control-group.error
-                                    control-name="taxrates[]"
-                                >
-                                </x-admin::form.control-group.error>
+                                <template v-else>
+                                    <v-field
+                                        name="taxrates[]"
+                                        rules="required"
+                                        label="@lang('admin::app.settings.taxes.categories.index.create.tax-rates')"
+                                        v-model="selectedTaxRates.tax_rates"
+                                        multiple
+                                    >
+                                        <select
+                                            name="taxrates[]"
+                                            class="flex min-h-[39px] w-full rounded-md border px-3 py-2 text-sm text-gray-600 transition-all hover:border-gray-400 focus:border-gray-400 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-gray-400 dark:focus:border-gray-400"
+                                            :class="[errors['options[sort]'] ? 'border border-red-600 hover:border-red-600' : '']"
+                                            multiple
+                                            v-model="selectedTaxRates.tax_rates"
+                                        >
+                                            <option
+                                                v-for="taxRate in taxRates"
+                                                :value="taxRate.id"
+                                                :text="taxRate.identifier"
+                                            >
+                                            </option>
+                                        </select>
+                                    </v-field>
+
+                                    <x-admin::form.control-group.error
+                                        control-name="taxrates[]"
+                                    >
+                                    </x-admin::form.control-group.error>
+                                </template>
                             </x-admin::form.control-group>
 
                         </x-slot>
@@ -247,7 +263,7 @@
                                 class="primary-button"
                                 :title="trans('admin::app.settings.taxes.categories.index.create.save-btn')"
                                 ::loading="isLoading"
-                                ::disabled="isLoading"
+                                ::disabled="isLoading || (!selectedTaxCategories && !taxRates.length)"
                             />
                         </x-slot>
                     </x-admin::modal>

--- a/packages/Webkul/Admin/src/Resources/views/settings/taxes/categories/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/taxes/categories/index.blade.php
@@ -208,17 +208,20 @@
                                     @lang('admin::app.settings.taxes.categories.index.create.tax-rates')
                                 </x-admin::form.control-group.label>
 
-                                <!-- Empty state: no tax rates exist yet -->
-                                <template v-if="!taxRates.length">
+                                <!-- Tax Rates Notice -->
+                                <template v-if="! taxRates.length">
                                     <p class="mt-1.5 text-sm text-amber-600 dark:text-amber-400">
                                         @lang('admin::app.settings.taxes.categories.index.create.empty-text')
-                                        <a
-                                            href="{{ route('admin.settings.taxes.rates.create') }}"
-                                            class="font-semibold underline"
-                                            target="_blank"
-                                        >
-                                            @lang('admin::app.settings.taxes.categories.index.create.add-tax-rates')
-                                        </a>
+
+                                        @if (bouncer()->hasPermission('settings.taxes.tax_rates.create'))
+                                            <a
+                                                href="{{ route('admin.settings.taxes.rates.create') }}"
+                                                class="font-semibold underline"
+                                                target="_blank"
+                                            >
+                                                @lang('admin::app.settings.taxes.categories.index.create.add-tax-rates')
+                                            </a>
+                                        @endif
                                     </p>
                                 </template>
 
@@ -233,7 +236,7 @@
                                         <select
                                             name="taxrates[]"
                                             class="flex min-h-[39px] w-full rounded-md border px-3 py-2 text-sm text-gray-600 transition-all hover:border-gray-400 focus:border-gray-400 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-gray-400 dark:focus:border-gray-400"
-                                            :class="[errors['options[sort]'] ? 'border border-red-600 hover:border-red-600' : '']"
+                                            :class="[errors['taxrates[]'] ? 'border border-red-600 hover:border-red-600' : '']"
                                             multiple
                                             v-model="selectedTaxRates.tax_rates"
                                         >
@@ -246,13 +249,9 @@
                                         </select>
                                     </v-field>
 
-                                    <x-admin::form.control-group.error
-                                        control-name="taxrates[]"
-                                    >
-                                    </x-admin::form.control-group.error>
+                                    <x-admin::form.control-group.error control-name="taxrates[]" />
                                 </template>
                             </x-admin::form.control-group>
-
                         </x-slot>
 
                         <!-- Modal Footer -->
@@ -263,7 +262,7 @@
                                 class="primary-button"
                                 :title="trans('admin::app.settings.taxes.categories.index.create.save-btn')"
                                 ::loading="isLoading"
-                                ::disabled="isLoading || (!selectedTaxCategories && !taxRates.length)"
+                                ::disabled="isLoading || ! taxRates.length"
                             />
                         </x-slot>
                     </x-admin::modal>


### PR DESCRIPTION
Fixes #11461

## Problem

When no Tax Rates have been created yet, the Tax Category creation modal shows a required `<select>` with zero options. There is no explanation for why the field is empty and no way to resolve the situation from within the form — the admin is stuck.

## Solution

- When `taxRates` is empty, replace the select with a short notice using the existing `empty-text` translation key, and a link (opens in a new tab) pointing directly to the Tax Rate creation page.
- The `v-field` validation rule is only rendered when tax rates are available, so vee-validate does not block the form with an irrelevant error.
- The **Save** button is disabled during Tax Category *creation* when no tax rates exist, preventing a pointless server-side 422 response.
- Editing an existing Tax Category (which already has rates assigned) is unaffected.

No new language keys are needed; the existing `empty-text` and `add-tax-rates` keys are reused.