### PR TITLE
fix: update compare product count in header

### DIFF
--- a/packages/Webkul/Shop/src/Resources/views/compare/index.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/compare/index.blade.php
@@ -219,6 +219,8 @@
 
                                     localStorage.setItem('compare_items', JSON.stringify(items));
 
+                                    this.$emitter.emit('update-compare-count');
+
                                     return;
                                 }
 
@@ -230,6 +232,8 @@
                                         this.items = response.data.data;
 
                                         this.$emitter.emit('add-flash', { type: 'success', message: response.data.message });
+
+                                        this.$emitter.emit('update-compare-count');
 
                                     })
                                     .catch(error => {
@@ -249,6 +253,8 @@
 
                                     this.$emitter.emit('add-flash', { type: 'success', message:  "@lang('shop::app.compare.remove-all-success')" });
 
+                                    this.$emitter.emit('update-compare-count');
+
                                     return;
                                 }
 
@@ -259,6 +265,8 @@
                                         this.items = [];
 
                                         this.$emitter.emit('add-flash', { type: 'success', message: response.data.data.message });
+
+                                        this.$emitter.emit('update-compare-count');
                                     })
                                     .catch(error => {});
                             }

--- a/packages/Webkul/Shop/src/Resources/views/components/layouts/header/desktop/bottom.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/components/layouts/header/desktop/bottom.blade.php
@@ -112,10 +112,12 @@
                     href="{{ route('shop.compare.index') }}"
                     aria-label="@lang('shop::app.components.layouts.header.desktop.bottom.compare')"
                 >
-                    <span
-                        class="inline-block text-2xl cursor-pointer icon-compare"
-                        role="presentation"
-                    ></span>
+                    <v-compare-icon>
+                        <span
+                            class="inline-block text-2xl cursor-pointer icon-compare"
+                            role="presentation"
+                        ></span>
+                    </v-compare-icon>
                 </a>
             @endif
 

--- a/packages/Webkul/Shop/src/Resources/views/components/layouts/header/index.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/components/layouts/header/index.blade.php
@@ -200,4 +200,77 @@
     >
         <x-shop::layouts.header.mobile />
     </script>
+
+    <script
+        type="text/x-template"
+        id="v-compare-icon-template"
+    >
+        <span class="relative inline-block">
+            <span
+                class="inline-block text-2xl cursor-pointer icon-compare"
+                role="presentation"
+            ></span>
+
+            <span
+                class="absolute -top-4 rounded-[44px] bg-navyBlue px-2 py-1.5 text-xs font-semibold leading-[9px] text-white ltr:left-5 rtl:right-5"
+                v-if="compareCount > 0"
+            >
+                @{{ compareCount }}
+            </span>
+        </span>
+    </script>
+
+    <script type="module">
+        app.component('v-compare-icon', {
+            template: '#v-compare-icon-template',
+
+            data() {
+                return {
+                    isCustomer: '{{ auth()->guard('customer')->check() }}',
+
+                    compareCount: 0,
+                };
+            },
+
+            mounted() {
+                this.refreshCompareCount();
+
+                this.$emitter.on('update-compare-count', this.refreshCompareCount);
+            },
+
+            beforeUnmount() {
+                this.$emitter.off('update-compare-count', this.refreshCompareCount);
+            },
+
+            methods: {
+                refreshCompareCount() {
+                    if (this.isCustomer) {
+                        this.getCustomerCompareCount();
+
+                        return;
+                    }
+
+                    this.compareCount = this.getGuestCompareCount();
+                },
+
+                getGuestCompareCount() {
+                    try {
+                        const items = JSON.parse(localStorage.getItem('compare_items') ?? '[]');
+
+                        return Array.isArray(items) ? items.length : 0;
+                    } catch (e) {
+                        return 0;
+                    }
+                },
+
+                getCustomerCompareCount() {
+                    this.$axios.get("{{ route('shop.api.compare.index') }}")
+                        .then(response => {
+                            this.compareCount = response.data.data.length;
+                        })
+                        .catch(error => {});
+                },
+            },
+        });
+    </script>
 @endPushOnce

