### PR TITLE
fix: scope category filter options to current category products

### DIFF
--- a/packages/Webkul/Shop/src/Http/Controllers/API/CategoryController.php
+++ b/packages/Webkul/Shop/src/Http/Controllers/API/CategoryController.php
@@ -88,7 +88,7 @@ class CategoryController extends APIController
     }
 
     /**
-     * Get attribute options with pagination and search.
+     * Get attribute options with pagination, search, and optional category scoping.
      */
     public function getAttributeOptions(int $attributeId): mixed
     {
@@ -104,6 +104,25 @@ class CategoryController extends APIController
             ->with([
                 'translation' => fn ($query) => $query->where('locale', core()->getCurrentLocale()->code),
             ]);
+
+        if ($categoryId = request('category_id')) {
+            $query->whereExists(function ($exists) use ($attribute, $categoryId) {
+                $exists->selectRaw('1')
+                    ->from('product_attribute_values as pav')
+                    ->join('product_categories as pc', 'pc.product_id', '=', 'pav.product_id')
+                    ->where('pav.attribute_id', $attribute->id)
+                    ->where('pc.category_id', $categoryId);
+
+                if (in_array($attribute->type, [
+                    AttributeTypeEnum::CHECKBOX->value,
+                    AttributeTypeEnum::MULTISELECT->value,
+                ])) {
+                    $exists->whereRaw('FIND_IN_SET(attribute_options.id, pav.text_value)');
+                } else {
+                    $exists->whereColumn('pav.integer_value', 'attribute_options.id');
+                }
+            });
+        }
 
         if ($search = request('search')) {
             $query->where(function ($query) use ($search) {

--- a/packages/Webkul/Shop/src/Resources/views/categories/filters.blade.php
+++ b/packages/Webkul/Shop/src/Resources/views/categories/filters.blade.php
@@ -137,6 +137,7 @@
                     ref="filterItemComponent"
                     :key="filterIndex"
                     :filter="filter"
+                    :category-id="categoryId"
                     v-for='(filter, filterIndex) in filters.available'
                     @values-applied="applyFilter(filter, $event)"
                 >
@@ -345,6 +346,8 @@
                 return {
                     isLoading: true,
 
+                    categoryId: "{{ isset($category) ? $category->id : '' }}",
+
                     filters: {
                         available: {},
 
@@ -426,7 +429,7 @@
         app.component('v-filter-item', {
             template: '#v-filter-item-template',
 
-            props: ['filter'],
+            props: ['filter', 'categoryId'],
 
             data() {
                 return {
@@ -514,6 +517,7 @@
                         params: {
                             page: this.currentPage,
                             search: this.searchQuery,
+                            category_id: this.categoryId,
                         }
                     })
                     .then(response => {


### PR DESCRIPTION
## Description

Fixes #9793.

Option-based layered-navigation filters (e.g. Brand) on a category page listed every option in the catalog, even options with no products in the current category.

### Changes

* `getAttributeOptions` accepts an optional `category_id` and returns only options referenced by products in that category.
* Select attributes are matched via `integer_value`; multiselect/checkbox via `FIND_IN_SET` on `text_value`, mirroring the product listing query.
* The storefront filter component sends the current category id when loading options; pages without a category (e.g. search) behave exactly as before.
* Pagination, option search, and option translations behave as before.

### Scope

* One Shop API controller method plus one Blade/Vue component.
* Backwards compatible: new optional query parameter only, no response shape changes.
* No database changes.
* No translations added.
* No generated/compiled assets modified.

### Testing

* `node --check` passed for the touched Blade module script.
* `git diff --check` passed.
* `vendor/bin/pint --test` could not be run because PHP/vendor dependencies are unavailable in the local environment.
* Pest tests could not be run for the same reason.
* Playwright tests could not be run because the application/database/browser environment is unavailable.

### Known limits

* Only product-level attribute values are considered, not variant-only values.
* Membership is scoped to the exact category, not its descendants.
* Channel and locale of the attribute value are not considered.
