### PR TITLE
fix: drop three indexes that duplicate an existing primary or unique key

### DIFF
--- a/packages/Webkul/Attribute/src/Database/Migrations/2026_09_04_000002_drop_duplicate_attributes_code_index.php
+++ b/packages/Webkul/Attribute/src/Database/Migrations/2026_09_04_000002_drop_duplicate_attributes_code_index.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('attributes', function (Blueprint $table) {
+            if (Schema::hasIndex('attributes', DB::getTablePrefix().'attributes_code_index')) {
+                $table->dropIndex(['code']);
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('attributes', function (Blueprint $table) {
+            if (! Schema::hasIndex('attributes', DB::getTablePrefix().'attributes_code_index')) {
+                $table->index('code');
+            }
+        });
+    }
+};

--- a/packages/Webkul/Attribute/src/Database/Migrations/2026_09_04_000002_drop_duplicate_attributes_code_index.php
+++ b/packages/Webkul/Attribute/src/Database/Migrations/2026_09_04_000002_drop_duplicate_attributes_code_index.php
@@ -2,24 +2,29 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    /**
+     * Run the migrations.
+     */
     public function up(): void
     {
         Schema::table('attributes', function (Blueprint $table) {
-            if (Schema::hasIndex('attributes', DB::getTablePrefix().'attributes_code_index')) {
+            if (Schema::hasIndex('attributes', $table->getPrefix().'attributes_code_index')) {
                 $table->dropIndex(['code']);
             }
         });
     }
 
+    /**
+     * Reverse the migrations.
+     */
     public function down(): void
     {
         Schema::table('attributes', function (Blueprint $table) {
-            if (! Schema::hasIndex('attributes', DB::getTablePrefix().'attributes_code_index')) {
+            if (! Schema::hasIndex('attributes', $table->getPrefix().'attributes_code_index')) {
                 $table->index('code');
             }
         });

--- a/packages/Webkul/Core/src/Database/Migrations/2026_09_04_000001_drop_duplicate_channel_pivot_indexes.php
+++ b/packages/Webkul/Core/src/Database/Migrations/2026_09_04_000001_drop_duplicate_channel_pivot_indexes.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('channel_locales', function (Blueprint $table) {
+            if (Schema::hasIndex('channel_locales', DB::getTablePrefix().'channel_locales_cid_lid_idx')) {
+                $table->dropIndex('channel_locales_cid_lid_idx');
+            }
+        });
+
+        Schema::table('channel_currencies', function (Blueprint $table) {
+            if (Schema::hasIndex('channel_currencies', DB::getTablePrefix().'channel_currencies_cid_cyid_idx')) {
+                $table->dropIndex('channel_currencies_cid_cyid_idx');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('channel_locales', function (Blueprint $table) {
+            if (! Schema::hasIndex('channel_locales', DB::getTablePrefix().'channel_locales_cid_lid_idx')) {
+                $table->index(['channel_id', 'locale_id'], 'channel_locales_cid_lid_idx');
+            }
+        });
+
+        Schema::table('channel_currencies', function (Blueprint $table) {
+            if (! Schema::hasIndex('channel_currencies', DB::getTablePrefix().'channel_currencies_cid_cyid_idx')) {
+                $table->index(['channel_id', 'currency_id'], 'channel_currencies_cid_cyid_idx');
+            }
+        });
+    }
+};

--- a/packages/Webkul/Core/src/Database/Migrations/2026_09_04_000001_drop_duplicate_channel_pivot_indexes.php
+++ b/packages/Webkul/Core/src/Database/Migrations/2026_09_04_000001_drop_duplicate_channel_pivot_indexes.php
@@ -2,36 +2,41 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    /**
+     * Run the migrations.
+     */
     public function up(): void
     {
         Schema::table('channel_locales', function (Blueprint $table) {
-            if (Schema::hasIndex('channel_locales', DB::getTablePrefix().'channel_locales_cid_lid_idx')) {
+            if (Schema::hasIndex('channel_locales', 'channel_locales_cid_lid_idx')) {
                 $table->dropIndex('channel_locales_cid_lid_idx');
             }
         });
 
         Schema::table('channel_currencies', function (Blueprint $table) {
-            if (Schema::hasIndex('channel_currencies', DB::getTablePrefix().'channel_currencies_cid_cyid_idx')) {
+            if (Schema::hasIndex('channel_currencies', 'channel_currencies_cid_cyid_idx')) {
                 $table->dropIndex('channel_currencies_cid_cyid_idx');
             }
         });
     }
 
+    /**
+     * Reverse the migrations.
+     */
     public function down(): void
     {
         Schema::table('channel_locales', function (Blueprint $table) {
-            if (! Schema::hasIndex('channel_locales', DB::getTablePrefix().'channel_locales_cid_lid_idx')) {
+            if (! Schema::hasIndex('channel_locales', 'channel_locales_cid_lid_idx')) {
                 $table->index(['channel_id', 'locale_id'], 'channel_locales_cid_lid_idx');
             }
         });
 
         Schema::table('channel_currencies', function (Blueprint $table) {
-            if (! Schema::hasIndex('channel_currencies', DB::getTablePrefix().'channel_currencies_cid_cyid_idx')) {
+            if (! Schema::hasIndex('channel_currencies', 'channel_currencies_cid_cyid_idx')) {
                 $table->index(['channel_id', 'currency_id'], 'channel_currencies_cid_cyid_idx');
             }
         });


### PR DESCRIPTION
## Issue Reference

None. This is a small schema fix rather than a reported bug, so there was nothing to reference. Happy to open an issue first if you would prefer that order.

## Description

The September 2025 indexing migrations added three indexes that duplicate a key already present on the table.

| table | key already present | index added |
| --- | --- | --- |
| `channel_currencies` | `PRIMARY (channel_id, currency_id)` | `channel_currencies_cid_cyid_idx` on the same two columns, same order |
| `channel_locales` | `PRIMARY (channel_id, locale_id)` | `channel_locales_cid_lid_idx` on the same two columns, same order |
| `attributes` | `attributes_code_unique (code)` | `attributes_code_index (code)` |

A primary key and a unique key are already indexes, so each of these adds write cost and storage without adding a read path.

This is easy to miss, because `->primary()` and `->unique()` do not look like index declarations at the call site.

Two migrations, one per package, each reusing the `hasIndex` guard from your own September migrations so they are safe to run twice and on installs where the index was never created. The `up()` here is effectively the `down()` you already wrote.

`master` carries the same three indexes and needs the same change.

## How To Test This?

On an installed 2.4 database:

```
php artisan migrate
```

Then confirm the three indexes are gone and nothing else is:

```sql
SELECT TABLE_NAME, INDEX_NAME, GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX) cols
FROM information_schema.STATISTICS
WHERE TABLE_SCHEMA = DATABASE()
  AND TABLE_NAME IN ('channel_locales','channel_currencies','attributes')
GROUP BY TABLE_NAME, INDEX_NAME;
```

`php artisan migrate:rollback` restores them.

What I ran, on a fresh 2.4 install with seed data, MySQL 9.6:

- `vendor/bin/pint --test` on both files: passed.
- `vendor/bin/pest` before the change: 6 failed, 1471 passed.
- `vendor/bin/pest` after the change: the same 6 failures, same tests. They are all `it should update the ... product` in `Admin/tests/Feature/Catalog/Products/Types` and look unrelated to indexes.
- One earlier run reported 7 failures rather than 6. On repeat the failing set was identical, so that suite appears mildly flaky and the extra one was not caused by this change. Flagging it so a 7 does not get read as a regression.
- `php artisan bagisto:translations:check` not run: no locale files are touched.

Also verified directly against the schema. After migrating, a duplicate insert still fails on the primary key and `ON DELETE CASCADE` still clears both pivots. No foreign key depends on the dropped indexes, since InnoDB keeps its own index for `currency_id` and `locale_id`.

## Documentation

- [ ] My pull request requires an update on the documentation repository.

No documentation change: nothing user facing changes.

## Branch Selection

- [x] Target Branch: 2.4

`master` needs the same change and I am happy to open a second pull request against it.

## Tailwind Reordering

Not applicable, no front end changes.

---

Found with [Laravel Truss](https://github.com/albertoarena/laravel-truss), a structure only schema linter, while running it against real Laravel applications.