--- a/packages/Webkul/Shop/src/Resources/views/components/layouts/header/mobile/index.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/components/layouts/header/mobile/index.blade.php
@@ -48,7 +48,9 @@
                         href="{{ route('shop.compare.index') }}"
                         aria-label="@lang('shop::app.components.layouts.header.mobile.compare')"
                     >
-                        <span class="text-2xl cursor-pointer icon-compare"></span>
+                        <v-compare-icon>
+                            <span class="text-2xl cursor-pointer icon-compare"></span>
+                        </v-compare-icon>
                     </a>
                 @endif
 

--- a/packages/Webkul/Shop/src/Resources/views/components/products/card.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/components/products/card.blade.php
@@ -380,6 +380,8 @@
                             })
                             .then(response => {
                                 this.$emitter.emit('add-flash', { type: 'success', message: response.data.data.message });
+
+                                this.$emitter.emit('update-compare-count');
                             })
                             .catch(error => {
                                 if ([400, 422].includes(error.response.status)) {
@@ -406,6 +408,8 @@
                             localStorage.setItem('compare_items', JSON.stringify(items));
 
                             this.$emitter.emit('add-flash', { type: 'success', message: "@lang('shop::app.components.products.card.add-to-compare-success')" });
+
+                            this.$emitter.emit('update-compare-count');
                         } else {
                             this.$emitter.emit('add-flash', { type: 'warning', message: "@lang('shop::app.components.products.card.already-in-compare')" });
                         }
@@ -413,6 +417,8 @@
                         localStorage.setItem('compare_items', JSON.stringify([productId]));
 
                         this.$emitter.emit('add-flash', { type: 'success', message: "@lang('shop::app.components.products.card.add-to-compare-success')" });
+
+                        this.$emitter.emit('update-compare-count');
 
                     }
                 },

--- a/packages/Webkul/Shop/src/Resources/views/products/view.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/products/view.blade.php
@@ -693,6 +693,8 @@
                                 })
                                 .then(response => {
                                     this.$emitter.emit('add-flash', { type: 'success', message: response.data.data.message });
+
+                                    this.$emitter.emit('update-compare-count');
                                 })
                                 .catch(error => {
                                     if ([400, 422].includes(error.response.status)) {
@@ -719,6 +721,8 @@
                                 this.setStorageValue(this.getCompareItemsStorageKey(), existingItems);
 
                                 this.$emitter.emit('add-flash', { type: 'success', message: "@lang('shop::app.products.view.add-to-compare')" });
+
+                                this.$emitter.emit('update-compare-count');
                             } else {
                                 this.$emitter.emit('add-flash', { type: 'warning', message: "@lang('shop::app.products.view.already-in-compare')" });
                             }
@@ -726,6 +730,8 @@
                             this.setStorageValue(this.getCompareItemsStorageKey(), [productId]);
 
                             this.$emitter.emit('add-flash', { type: 'success', message: "@lang('shop::app.products.view.add-to-compare')" });
+
+                            this.$emitter.emit('update-compare-count');
                         }
                     },
 


### PR DESCRIPTION
## Description

Fixes #10705.

The compare product count in the storefront header did not update after adding or removing products.

### Changes

* Added a reactive compare-count badge to the desktop and mobile headers.
* Added initial compare-count loading for both guest and authenticated customers.
* Added compare-count updates after successful add/remove operations.
* Recompute the count from the existing source of truth to prevent count drift.
* Preserved the existing Compare link, accessibility label, and compare functionality.

### Scope

* Frontend Blade/Vue only.
* No backend/API changes.
* No database changes.
* No translations added.
* No generated/compiled assets modified.

### Testing

* `node --check` passed for all extracted JavaScript blocks.
* `git diff --check` passed.
* `vendor/bin/pint --test` could not be run because PHP/vendor dependencies are unavailable in the local environment.
* Pest tests could not be run for the same reason.
* Playwright compare tests could not be run because the application/database/browser environment is unavailable.
